### PR TITLE
Add .env file

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,9 @@ if [ $# -gt 1 ]; then
     ./sebak $@
 else
     # Node mode
+    if [ -f ".env" ]; then
+      source ./.env
+    fi
     ./sebak genesis ${SEBAK_GENESIS_BLOCK}
     ./sebak node --log-level debug
 fi


### PR DESCRIPTION
This file is automatically generated when a container is initialized.

SEBAK doesn't support config file, so environment variables are put dynamically in that file.