### PR TITLE
Fix panic on master

### DIFF
--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -66,7 +66,7 @@ func NewNodeRunner(
 
 func (nr *NodeRunner) Ready() {
 	nr.network.SetContext(nr.ctx)
-	nr.network.AddHandler(nr.ctx, AddAPIHandlers)
+	nr.network.AddHandler(nr.ctx, AddAPIHandlers(nr.storage))
 	nr.network.Ready()
 }
 


### PR DESCRIPTION
At the moment, due to a missing parameter, we pass a function instead of its result,
which leads to a panic during a type conversion, as can be seen below:

```
panic: interface conversion: interface {} is func(*sebakstorage.LevelDBBackend) func(context.Context, *sebaknetwork.HTTP2Network), not func(context.Context, *sebaknetwork.HTTP2Network)

goroutine 1 [running]:
boscoin.io/sebak/lib/network.(*HTTP2Network).AddHandler(0xc4200ceb00, 0x9dc800, 0xc4205f43c0, 0xc420095670, 0x1, 0x1, 0x9de900, 0x9dc800)
	/go/src/boscoin.io/sebak/lib/network/http2_network.go:160 +0x91
boscoin.io/sebak/lib.(*NodeRunner).Ready(0xc42009a680)
	/go/src/boscoin.io/sebak/lib/node_runner.go:69 +0xce
boscoin.io/sebak/lib.(*NodeRunner).Start(0xc42009a680, 0x12, 0x9e0360)
	/go/src/boscoin.io/sebak/lib/node_runner.go:74 +0x2f
boscoin.io/sebak/cmd/sebak/cmd.runNode()
	/go/src/boscoin.io/sebak/cmd/sebak/cmd/node.go:284 +0x774
boscoin.io/sebak/cmd/sebak/cmd.init.2.func1(0xc4200e9b80, 0xc4200b2300, 0x0, 0x6)
	/go/src/boscoin.io/sebak/cmd/sebak/cmd/node.go:115 +0x25
boscoin.io/sebak/vendor/github.com/spf13/cobra.(*Command).execute(0xc4200e9b80, 0xc4200b2240, 0x6, 0x6, 0xc4200e9b80, 0xc4200b2240)
	/go/src/boscoin.io/sebak/vendor/github.com/spf13/cobra/command.go:766 +0x2c1
boscoin.io/sebak/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc7fb20, 0xc7fd80, 0xc420063f78, 0x405dac)
	/go/src/boscoin.io/sebak/vendor/github.com/spf13/cobra/command.go:852 +0x30a
boscoin.io/sebak/vendor/github.com/spf13/cobra.(*Command).Execute(0xc7fb20, 0x2, 0x0)
	/go/src/boscoin.io/sebak/vendor/github.com/spf13/cobra/command.go:800 +0x2b
boscoin.io/sebak/cmd/sebak/cmd.Execute()
	/go/src/boscoin.io/sebak/cmd/sebak/cmd/init.go:22 +0x2d
main.main()
	/go/src/boscoin.io/sebak/cmd/sebak/main.go:8 +0x20
```
