### PR TITLE
#62; 'cmd/sebak/main.go' crashes when empty post data received

### DIFF
--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -77,11 +77,11 @@ func (t Message) String() string {
 	return string(o)
 }
 
-func (t Message) Head() string {
+func (t Message) Head(n int) string {
 	s := t.String()
 	i := math.Min(
 		float64(len(s)),
-		float64(50),
+		float64(n),
 	)
 	return s[:int(i)]
 }

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -199,7 +199,7 @@ func (nr *NodeRunner) handleMessage() {
 	for message := range nr.network.ReceiveMessage() {
 		switch message.Type {
 		case sebaknetwork.ConnectMessage:
-			nr.log.Debug("got connect", "message", message.Head())
+			nr.log.Debug("got connect", "message", message.Head(50))
 			if _, err := sebakcommon.NewValidatorFromString(message.Data); err != nil {
 				nr.log.Error("invalid validator data was received", "data", message.Data)
 				continue
@@ -210,7 +210,7 @@ func (nr *NodeRunner) handleMessage() {
 				continue
 			}
 
-			nr.log.Debug("got message from client`", "message", message.Head())
+			nr.log.Debug("got message from client`", "message", message.Head(50))
 
 			checker := &NodeRunnerHandleMessageChecker{
 				DefaultChecker: sebakcommon.DefaultChecker{nr.handleMessageFromClientCheckerFuncs},
@@ -232,7 +232,7 @@ func (nr *NodeRunner) handleMessage() {
 				nr.log.Error("got empty ballot message`")
 				continue
 			}
-			nr.log.Debug("got ballot", "message", message.Head())
+			nr.log.Debug("got ballot", "message", message.Head(50))
 
 			checker := &NodeRunnerHandleBallotChecker{
 				DefaultChecker: sebakcommon.DefaultChecker{nr.handleBallotCheckerFuncs},
@@ -259,7 +259,7 @@ func (nr *NodeRunner) handleMessage() {
 			}
 			nr.closeConsensus(checker)
 		default:
-			nr.log.Error("got unknown", "message", message.Head())
+			nr.log.Error("got unknown", "message", message.Head(50))
 		}
 	}
 }


### PR DESCRIPTION
## Github Issue
#62 

### Background
@Geod24 reported #62. The crash is caused by slicing empty string in debug log.

### Solution
Add `Message.Head()` method, it will return n-length strings from first. If length of string is below n, return entire string.

Additionally, empty incoming message will be filtered for `sebaknetwork.MessageFromClient` and `sebaknetwork.BallotMessage`.