### PR TITLE
Fix entrypoint to accept any command

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,7 +3,7 @@
 # This entrypoint has 2 modes: if any argument is provided to `docker run`, the
 # arguments are passed directly to sebak Otherwise, it just starts a node with the
 # environment file
-if [ $# -gt 1 ]; then
+if [ $# -gt 0 ]; then
     # Argument mode
     ./sebak $@
 else


### PR DESCRIPTION
This was working because most of the commands have more than one argument,
but calling '--help' or 'version' would fail.