### PR TITLE
Add codecov configuration to fix the file path

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+## Fixes the path used so that codecov can properly display files and diff
+## When coverage is uploaded from CI, the absolute path (`/go/src/boscoin.io...`)
+## is present in the report, which Codecov cannot match by default
+fixes:
+  - "go/src/boscoin.io/sebak/::"  # Remove the prefix


### PR DESCRIPTION
If you go to https://codecov.io/gh/bosnet/sebak at the bottom of the page there is a link to the file "go/src/boscoin.io/sebak/..." because when the coverage file is uploaded, that's the path being referenced.
Codecov provides a solution to trim the path, which is used here.
See https://docs.codecov.io/docs/fixing-paths