### PR TITLE
'github.com/owlchain/sebak' -> 'boscoin.io/sebak'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM golang:alpine AS builder
 LABEL maintainer="BOSCoin Developers <devteam@boscoin.io>"
 
 #golang:alpine set $GOPATH to `/go`
-COPY ./ /go/src/github.com/owlchain/sebak
-WORKDIR /go/src/github.com/owlchain/sebak
+COPY ./ /go/src/boscoin.io/sebak
+WORKDIR /go/src/boscoin.io/sebak
 
 ## Since those need to be re-run every time anyway, they are in a single stage
 # `git` and `openssh` are needed for `go get`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SEBAK
 
-[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](http://godoc.org/github.com/owlchain/sebak/lib) [![CircleCI](https://circleci.com/gh/owlchain/sebak.svg?style=svg&circle-token=fd8cbd27a7594539b58dd3c46363a2c693f25edb)](https://circleci.com/gh/owlchain/sebak)
+[![GoDoc](https://godoc.org/github.com/golang/gddo?status.svg)](http://godoc.org/github.com/bosnet/sebak/lib) [![CircleCI](https://circleci.com/gh/bosnet/sebak.svg?style=svg&circle-token=fd8cbd27a7594539b58dd3c46363a2c693f25edb)](https://circleci.com/gh/bosnet/sebak)
 
 Sebak is the core node for crypto-currency blockchain.
 
@@ -14,10 +14,10 @@ To start sebak:
 $ mkdir sebak
 $ cd sebak
 $ export GOPATH=$(pwd)
-$ go get github.com/owlchain/sebak
-$ cd src/github.com/owlchain/sebak
+$ go get boscoin.io/sebak
+$ cd src/boscoin.io/sebak
 $ dep ensure
-$ go install github.com/owlchain/sebak/cmd/sebak
+$ go install boscoin.io/sebak/cmd/sebak
 ```
 
 ## Test

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -10,11 +10,11 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib"
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/storage"
 
-	"github.com/owlchain/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/cmd/sebak/common"
 )
 
 const (

--- a/cmd/sebak/cmd/init.go
+++ b/cmd/sebak/cmd/init.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/owlchain/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/cmd/sebak/common"
 )
 
 var rootCmd = &cobra.Command{

--- a/cmd/sebak/cmd/key.go
+++ b/cmd/sebak/cmd/key.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/owlchain/sebak/cmd/sebak/cmd/key"
+	"boscoin.io/sebak/cmd/sebak/cmd/key"
 )
 
 var (

--- a/cmd/sebak/cmd/key/generate.go
+++ b/cmd/sebak/cmd/key/generate.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/cmd/sebak/common"
 )
 
 var (

--- a/cmd/sebak/cmd/node.go
+++ b/cmd/sebak/cmd/node.go
@@ -14,12 +14,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib"
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/network"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/storage"
 
-	"github.com/owlchain/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/cmd/sebak/common"
 )
 
 type FlagValidators []*sebakcommon.Validator

--- a/cmd/sebak/cmd/version.go
+++ b/cmd/sebak/cmd/version.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/owlchain/sebak/lib"
+	"boscoin.io/sebak/lib"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/sebak/common/util.go
+++ b/cmd/sebak/common/util.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/owlchain/sebak/lib"
+	"boscoin.io/sebak/lib"
 )
 
 /**

--- a/cmd/sebak/main.go
+++ b/cmd/sebak/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/owlchain/sebak/cmd/sebak/cmd"
+	"boscoin.io/sebak/cmd/sebak/cmd"
 )
 
 func main() {

--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -5,9 +5,9 @@ import (
 	"sort"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 	"github.com/stellar/go/keypair"
 )
 

--- a/lib/ballot_checker.go
+++ b/lib/ballot_checker.go
@@ -2,8 +2,8 @@ package sebak
 
 import (
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 type BallotChecker struct {

--- a/lib/ballot_test.go
+++ b/lib/ballot_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 func makeNewBallot(state sebakcommon.BallotState, vote VotingHole) (*keypair.Full, Transaction, Ballot) {

--- a/lib/block_account.go
+++ b/lib/block_account.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/storage"
 )
 
 // BlockAccount is account model in block. the storage should support,

--- a/lib/block_account_test.go
+++ b/lib/block_account_test.go
@@ -3,7 +3,7 @@ package sebak
 import (
 	"testing"
 
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/storage"
 )
 
 func TestSaveNewBlockAccount(t *testing.T) {

--- a/lib/block_operation.go
+++ b/lib/block_operation.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 // BlockOperation is `Operation` data for block. the storage should support,

--- a/lib/block_operation_test.go
+++ b/lib/block_operation_test.go
@@ -3,9 +3,9 @@ package sebak
 import (
 	"testing"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 func TestNewBlockOperationFromOperation(t *testing.T) {

--- a/lib/block_transaction.go
+++ b/lib/block_transaction.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 // BlockTransaction is `Transaction` data for block. the storage should support,

--- a/lib/block_transaction_history.go
+++ b/lib/block_transaction_history.go
@@ -3,9 +3,9 @@ package sebak
 import (
 	"fmt"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 // BlockTransactionHistory is for keeping `Transaction` history. the storage should support,

--- a/lib/block_transaction_test.go
+++ b/lib/block_transaction_test.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 func TestNewBlockTransaction(t *testing.T) {

--- a/lib/consensus.go
+++ b/lib/consensus.go
@@ -1,7 +1,7 @@
 package sebak
 
 import (
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 type Consensus interface {

--- a/lib/data.go
+++ b/lib/data.go
@@ -14,7 +14,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/error"
 )
 
 const (

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -1,8 +1,8 @@
 package sebak
 
 import (
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 type ISAAC struct {

--- a/lib/isaac_test.go
+++ b/lib/isaac_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 func NewRandomNode() sebakcommon.Node {

--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 type Network interface {

--- a/lib/network/connection_manager.go
+++ b/lib/network/connection_manager.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	logging "github.com/inconshreveable/log15"
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 type ConnectionManager struct {

--- a/lib/network/http2_network.go
+++ b/lib/network/http2_network.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/gorilla/handlers"
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 
 	"golang.org/x/net/http2"
 )

--- a/lib/network/http2_network_client.go
+++ b/lib/network/http2_network_client.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 type HTTP2NetworkClient struct {

--- a/lib/network/http2_network_handler.go
+++ b/lib/network/http2_network_handler.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 func Index(ctx context.Context, t *HTTP2Network) HandlerFunc {

--- a/lib/network/memory_network.go
+++ b/lib/network/memory_network.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/google/uuid"
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 var memoryNetworks map[ /* endpoint */ string]*MemoryNetwork

--- a/lib/network/memory_network_client.go
+++ b/lib/network/memory_network_client.go
@@ -1,7 +1,7 @@
 package sebaknetwork
 
 import (
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 type MemoryTransportClient struct {

--- a/lib/network/memory_network_test.go
+++ b/lib/network/memory_network_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 	"github.com/stellar/go/keypair"
 )
 

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	logging "github.com/inconshreveable/log15"
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/network"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/storage"
 )
 
 type NodeRunner struct {

--- a/lib/node_runner_checker.go
+++ b/lib/node_runner_checker.go
@@ -1,8 +1,8 @@
 package sebak
 
 import (
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/network"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
 )
 
 type NodeRunnerHandleMessageChecker struct {

--- a/lib/node_runner_create_account_test.go
+++ b/lib/node_runner_create_account_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/network"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
 )
 
 func TestNodeRunnerCreateAccount(t *testing.T) {

--- a/lib/node_runner_etc_test.go
+++ b/lib/node_runner_etc_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/network"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
 )
 
 // TestNodeRunnerLimitIncomingBallotsFromUnknownValidator checks, the incoming

--- a/lib/node_runner_isaac_test.go
+++ b/lib/node_runner_isaac_test.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/network"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
 )
 
 // TestNodeRunnerConsensusStoreInHistoryIncomingTxMessage checks, the incoming tx message will be

--- a/lib/node_runner_memory_network_test.go
+++ b/lib/node_runner_memory_network_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/network"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/storage"
 	"github.com/stellar/go/keypair"
 )
 

--- a/lib/node_runner_payment_test.go
+++ b/lib/node_runner_payment_test.go
@@ -8,8 +8,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/network"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
 )
 
 func TestNodeRunnerPayment(t *testing.T) {

--- a/lib/operation.go
+++ b/lib/operation.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/btcsuite/btcutil/base58"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 type OperationType string

--- a/lib/operation_create_account.go
+++ b/lib/operation_create_account.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 type OperationBodyCreateAccount struct {

--- a/lib/operation_payment.go
+++ b/lib/operation_payment.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 type OperationBodyPayment struct {

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 	"github.com/syndtr/goleveldb/leveldb"
 	leveldbIterator "github.com/syndtr/goleveldb/leveldb/iterator"
 	leveldbOpt "github.com/syndtr/goleveldb/leveldb/opt"

--- a/lib/storage/leveldb_test.go
+++ b/lib/storage/leveldb_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 func TestLevelDBBackendInitFileStorage(t *testing.T) {

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"net/url"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 var SupportedStorageType []string = []string{

--- a/lib/test.go
+++ b/lib/test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 )
 
 func testMakeBlockAccount() *BlockAccount {

--- a/lib/transaction.go
+++ b/lib/transaction.go
@@ -7,9 +7,9 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
 )
 
 // TODO versioning

--- a/lib/transaction_checker.go
+++ b/lib/transaction_checker.go
@@ -6,8 +6,8 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/stellar/go/keypair"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 type TransactionChecker struct {

--- a/lib/transaction_test.go
+++ b/lib/transaction_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/owlchain/sebak/lib/storage"
+	"boscoin.io/sebak/lib/storage"
 	"github.com/stellar/go/keypair"
 )
 

--- a/lib/voting.go
+++ b/lib/voting.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"math"
 
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 type VotingHole string

--- a/lib/voting_checker.go
+++ b/lib/voting_checker.go
@@ -1,8 +1,8 @@
 package sebak
 
 import (
-	"github.com/owlchain/sebak/lib/common"
-	"github.com/owlchain/sebak/lib/error"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 type VotingResultChecker struct {

--- a/lib/voting_test.go
+++ b/lib/voting_test.go
@@ -3,7 +3,7 @@ package sebak
 import (
 	"testing"
 
-	"github.com/owlchain/sebak/lib/common"
+	"boscoin.io/sebak/lib/common"
 	"github.com/stellar/go/keypair"
 )
 


### PR DESCRIPTION
### Github Issue
#76 

### Background
The current repository org, 'owlchain' is for private development, so to publishing SEBAK as open-source, we need to move to 'bosnet' org. The keep our identity to be clearer, the new go import path will be better, the name is 'boscoin.io'.

* New source repository will be "https://github.com/bosnet/sebak"
* New go import path will be "boscoin.io/sebak"

I already renamed the import path to "boscoin.io/sebak" from "github.com/owlchain/sebak" and check to pass the `go test ./...` also too.