### PR TITLE
Fix #1, #133 - Implement sebak wallet pay

### DIFF
--- a/cmd/sebak/cmd/wallet.go
+++ b/cmd/sebak/cmd/wallet.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"boscoin.io/sebak/cmd/sebak/cmd/wallet"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	walletCmd *cobra.Command
+)
+
+func init() {
+	walletCmd = &cobra.Command{
+		Use:   "wallet",
+		Short: "CLI for wallet management",
+		Run: func(c *cobra.Command, args []string) {
+			if len(args) < 1 {
+				c.Usage()
+			}
+		},
+	}
+
+	rootCmd.AddCommand(walletCmd)
+	walletCmd.AddCommand(wallet.PaymentCmd)
+}

--- a/cmd/sebak/cmd/wallet/payment.go
+++ b/cmd/sebak/cmd/wallet/payment.go
@@ -1,0 +1,220 @@
+package wallet
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+
+	"boscoin.io/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/lib"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
+
+	"github.com/spf13/cobra"
+	"github.com/stellar/go/keypair"
+)
+
+var (
+	flagNetworkID     string = sebakcommon.GetENVValue("SEBAK_NETWORK_ID", "")
+	PaymentCmd        *cobra.Command
+	flagEndpoint      string
+	flagCreateAccount bool
+)
+
+func init() {
+	PaymentCmd = &cobra.Command{
+		Use:   "payment <receiver pubkey> <amount> <sender secret seed>",
+		Short: "Send <amount> BOSCoin from one wallet to another",
+		Args:  cobra.ExactArgs(3),
+		Run: func(c *cobra.Command, args []string) {
+			var err error
+			var amount sebak.Amount
+			var sender keypair.KP
+			var receiver keypair.KP
+			var endpoint *sebakcommon.Endpoint
+
+			// Receiver's public key
+			if receiver, err = keypair.Parse(args[0]); err != nil {
+				common.PrintFlagsError(c, "<receiver public key>", err)
+			} else if _, err = receiver.Sign([]byte("witness")); err == nil {
+				common.PrintFlagsError(c, "<receiver public key>", fmt.Errorf("Provided key is a secret seed, not an address"))
+			}
+
+			// Amount
+			if amount, err = common.ParseAmountFromString(args[1]); err != nil {
+				common.PrintFlagsError(c, "<amount>", err)
+			}
+
+			// Sender's secret seed
+			if sender, err = keypair.Parse(args[2]); err != nil {
+				common.PrintFlagsError(c, "<sender secret seed>", err)
+			} else if _, ok := sender.(*keypair.Full); !ok {
+				common.PrintFlagsError(c, "<sender secret seed>", fmt.Errorf("Provided key is an address, not a secret seed"))
+			}
+
+			// Check a network ID was provided
+			if len(flagNetworkID) == 0 {
+				common.PrintFlagsError(c, "--network-id", fmt.Errorf("A --network-id needs to be provided"))
+			}
+
+			if endpoint, err = sebakcommon.ParseNodeEndpoint(flagEndpoint); err != nil {
+				common.PrintFlagsError(c, "--endpoint", err)
+			}
+
+			// TODO: Validate input transaction (does the sender have enough money?)
+
+			// At the moment this is a rather crude implementation: There is no support for pooling of transaction,
+			// 1 operation == 1 transaction
+			var tx sebak.Transaction
+			var connection *sebakcommon.HTTP2Client
+			var sender_account sebak.BlockAccount
+
+			// Keep-alive ignores timeout/idle timeout
+			if connection, err = sebakcommon.NewHTTP2Client(0, 0, true); err != nil {
+				log.Fatal("Error while creating network client: ", err)
+				os.Exit(1)
+			}
+			client := sebaknetwork.NewHTTP2NetworkClient(endpoint, connection)
+
+			if sender_account, err = getSenderDetails(client, sender); err != nil {
+				log.Fatal("Could not fetch sender account: ", err)
+				os.Exit(1)
+			}
+
+			if flagCreateAccount {
+				tx = makeTransactionCreateAccount(sender, receiver, amount, sender_account.Checkpoint)
+			} else {
+				tx = makeTransactionPayment(sender, receiver, amount, sender_account.Checkpoint)
+			}
+
+			tx.Sign(sender, []byte(flagNetworkID))
+
+			// Send request
+			var retbody []byte
+			if retbody, err = client.SendMessage(tx); err != nil {
+				log.Fatal("Network error: ", err, " body: ", retbody)
+				os.Exit(1)
+			}
+		},
+	}
+	PaymentCmd.Flags().StringVar(&flagEndpoint, "endpoint", flagEndpoint, "endpoint to send the transaction to (https / memory address)")
+	PaymentCmd.Flags().StringVar(&flagNetworkID, "network-id", flagNetworkID, "network id")
+	PaymentCmd.Flags().BoolVar(&flagCreateAccount, "create", flagCreateAccount, "Whether or not the account should be created")
+}
+
+///
+/// Make a full transaction, with a single operation to create an account
+///
+/// TODO:
+///   Move to lib (it was 'borrowed' from test code)
+///
+/// Params:
+///   kpSource = Sender's keypair.Full seed/address
+///   kpDest   = Newly created account's address
+///   amount   = Amount to send as initial value
+///   chkp     = Checkpoint of the last transaction
+///
+/// Returns:
+///   `sebak.Transaction` = The generated `Transaction` creating the account
+///
+func makeTransactionCreateAccount(kpSource keypair.KP, kpDest keypair.KP, amount sebak.Amount, chkp string) sebak.Transaction {
+	opb := sebak.NewOperationBodyCreateAccount(kpDest.Address(), amount)
+
+	op := sebak.Operation{
+		H: sebak.OperationHeader{
+			Type: sebak.OperationCreateAccount,
+		},
+		B: opb,
+	}
+
+	txBody := sebak.TransactionBody{
+		Source:     kpSource.Address(),
+		Fee:        sebak.BaseFee,
+		Checkpoint: chkp,
+		Operations: []sebak.Operation{op},
+	}
+
+	tx := sebak.Transaction{
+		T: "transaction",
+		H: sebak.TransactionHeader{
+			Created: sebakcommon.NowISO8601(),
+			Hash:    txBody.MakeHashString(),
+		},
+		B: txBody,
+	}
+
+	return tx
+}
+
+///
+/// Make a full transaction, with a single payment operation in it
+///
+/// TODO:
+///   Move to lib (it was 'borrowed' from test code)
+///
+/// Params:
+///   kpSource = Sender's keypair.Full seed/address
+///   kpDest   = Receiver's keypair.FromAddress address
+///   amount   = Amount to send as initial value
+///   chkp     = Checkpoint of the last transaction
+///
+/// Returns:
+///  `sebak.Transaction` = The generated `Transaction` to do a payment
+///
+func makeTransactionPayment(kpSource keypair.KP, kpDest keypair.KP, amount sebak.Amount, chkp string) sebak.Transaction {
+	opb := sebak.NewOperationBodyPayment(kpDest.Address(), amount)
+
+	op := sebak.Operation{
+		H: sebak.OperationHeader{
+			Type: sebak.OperationPayment,
+		},
+		B: opb,
+	}
+
+	txBody := sebak.TransactionBody{
+		Source:     kpSource.Address(),
+		Fee:        sebak.Amount(sebak.BaseFee),
+		Checkpoint: chkp,
+		Operations: []sebak.Operation{op},
+	}
+
+	tx := sebak.Transaction{
+		T: "transaction",
+		H: sebak.TransactionHeader{
+			Created: sebakcommon.NowISO8601(),
+			Hash:    txBody.MakeHashString(),
+		},
+		B: txBody,
+	}
+
+	return tx
+}
+
+///
+/// Get the BlockAccount of the sender
+///
+/// TODO:
+///   Move to lib
+///
+/// Params:
+///   conn = Network connection to the node to request
+///   sender = sender from which to request the account (only `Address` is used)
+///
+/// Returns:
+///   sebak.BlockAccount = The deserialized block account, or a default-initialized one if an error occured
+///   error = `nil` or the error that occured (either network or deserialization)
+///
+func getSenderDetails(conn *sebaknetwork.HTTP2NetworkClient, sender keypair.KP) (sebak.BlockAccount, error) {
+	var ba sebak.BlockAccount
+	var err error
+	var retBody []byte
+
+	//response, err = c.client.Post(u.String(), body, headers)
+	if retBody, err = conn.Get("/api/account/" + sender.Address()); err != nil {
+		return ba, err
+	}
+
+	err = json.Unmarshal(retBody, &ba)
+	return ba, err
+}

