### PR TITLE
Using log.CallerFileHandler for logging file name and line number

### DIFF
--- a/cmd/sebak/cmd/node.go
+++ b/cmd/sebak/cmd/node.go
@@ -188,6 +188,8 @@ func parseFlagsNode() {
 		}
 	}
 
+	logHandler = logging.CallerFileHandler(logHandler)
+
 	log = logging.New("module", "main")
 	log.SetHandler(logging.LvlFilterHandler(logLevel, logHandler))
 	sebak.SetLogging(logLevel, logHandler)

--- a/lib/common/test/log.go
+++ b/lib/common/test/log.go
@@ -12,7 +12,7 @@ func LogHandler() logging.Handler {
 			return logging.DiscardHandler()
 		},
 		"stdout": func() logging.Handler {
-			return logging.StdoutHandler
+			return logging.CallerStackHandler("%+v", logging.StdoutHandler)
 		},
 	}
 

--- a/lib/network/init.go
+++ b/lib/network/init.go
@@ -9,7 +9,8 @@ import (
 var log logging.Logger = logging.New("module", "network")
 
 func SetLogging(level logging.Lvl, handler logging.Handler) {
-	log.SetHandler(logging.LvlFilterHandler(level, handler))
+	lh := logging.LvlFilterHandler(level, handler)
+	log.SetHandler(lh)
 }
 
 func init() {


### PR DESCRIPTION

### Background

I think that logging  file name, the line number of it are a good information for debugging 

This will output a line that looks like:

 > lvl=dbug msg="got connect" module=sebak node=GDTE.6RAE  **caller=node_runner.go:204**

Reference : https://godoc.org/github.com/inconshreveable/log15#hdr-Logging_File_Names_and_Line_Numbers


### Result 

```
node3_1  | t=2018-07-01T08:11:52+0000 lvl=dbug msg="got connect" module=sebak node=GDTE.6RAE message="{\"Type\":\"connect\",\"Data\":\"eyJhZGRyZXNzIjoiR0RJUkY0" caller=node_runner.go:204
node2_1  | t=2018-07-01T08:11:52+0000 lvl=dbug msg="got connect" module=sebak node=GAYG.TLY7 message="{\"Type\":\"connect\",\"Data\":\"eyJhZGRyZXNzIjoiR0RJUkY0" caller=node_runner.go:204
node2_1  | t=2018-07-01T08:11:52+0000 lvl=dbug msg="got connect" module=sebak node=GAYG.TLY7 message="{\"Type\":\"connect\",\"Data\":\"eyJhZGRyZXNzIjoiR0RURVBG" caller=node_runner.go:204
node1_1  | t=2018-07-01T08:11:52+0000 lvl=dbug msg="got connect" module=sebak node=GDIR.M6CC message="{\"Type\":\"connect\",\"Data\":\"eyJhZGRyZXNzIjoiR0RURVBG" caller=node_runner.go:204
```

### Possible Drawbacks

When `go test` , `log.CallerStackHandler` is used insteads of `log.CallerFileHandler` for more detail information. 

```
t=2018-07-01T17:19:33+0900 lvl=dbug msg="consensus closed" module=sebak node=GA6Q.2FDO stack="[boscoin.io/sebak/lib/node_runner.go:275 boscoin.io/sebak/lib/node_runner.go:253]"
```

I am not sure but `runtime.Caller(1)` or stack tracing can make a little overhead during logging.