### PR TITLE
 Document and improve Amount's marshalling

### DIFF
--- a/lib/data.go
+++ b/lib/data.go
@@ -1,13 +1,13 @@
-/**
- * Define the `Amount` type, which is the monetary type used accross the code base
- *
- * One BOSCoin accounts for 10 million currency units.
- * In addition to the `Amount` type, some member functions are defined:
- * - Add / Sub do an addition / substraction and return an error object
- * - AddCheck / SubCheck call `Add` / `Sub` and turn any `error` into a `panic`.
- *   Those are provided for testing / quick prototyping and should not be in production code.
- * - Invariant `panic`s if the instance it's called on violates its invariant (see Contract programming)
- */
+//
+// Define the `Amount` type, which is the monetary type used accross the code base
+//
+// One BOSCoin accounts for 10 million currency units.
+// In addition to the `Amount` type, some member functions are defined:
+// - Add / Sub do an addition / substraction and return an error object
+// - AddCheck / SubCheck call `Add` / `Sub` and turn any `error` into a `panic`.
+//   Those are provided for testing / quick prototyping and should not be in production code.
+// - Invariant `panic`s if the instance it's called on violates its invariant (see Contract programming)
+//
 package sebak
 
 import (
@@ -18,19 +18,19 @@ import (
 )
 
 const (
-	/// 10,000,000 units == 1 BOSCoin
+	// 10,000,000 units == 1 BOSCoin
 	amountPerCoin Amount = 10000000
-	/// The maximum possible supply of coins within any network
-	/// It is 10 trillions BOSCoin, or 100,000,000,000,000,000,000 in `Amount`
+	// The maximum possible supply of coins within any network
+	// It is 10 trillions BOSCoin, or 100,000,000,000,000,000,000 in `Amount`
 	MaximumBalance Amount = 1000000000000 * amountPerCoin
-	/// An invalid valid, used to make an instance unusable
+	// An invalid valid, used to make an instance unusable
 	invalidValue = Amount(MaximumBalance + 1)
 )
 
-/// Main monetary type used accross sebak
+// Main monetary type used accross sebak
 type Amount uint64
 
-/// Check this type's invariant, that is, its value is <= MaximumBalance
+// Check this type's invariant, that is, its value is <= MaximumBalance
 func (this Amount) Invariant() {
 	if this > MaximumBalance {
 		// `uint64` is necessary to avoid a recursive call to `String`
@@ -39,18 +39,18 @@ func (this Amount) Invariant() {
 	}
 }
 
-/// Stringer interface implementation
+// Stringer interface implementation
 func (a Amount) String() string {
 	a.Invariant()
 	return strconv.FormatInt(int64(a), 10)
 }
 
-/**
- * Add an `Amount` to this `Amount`
- *
- * If the resulting value would overflow maximumAmount, an error is returned,
- * along with the value (which would trigger a `panic` if used).
- */
+//
+// Add an `Amount` to this `Amount`
+//
+// If the resulting value would overflow maximumAmount, an error is returned,
+// along with the value (which would trigger a `panic` if used).
+//
 func (a Amount) Add(added Amount) (n Amount, err error) {
 	a.Invariant()
 	added.Invariant()
@@ -60,8 +60,8 @@ func (a Amount) Add(added Amount) (n Amount, err error) {
 	return
 }
 
-/// Counterpart of `Add` which panic instead of returning an error
-/// Useful for debugging and testing, should be avoided in regular code
+// Counterpart of `Add` which panic instead of returning an error
+// Useful for debugging and testing, should be avoided in regular code
 func (a Amount) MustAdd(added Amount) Amount {
 	if v, err := a.Add(added); err != nil {
 		panic(err)
@@ -70,12 +70,12 @@ func (a Amount) MustAdd(added Amount) Amount {
 	}
 }
 
-/**
- * Substract an `Amount` to this `Amount`
- *
- * If the resulting value would underflow, an error is returned,
- * along with an invalid value (which would trigger a `panic` if used).
- */
+//
+// Substract an `Amount` to this `Amount`
+//
+// If the resulting value would underflow, an error is returned,
+// along with an invalid value (which would trigger a `panic` if used).
+//
 func (a Amount) Sub(sub Amount) (Amount, error) {
 	a.Invariant()
 	sub.Invariant()
@@ -85,8 +85,8 @@ func (a Amount) Sub(sub Amount) (Amount, error) {
 	return a - sub, nil
 }
 
-/// Counterpart of `Sub` which panic instead of returning an error
-/// Useful for debugging and testing, should be avoided in regular code
+// Counterpart of `Sub` which panic instead of returning an error
+// Useful for debugging and testing, should be avoided in regular code
 func (a Amount) MustSub(sub Amount) Amount {
 	if v, err := a.Sub(sub); err != nil {
 		panic(err)

--- a/lib/data.go
+++ b/lib/data.go
@@ -95,18 +95,15 @@ func (a Amount) MustSub(sub Amount) Amount {
 	}
 }
 
+// Implement JSON's Marshaler interface
 func (a Amount) MarshalJSON() ([]byte, error) {
-	return []byte(fmt.Sprintf("\"%s\"", strconv.FormatInt(int64(a), 10))), nil
+	return []byte(fmt.Sprintf("\"%s\"", a.String())), nil
 }
 
+// Implement JSON's Unmarshaler interface
+// If Unmarshalling errors, `a` will have an `invalidValue`
 func (a *Amount) UnmarshalJSON(b []byte) (err error) {
-	var c int64
-	if c, err = strconv.ParseInt(string(b[1:len(b)-1]), 10, 64); err != nil {
-		return
-	}
-
-	*a = Amount(c)
-
+	*a, err = AmountFromString(string(b[1 : len(b)-1]))
 	return
 }
 


### PR DESCRIPTION
```
By parsing the incoming data with ParseInt, we did not do any verification on the incoming data
An attacker could send a value which is over the limit and this would not be detected.
By using AmountFromString we ensure that this result in an Error, and a predictable value.
```

Better reviewed commit-by-commit.