--- a/lib/network/http2_network_client.go
+++ b/lib/network/http2_network_client.go
@@ -142,3 +142,37 @@ func (c *HTTP2NetworkClient) SendBallot(message sebakcommon.Serializable) (retBo
 
 	return
 }
+
+///
+/// Perform a raw Get request on this peer
+///
+/// This is a quick way to request the API.
+/// As APIs are rapidly evolving, wrapping all of them properly
+/// would be counter productive, to this function is provided.
+///
+/// Params:
+///   endpoint = URL chunk to request (e.g. `/api/foo?bar=baguette`)
+///
+/// Returns:
+///   []byte = Body part returned by the query if it was successful
+///   error  = Error information if the query wasn't successful
+///
+func (client *HTTP2NetworkClient) Get(endpoint string) ([]byte, error) {
+	var body []byte
+	var err error
+	var response *http.Response
+	headers := client.DefaultHeaders()
+
+	headers.Set("Accept", "application/json")
+	u := client.resolvePath(endpoint)
+
+	if response, err = client.client.Get(u.String(), headers); err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusOK {
+		body, err = ioutil.ReadAll(response.Body)
+	}
+
+	return body, err
+}


### PR DESCRIPTION
Based on #82 

This send a simple transaction to a node, using the endpoint's address.
For testing, I start the three nodes using:
```
docker run --net host --rm -it --env-file=docker/node1.env sebak
docker run --net host --rm -it --env-file=docker/node2.env sebak
docker run --net host --rm -it --env-file=docker/node3.env sebak
```

