### PR TITLE
Add `oklog.run` for graceful stop

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,6 +23,12 @@
   revision = "501929d3d046174c3d39f0ea54ece471aa17238c"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "346938d642f2ec3594ed81d874461961cd0faa76"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/ethereum/go-ethereum"
   packages = ["rlp"]
   revision = "12683feca7483f0b0bf425c3c520e2724f69f2aa"
@@ -47,10 +53,22 @@
   version = "0.2"
 
 [[projects]]
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
+
+[[projects]]
   name = "github.com/gorilla/handlers"
   packages = ["."]
   revision = "90663712d74cb411cbef281bc1e08c19d1a76145"
   version = "v1.3.0"
+
+[[projects]]
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
 
 [[projects]]
   name = "github.com/inconshreveable/log15"
@@ -92,10 +110,22 @@
   revision = "a875e7c9fa2388ce03279f6b5ba1c2ccd1f9e917"
 
 [[projects]]
+  name = "github.com/oklog/run"
+  packages = ["."]
+  revision = "4dadeb3030eda0273a12382bb2348ffc7c9d1a39"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
+
+[[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -128,6 +158,12 @@
     "xdr"
   ]
   revision = "87a45bf9f03de7e521afc77d6695917ec174d3d7"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
@@ -202,6 +238,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "22bea8df38b9a921915c67651cb283a0b2db2583f9f11a21d22a79e029c07a24"
+  inputs-digest = "a962ffc8383dc57d2890c2af3b92ca3b4a85528f7523d876aab62ef33e8eb7dc"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -41,3 +41,7 @@
 [[constraint]]
   name = "github.com/spf13/cobra"
   version = "0.0.3"
+
+[[constraint]]
+  name = "github.com/oklog/run"
+  version = "1.0.0"

--- a/cmd/sebak/common/interrupt.go
+++ b/cmd/sebak/common/interrupt.go
@@ -1,0 +1,20 @@
+package common
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func Interrupt(cancel <-chan struct{}) error {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	select {
+	case sig := <-c:
+		return fmt.Errorf("received signal %s", sig)
+	case <-cancel:
+		return errors.New("canceled")
+	}
+}


### PR DESCRIPTION
### Requirements


### Github Issue

#26 

### Background


### Solution

Using `oklog/run` for a universal mechanism to manage goroutine lifecycles. 

`oklog/run` : https://github.com/oklog/run

### Possible Drawbacks