### PR TITLE
LevelDBBackend.GetRaw() can return ErrorStorageRecordDoesNotExit #74

### DIFF
--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -32,4 +32,5 @@ var (
 	ErrorBlockAccountAlreadyExists        = NewError(129, "account already exists in block")
 	ErrorAccountBalanceUnderZero          = NewError(130, "account balance will be under zero")
 	ErrorMaximumBalanceReached            = NewError(131, "monetary amount would be greater than the total supply of coins")
+	ErrorStorageRecordDoesNotExist        = NewError(132, "record does not exist in storage")
 )

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 
-	"boscoin.io/sebak/lib/common"
 	"github.com/syndtr/goleveldb/leveldb"
 	leveldbIterator "github.com/syndtr/goleveldb/leveldb/iterator"
 	leveldbOpt "github.com/syndtr/goleveldb/leveldb/opt"
 	leveldbStorage "github.com/syndtr/goleveldb/leveldb/storage"
 	leveldbUtil "github.com/syndtr/goleveldb/leveldb/util"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 type LevelDBCore interface {
@@ -100,8 +102,8 @@ func (st *LevelDBBackend) Has(k string) (bool, error) {
 func (st *LevelDBBackend) GetRaw(k string) (b []byte, err error) {
 	var exists bool
 	if exists, err = st.Has(k); !exists || err != nil {
-		if !exists {
-			err = fmt.Errorf("key, '%s' does not exists", k)
+		if !exists || err == leveldb.ErrNotFound {
+			err = sebakerror.ErrorStorageRecordDoesNotExist
 		}
 		return
 	}

--- a/lib/storage/leveldb_test.go
+++ b/lib/storage/leveldb_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 )
 
 func TestLevelDBBackendInitFileStorage(t *testing.T) {
@@ -133,6 +134,11 @@ func TestLevelDBBackendGetRaw(t *testing.T) {
 	input := "findme"
 
 	st.New(key, input)
+
+	// when record does not exist, it should return ErrorStorageRecordDoesNotExist
+	if _, err := st.GetRaw("vacuum"); err != sebakerror.ErrorStorageRecordDoesNotExist {
+		t.Errorf("failed to GetRaw: want=%v have=%v", sebakerror.ErrorStorageRecordDoesNotExist, err)
+	}
 }
 
 func TestLevelDBBackendSet(t *testing.T) {


### PR DESCRIPTION
#74 

-  Add `ErrorStorageRecordDostNotExit` in `lib/error`
- `LevelDBBackend.GetRaw()` returns the error when record dose not exist. 

ps) It's reopened PR  because my forked repo is broken after changing repo. 