Than I send the payment using:
```
docker build . -t sebak-testing && docker rmi -f $(docker images -f "dangling=true" -q) && docker run --rm --network host -it sebak-testing wallet pay 150000 SBECGI3FSCYHNQIMANNCWQSVA6S5C6L4BXFKAPMBAMI5V47NWXNE37MN GAYGELM74WJMKSLDN5YP2VAMP64WC4IXIGICUNK2SCVIT7KPTLY7M3MW  --endpoint=https://127.0.0.1:2822
```

Notice that this is sending 150k GON from Genesis account / Node 1's account to Node 2's account, and the transaction is relayed to Node 2.
There's a few questions that this raised:
- How do we validate the transaction. In a real world, we want to prevent attacker from DDoSing us. A common technique used for this is banning, which is triggered by malicious actions. If we don't validate that the transaction would pass consensus beforehand, we cannot use this mechanism or we risk banning good users.
- In order to check that a tx would pass consensus, we need to know the state of the blockchain at the moment. Which is completely out of scope of a small CLI tool. One way to mitigate this would be to have "relay" nodes (akin to Stellar's Horizon) who do the validation.
- We should look into definining a config file for Sebak.

This does not work ATM, the output for the receiver node (2) is:
```
127.0.0.1 - - [18/Jun/2018:03:12:39 +0000] "POST /message HTTP/2.0" 200 0 "" "Go-http-client/2.0"
127.0.0.1 - - [18/Jun/2018:03:12:40 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GDTE.6RAE"
127.0.0.1 - - [18/Jun/2018:03:12:40 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GDIR.M6CC"
127.0.0.1 - - [18/Jun/2018:03:12:40 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GDTE.6RAE"
127.0.0.1 - - [18/Jun/2018:03:12:40 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GDIR.M6CC"
EROR[06-18|03:12:40] failed to handle ballot                  module=sebak node=GAYG.TLY7 error="{\"code\":100,\"message\":\"already exists in block\"}"
EROR[06-18|03:12:40] consensus closed                         module=sebak node=GAYG.TLY7
```

Other nodes display a similar error (following is node 1):
```
127.0.0.1 - - [18/Jun/2018:03:12:39 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GAYG.TLY7"
127.0.0.1 - - [18/Jun/2018:03:12:40 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GDTE.6RAE"
EROR[06-18|03:12:40] failed to handle ballot                  module=sebak node=GDIR.M6CC error="{\"code\":100,\"message\":\"already exists in block\"}"
EROR[06-18|03:12:40] consensus closed                         module=sebak node=GDIR.M6CC
127.0.0.1 - - [18/Jun/2018:03:12:40 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GDTE.6RAE"
127.0.0.1 - - [18/Jun/2018:03:12:40 +0000] "POST /ballot HTTP/2.0" 200 0 "" "v-GAYG.TLY7"
```

Code written while pair programming with @cmcm2222 