### PR TITLE
Install vendor on Docker if there is no vendor 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,15 @@ LABEL maintainer="BOSCoin Developers <devteam@boscoin.io>"
 COPY ./ /go/src/boscoin.io/sebak
 WORKDIR /go/src/boscoin.io/sebak
 
+RUN apk add --no-cache git openssh
+
 ## Note that we do not get the dependencies anew
 ## We carry over whatever is in `vendor`, so the user MUST run `dep ensure` in their local copy
 ## This make building the container orders of magnitude faster (`dep ensure` is extremely slow),
 ## greatly reduce the container's size, and gives more control to the user as to what is tested
-## (one can replace a dependency, if needed).
+## Otherwise, install dep and dependencies.(e.g Docker Hub automated build)
+RUN if [ ! -d vendor ]; then go get github.com/golang/dep/cmd/dep; dep ensure -v; fi
+
 RUN go install -v ./...
 
 ## This one is much more lightweight


### PR DESCRIPTION
from @Geod24 's comment in #164

Without this, we can't build the docker image on Docker Hub automated build.