### PR TITLE
Use check Amount primitives (+code cleanup)

### DIFF
--- a/lib/data.go
+++ b/lib/data.go
@@ -3,8 +3,8 @@
 //
 // One BOSCoin accounts for 10 million currency units.
 // In addition to the `Amount` type, some member functions are defined:
-// - Add / Sub do an addition / substraction and return an error object
-// - AddCheck / SubCheck call `Add` / `Sub` and turn any `error` into a `panic`.
+// - `Add` / `Sub` do an addition / substraction and return an error object
+// - `MustAdd` / `MustSub` call `Add` / `Sub` and turn any `error` into a `panic`.
 //   Those are provided for testing / quick prototyping and should not be in production code.
 // - Invariant `panic`s if the instance it's called on violates its invariant (see Contract programming)
 //

--- a/lib/data.go
+++ b/lib/data.go
@@ -85,6 +85,49 @@ func (a Amount) Sub(sub Amount) (Amount, error) {
 	return a - sub, nil
 }
 
+//
+// Add this `Amount` to itself, `n` times
+//
+// If the resulting value would overflow maximumAmount, an error is returned,
+// along with the value (which would trigger a `panic` if used).
+//
+func (a Amount) MultInt(n int) (Amount, error) {
+	return a.MultInt64(int64(n))
+}
+
+/// Ditto
+func (a Amount) MultUint(n uint) (Amount, error) {
+	return a.MultUint64(uint64(n))
+}
+
+/// Ditto
+func (a Amount) MultInt64(n int64) (Amount, error) {
+	if n < 0 {
+		return invalidValue, sebakerror.ErrorAccountBalanceUnderZero
+	}
+	return a.MultUint64(uint64(n))
+}
+
+/// Ditto
+func (a Amount) MultUint64(n uint64) (Amount, error) {
+	a.Invariant()
+	if uint64(MaximumBalance)/n < uint64(a) {
+		return invalidValue, sebakerror.ErrorMaximumBalanceReached
+	}
+
+	return Amount(uint64(a) * n), nil
+}
+
+// Counterpart of `Mult` which panic instead of returning an error
+// Useful for debugging and testing, should be avoided in regular code
+func (a Amount) MustMult(n int) Amount {
+	if v, err := a.MultInt(n); err != nil {
+		panic(err)
+	} else {
+		return v
+	}
+}
+
 // Counterpart of `Sub` which panic instead of returning an error
 // Useful for debugging and testing, should be avoided in regular code
 func (a Amount) MustSub(sub Amount) Amount {

--- a/lib/data_test.go
+++ b/lib/data_test.go
@@ -21,6 +21,31 @@ func TestAmount_Invariant(t *testing.T) {
 	amount.Invariant()
 }
 
+func TestAmount_Mult(t *testing.T) {
+	if Amount(100).MustMult(50) != Amount(5000) {
+		t.Errorf("MustMult returned a wrong result")
+	}
+	val, err := Amount(100).MultUint(50)
+	if err != nil || val != Amount(5000) {
+		t.Errorf("MustMult returned an error or a wrong result")
+	}
+	// Test `MustMult` + overflow failure
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("Expected `panic` did not happen")
+			}
+		}()
+		_ = MaximumBalance.MustMult(2)
+		t.Error("Unreachable code")
+	}()
+	// Test negative value
+	_, err = Amount(42).MultInt(-42)
+	if err == nil {
+		t.Errorf("Expected error on negative value was not triggered")
+	}
+}
+
 // https://github.com/bosnet/sebak/issues/85
 func TestAmount_Uint64OutOfRange(t *testing.T) {
 	amount, err := AmountFromString(maximumBalanceStr)

--- a/lib/node_runner_checker.go
+++ b/lib/node_runner_checker.go
@@ -249,8 +249,8 @@ func CheckNodeRunnerHandleBallotVotingHole(c sebakcommon.Checker, args ...interf
 	votingHole = VotingNO
 
 	tx := checker.GetTransaction()
-	if tx.B.Fee < Amount(BaseFee) {
-		checker.NodeRunner.Log().Debug("VotingNO: tx.B.Fee < Amount(BaseFee)")
+	if tx.B.Fee < BaseFee {
+		checker.NodeRunner.Log().Debug("VotingNO: tx.B.Fee < BaseFee")
 		votingHole = VotingNO
 
 		return

--- a/lib/node_runner_memory_network_test.go
+++ b/lib/node_runner_memory_network_test.go
@@ -33,7 +33,7 @@ func makeTransaction(kp *keypair.Full) (tx Transaction) {
 
 	txBody := TransactionBody{
 		Source:     kp.Address(),
-		Fee:        Amount(BaseFee),
+		Fee:        BaseFee,
 		Checkpoint: uuid.New().String(),
 		Operations: ops,
 	}
@@ -63,7 +63,7 @@ func makeTransactionPayment(kpSource *keypair.Full, target string, amount Amount
 
 	txBody := TransactionBody{
 		Source:     kpSource.Address(),
-		Fee:        Amount(BaseFee),
+		Fee:        BaseFee,
 		Checkpoint: uuid.New().String(),
 		Operations: []Operation{op},
 	}
@@ -93,7 +93,7 @@ func makeTransactionCreateAccount(kpSource *keypair.Full, target string, amount 
 
 	txBody := TransactionBody{
 		Source:     kpSource.Address(),
-		Fee:        Amount(BaseFee),
+		Fee:        BaseFee,
 		Checkpoint: uuid.New().String(),
 		Operations: []Operation{op},
 	}

--- a/lib/test.go
+++ b/lib/test.go
@@ -79,7 +79,7 @@ func TestMakeTransaction(networkID []byte, n int) (kp *keypair.Full, tx Transact
 
 	txBody := TransactionBody{
 		Source:     kp.Address(),
-		Fee:        Amount(BaseFee),
+		Fee:        BaseFee,
 		Checkpoint: uuid.New().String(),
 		Operations: ops,
 	}

--- a/lib/transaction.go
+++ b/lib/transaction.go
@@ -150,17 +150,29 @@ func (tx Transaction) Source() string {
 	return tx.B.Source
 }
 
+//
+// Returns:
+//   the total monetary value of this transaction,
+//   which is the sum of its operations,
+//   optionally with fees
+//
+// Params:
+//   withFee = If fee should be included in the total
+//
 func (tx Transaction) TotalAmount(withFee bool) Amount {
-	var amount int64
+	// Note that the transaction shouldn't be constructed invalid
+	// (the sum of its Operations should not exceed the maximum supply)
+	var amount Amount
 	for _, op := range tx.B.Operations {
-		amount += int64(op.B.GetAmount())
+		amount = amount.MustAdd(op.B.GetAmount())
 	}
 
+	// TODO: This isn't checked anywhere yet
 	if withFee {
-		amount += int64(len(tx.B.Operations)) * int64(tx.B.Fee)
+		amount = amount.MustAdd(tx.B.Fee.MustMult(len(tx.B.Operations)))
 	}
 
-	return Amount(amount)
+	return amount
 }
 
 func (tx Transaction) Serialize() (encoded []byte, err error) {

--- a/lib/transaction.go
+++ b/lib/transaction.go
@@ -67,7 +67,7 @@ func NewTransaction(source, checkpoint string, ops ...Operation) (tx Transaction
 
 	txBody := TransactionBody{
 		Source:     source,
-		Fee:        Amount(BaseFee),
+		Fee:        BaseFee,
 		Checkpoint: checkpoint,
 		Operations: ops,
 	}

--- a/lib/transaction.go
+++ b/lib/transaction.go
@@ -219,6 +219,17 @@ func (tb TransactionBody) MakeHashString() string {
 	return base58.Encode(tb.MakeHash())
 }
 
+///
+/// Apply this transaction (`tx`) to the storage, externalizing it
+///
+/// Params:
+///   st = Storage backend
+///   ballot = the ballot that triggered consensus
+///   tx = `Transaction` to externalize
+///
+/// Returns:
+///   err = If the `Transaction` could not be externalized
+///
 func FinishTransaction(st *sebakstorage.LevelDBBackend, ballot Ballot, tx Transaction) (err error) {
 	var raw []byte
 	raw, err = ballot.Data().Serialize()

--- a/lib/transaction_test.go
+++ b/lib/transaction_test.go
@@ -39,20 +39,20 @@ func TestIsWellFormedTransactionWithLowerFee(t *testing.T) {
 
 	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
 	kp, tx := TestMakeTransaction(networkID, 1)
-	tx.B.Fee = Amount(BaseFee)
+	tx.B.Fee = BaseFee
 	tx.H.Hash = tx.B.MakeHashString()
 	tx.Sign(kp, networkID)
 	if err = tx.Validate(st); err != nil {
 		t.Errorf("transaction must not be failed for fee: %d: %v", BaseFee, err)
 	}
-	tx.B.Fee = Amount(BaseFee + 1)
+	tx.B.Fee = BaseFee.MustAdd(1)
 	tx.H.Hash = tx.B.MakeHashString()
 	tx.Sign(kp, networkID)
 	if err = tx.IsWellFormed(networkID); err != nil {
 		t.Errorf("transaction must not be failed for fee: %d: %v", BaseFee+1, err)
 	}
 
-	tx.B.Fee = Amount(BaseFee - 1)
+	tx.B.Fee = BaseFee.MustSub(1)
 	tx.H.Hash = tx.B.MakeHashString()
 	tx.Sign(kp, networkID)
 	if err = tx.IsWellFormed(networkID); err == nil {


### PR DESCRIPTION
Pretty straightforward, as long as you review it commit by commit.
The lack of overload or sane implicit type conversion led to some duplication, unfortunately.