### PR TITLE
Fix #61 Machine readable generating keypair's output

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -235,9 +235,15 @@
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
+  version = "v2.2.1"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e269f34ebea013fbfbaa243862e42da7e0765a372dca510f041ba88a37715a29"
+  inputs-digest = "0af34396c83b494e096440c603e0df3dd745715f780c461eda439288636cd72d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -45,3 +45,7 @@
 [[constraint]]
   name = "github.com/oklog/run"
   version = "1.0.0"
+
+[[constraint]]
+  name = "gopkg.in/yaml.v2"
+  version = "2.2.1"

--- a/cmd/sebak/cmd/key/generate.go
+++ b/cmd/sebak/cmd/key/generate.go
@@ -11,36 +11,87 @@ import (
 	"github.com/stellar/go/keypair"
 
 	"boscoin.io/sebak/cmd/sebak/common"
+	"io"
 )
 
 var (
 	GenerateCmd *cobra.Command
 
 	flagInput     string
-	flagShort     bool
 	flagPublicKey bool
+	flagFormat    string
 )
+
+type (
+	keyPair struct {
+		Seed              string  `json:"seed"`
+		Address           string  `json:"address"`
+		NetworkPassphrase *string `json:"network_passphrase,omitempty"`
+	}
+)
+
+func defaultEncode(v interface{}, w io.Writer) error {
+	t := template.Must(template.New("").Funcs(template.FuncMap{
+		"valueString": func(input *string) string {
+			if input == nil {
+				return ""
+			} else {
+				return *input
+			}
+		},
+	}).Parse(`       Secret Seed: {{ .Seed }}
+    Public Address: {{ .Address }}{{ if valueString .NetworkPassphrase }}
+Network Passphrase: "{{ .NetworkPassphrase|valueString }}"{{ end }}
+`))
+	return t.Execute(w, v)
+}
+
+func onelineEncode(v interface{}, w io.Writer) error {
+	kp := v.(keyPair)
+	fmt.Fprintf(w, "%s %s\n", kp.Seed, kp.Address)
+	return nil
+}
 
 func init() {
 	GenerateCmd = &cobra.Command{
 		Use:   "generate",
 		Short: "Generate keypair",
 		Run: func(c *cobra.Command, args []string) {
-			if len(args) > 0 {
-				flagInput = strings.TrimSpace(strings.Join(args, " "))
-			} else if flagPublicKey && len(flagInput) < 1 {
+			var passphrase *string = nil
+			input := strings.TrimSpace(strings.Join(args, " "))
+
+			if flagPublicKey && len(input) == 0 {
 				common.PrintFlagsError(c, "--publicKey", errors.New("--publicKey needs <public key>"))
 			}
 
-			kp, err := generateKP()
-			if err != nil {
+			kp, err := generateKP(input, flagPublicKey)
+
+			if flagPublicKey && err != nil {
 				common.PrintFlagsError(c, "<input>", fmt.Errorf("failed to parse public key: %v", err))
+			} else if !flagPublicKey && len(input) > 0 {
+				passphrase = &input
 			}
 
-			if flagShort {
-				fmt.Fprintf(os.Stdout, "%s %s\n", kp.Seed(), kp.Address())
+			encoders := map[string]common.Encode{
+				"json":       common.DefaultEncodes["json"],
+				"prettyjson": common.DefaultEncodes["prettyjson"],
+				"default":    defaultEncode,
+				"oneline":    onelineEncode,
+			}
+
+			if encode, ok := encoders[flagFormat]; ok {
+				err := encode(keyPair{
+					Seed:              kp.Seed(),
+					Address:           kp.Address(),
+					NetworkPassphrase: passphrase,
+				}, os.Stdout)
 
 				os.Exit(0)
+				if err != nil {
+					panic(err)
+				}
+			} else {
+				common.PrintFlagsError(c, "format", fmt.Errorf(`"%s" not recognized`, flagFormat))
 			}
 
 			t := template.Must(template.New("").Parse(`       Secret Seed: {{ .seed }}
@@ -56,27 +107,22 @@ Network Passphrase: "{{ .networkPassphrase}}"{{ end }}
 		},
 	}
 
-	GenerateCmd.Flags().BoolVar(&flagShort, "short", false, "short format, \"<secret seed> <public address>\"")
-	GenerateCmd.Flags().BoolVar(&flagPublicKey, "publicKey", false, "parse public key")
-	//GenerateCmd.Flags().StringVar(&flagNetworkPassphrase, "short", false, "short format, \"<secret seed> <public address>\"")
+	GenerateCmd.Flags().BoolVar(&flagPublicKey, "parse", false, "parse public key")
+	GenerateCmd.Flags().StringVar(&flagFormat, "format", "default", "format={default, json, oneline, prettyjson}")
 }
 
-func generateKP() (full *keypair.Full, err error) {
-	if len(flagInput) < 1 {
-		full, _ = keypair.Random()
-		return
-	}
-
-	if flagPublicKey {
+func generateKP(seedOrNetworkPassphrase string, fromSeed bool) (full *keypair.Full, err error) {
+	if len(seedOrNetworkPassphrase) == 0 {
+		full, err = keypair.Random()
+	} else if fromSeed {
 		var kp keypair.KP
-		kp, err = keypair.Parse(flagInput)
-		if err != nil {
-			return
-		}
 
-		full = kp.(*keypair.Full)
+		if kp, err = keypair.Parse(seedOrNetworkPassphrase); err == nil {
+			full = kp.(*keypair.Full)
+		}
+	} else {
+		full = keypair.Master(seedOrNetworkPassphrase).(*keypair.Full)
 	}
 
-	full = keypair.Master(flagInput).(*keypair.Full)
 	return
 }

--- a/cmd/sebak/common/encoder.go
+++ b/cmd/sebak/common/encoder.go
@@ -1,9 +1,9 @@
 package common
 
 import (
-	"io"
 	"encoding/json"
 	"gopkg.in/yaml.v2"
+	"io"
 )
 
 type Encode func(v interface{}, w io.Writer) error

--- a/cmd/sebak/common/encoder.go
+++ b/cmd/sebak/common/encoder.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"io"
+	"encoding/json"
+	"gopkg.in/yaml.v2"
+)
+
+type Encode func(v interface{}, w io.Writer) error
+
+var DefaultEncodes = map[string]Encode{
+	"json": func(v interface{}, w io.Writer) error {
+		return jsonEncode(v, w, false)
+	},
+	"prettyjson": func(v interface{}, w io.Writer) error {
+		return jsonEncode(v, w, true)
+	},
+	"yaml": func(v interface{}, w io.Writer) error {
+		e := yaml.NewEncoder(w)
+		return e.Encode(v)
+	},
+}
+
+func jsonEncode(v interface{}, w io.Writer, pretty bool) error {
+	e := json.NewEncoder(w)
+	if pretty {
+		e.SetIndent("", "  ")
+	}
+
+	return e.Encode(&v)
+}


### PR DESCRIPTION
 * fix #61 and I'll use it for #3 ~ #10, if possible.
 * #69 was broken and made agian.

Basic usage

```
$ sebak key generate --format json [--parse] [seedOrNetworkPassphrase]
{"seed":"SAYANWJGVJJU2EFM7VVW7LPUEDT64XCAFOLVNVXI2XK4T5MTL7GYKIII","address":"GCKMRRAOA5X6O5DHALNYE32KB2LNIEI5P2OXOSAZMDXIMBEQLCLMU3ZL"}

$ sebak key generate --format prettyjson [--parse] [seedOrNetworkPassphrase]
{
  "seed": "SAWPETN2L6YKGDRG5A5SVRNZ4KPBWFQ6LQP2OQS6OMCDGYUTROMCIBRZ",
  "address": "GDIWDGGNKUZEHWXH3DSCCED5TCD6E4HLDTDOJQDSVXVA6BCCWZNM5LJ4"
}

$ sebak key generate --format pretty [--parse] [seedOrNetworkPassphrase]
       Secret Seed: SB6BVDSRLGQ4AOB3ZTL2FSMGJJVYHQ6KEDLTWDFR25F5AOARNIISL6UL
    Public Address: GB5MBN4EGKO54A4GTHM5AL2ASSQRPNB3ESSHLXKPBVCPZN3AJL7QC4Z7

$ sebak key generate --format oneline [--parse] [seedOrNetworkPassphrase]
SAPGPM76SODAFPHJR2PQIAJTRWA5H7EOGRZAVYE32BDQ3AHYMETKM5FH GB2EJGMYJS3XBEWLVGPRJEDLBM75R35CMOVVRTMOGOQIDXKQTEBCOXPI

```