### PR TITLE
Set the log level on the node runner too

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,9 +39,5 @@
   version = "1.3.0"
 
 [[constraint]]
-  name = "github.com/mattn/go-isatty"
-  version = "0.0.3"
-
-[[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.3"

--- a/cmd/sebak/cmd/node.go
+++ b/cmd/sebak/cmd/node.go
@@ -10,7 +10,6 @@ import (
 	"golang.org/x/net/http2"
 
 	logging "github.com/inconshreveable/log15"
-	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/keypair"
 
@@ -195,15 +194,7 @@ func parseFlagsNode() {
 		common.PrintFlagsError(nodeCmd, "--log-level", err)
 	}
 
-	var logHandler logging.Handler
-
-	var formatter logging.Format
-	if isatty.IsTerminal(os.Stdout.Fd()) {
-		formatter = logging.TerminalFormat()
-	} else {
-		formatter = logging.JsonFormatEx(false, true)
-	}
-	logHandler = logging.StreamHandler(os.Stdout, formatter)
+	logHandler := logging.StdoutHandler
 
 	if len(flagLogOutput) < 1 {
 		flagLogOutput = "<stdout>"


### PR DESCRIPTION
This way when we set the debugging information, it actually applies to the core of the business logic and we can debug the consensus protocol.