### PR TITLE
Add basic integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ jobs:
           name: run tests
           command: |
             for pkg in $(go list ./... | grep -v vendor); do
-                SEBAK_LOG_HANDLER=null GOCACHE=off go test -v -timeout 3m -coverprofile=profile.out -covermode=atomic "$pkg"
+                SEBAK_LOG_HANDLER=null GOCACHE=off go test -v -timeout 3m -coverprofile=profile.out "$pkg"
                 if [ -f profile.out ]; then
                     cat profile.out >> coverage.txt
                     rm profile.out

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           name: run tests
           command: SEBAK_LOG_HANDLER=null GOCACHE=off go test -v -timeout 3m ./...
 
-  test_merged:
+  generate_merged_tree:
     <<: *defaults
     steps:
       - <<: *workspace
@@ -72,6 +72,15 @@ jobs:
               git fetch -u origin ${FETCH_REFS}
               git checkout "pr/${CIRCLE_PR_NUMBER}/merge"
             fi
+      - persist_to_workspace:
+          root: /
+          paths:
+            - go/src/boscoin.io/sebak
+
+  unittests:
+    <<: *defaults
+    steps:
+      - <<: *workspace
       - run:
           name: run tests
           command: |
@@ -85,6 +94,18 @@ jobs:
       - run:
           name: upload coverage reports
           command: bash <(curl -s https://codecov.io/bash) -F unittests
+
+  integration_tests:
+    <<: *defaults
+    steps:
+      - setup_remote_docker
+      - <<: *workspace
+      - run:
+          name: integration tests
+          command: ./tests/run.sh
+      - run:
+          name: upload coverage reports
+          command: bash <(curl -s https://codecov.io/bash) -F integration_tests
 
 workflows:
   version: 2
@@ -100,6 +121,12 @@ workflows:
       - test_go1_9:
           requires:
             - fmt
-      - test_merged:
+      - generate_merged_tree:
           requires:
             - fmt
+      - unittests:
+          requires:
+            - generate_merged_tree
+      - integration_tests:
+          requires:
+            - generate_merged_tree

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp*
 db
 *.orig
 .idea
+tests/*/coverage/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ LABEL maintainer="BOSCoin Developers <devteam@boscoin.io>"
 COPY ./ /go/src/boscoin.io/sebak
 WORKDIR /go/src/boscoin.io/sebak
 
+# You probably don't need to change this
+ARG BUILD_MODE="install"
+ARG BUILD_ARGS=''
+ARG BUILD_PKG="./..."
+
 RUN apk add --no-cache git openssh
 RUN go get github.com/ahmetb/govvv
 
@@ -15,9 +20,10 @@ RUN go get github.com/ahmetb/govvv
 ## greatly reduce the container's size, and gives more control to the user as to what is tested
 ## (one can replace a dependency, if needed).
 ## Otherwise, install dep and dependencies.(e.g Docker Hub automated build)
+
 RUN if [ ! -d vendor ]; then go get github.com/golang/dep/cmd/dep; dep ensure -v; fi
 
-RUN govvv install -pkg boscoin.io/sebak/lib/version -v ./...
+RUN go $BUILD_MODE $BUILD_ARGS -ldflags="$(govvv -pkg boscoin.io/sebak/lib/version -flags)" -v $BUILD_PKG
 
 ## This one is much more lightweight
 FROM alpine:latest AS runner

--- a/cmd/sebak/cmd/init.go
+++ b/cmd/sebak/cmd/init.go
@@ -23,3 +23,7 @@ func Execute() {
 		common.PrintFlagsError(rootCmd, "", err)
 	}
 }
+
+func SetArgs(s []string) {
+	rootCmd.SetArgs(s)
+}

--- a/cmd/sebak/common/interrupt.go
+++ b/cmd/sebak/common/interrupt.go
@@ -13,7 +13,8 @@ func Interrupt(cancel <-chan struct{}) error {
 	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 	select {
 	case sig := <-c:
-		return fmt.Errorf("received signal %s", sig)
+		fmt.Println("Received signal ", sig, ", shutting down...")
+		return nil
 	case <-cancel:
 		return errors.New("canceled")
 	}

--- a/cmd/sebak/main_test.go
+++ b/cmd/sebak/main_test.go
@@ -1,0 +1,29 @@
+// +build integration
+
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"boscoin.io/sebak/cmd/sebak/cmd"
+)
+
+// Run the program as a test
+// This needs to be compiled with `go test` with special flags (see tests/run.sh)
+// to do the trick.
+// It filters out test arguments for the main, then launch the mail.
+// This allows us to gather coverage reports from integration tests
+func TestIntegration(t *testing.T) {
+	var filteredArgs []string
+	for _, arg := range os.Args[1:] {
+		if strings.HasPrefix(arg, "-test.") ||
+			strings.HasPrefix(arg, "-httptest.") {
+			continue
+		}
+		filteredArgs = append(filteredArgs, arg)
+	}
+	cmd.SetArgs(filteredArgs)
+	main()
+}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,0 +1,11 @@
+## We do not have any dependency on Sebak itself and should not
+FROM alpine:latest
+
+RUN apk --no-cache add bash curl jq
+
+## Copy the full directory
+ADD . /tests/
+
+WORKDIR /tests/
+ENTRYPOINT [ "/tests/entrypoint.sh" ]
+CMD []

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,27 @@
+# SEBAK Integration tests
+
+## Dependencies
+
+This testsuite depends on `bash`, `curl`, `jq` and `docker`.
+You should have the ability to build and image to run it.
+
+## Layout
+
+Integration tests reside in this directory, while unittests reside in the source folder as is standard Golang practice.
+Each subdirectory contains an integration test.
+
+## Requests
+
+The base unit in a test is a request, which are represented by `json` files.
+A name should follow the following naming convention:
+- The name should be`request_$ID_[$NODE[_$DESCRIPTION]].json`
+- $ID is an integer, allowing to order requests
+- If two requests with the same `$ID` exists, they will be send at the same time
+- $NODE is the port of the node to send this request to
+- If $NODE is not provided, the request will be sent to all nodes
+- $DESCRIPTION is just an optional human readable description
+
+## Configuration
+
+In the future, it would be sensible to provide a way to configure the network.
+At the moment, the network is hard-coded to be the 3 nodes provided in this repository.

--- a/tests/account-creation/request_1_2821_create_account_1.json
+++ b/tests/account-creation/request_1_2821_create_account_1.json
@@ -1,0 +1,25 @@
+{
+  "T": "transaction",
+  "H": {
+    "version": "",
+    "created": "2018-01-01T00:00:00.000000000Z",
+    "hash": "CvrDmmXV8YcQV3tr1vvPRT1UczajsZzE6ZhAM3kDfU5a",
+    "signature": "3TYE7GJL6Ts57PboiMnrNmLsKxiUPz46Xk8nehwTnuLxfM1vkk9umjopcqTQToc2VsDFhVWXFNypjbhxKxtDizw4"
+  },
+  "B": {
+    "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",
+    "fee": "10000",
+    "checkpoint": "5nc4PvPKMxDTM6ets3hudktkA-5nc4PvPKMxDTM6ets3hudktkA",
+    "operations": [
+      {
+        "H": {
+          "type": "create-account"
+        },
+        "B": {
+          "target": "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4",
+          "amount": "10000000000"
+        }
+      }
+    ]
+  }
+}

--- a/tests/account-creation/request_1_2821_create_account_1.json.check
+++ b/tests/account-creation/request_1_2821_create_account_1.json.check
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xe
+export TEST_NAME=${BASH_SOURCE[0]}
+source $(dirname ${BASH_SOURCE[0]})/../utils.sh
+
+sleep 5
+
+EXPECTED1="9999999989999990000"
+EXPECTED2="10000000000"
+
+for ((port=2821;port<=2823;port++)); do
+    BA1=$(getAccount $port "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ" | jq ".Balance" | sed 's/"//g')
+    if [ -z ${BA1} ] || [ ${BA1} != ${EXPECTED1} ]; then
+        die "Expected balance to be ${EXPECTED1}, not ${BA1}"
+    fi
+    BA2=$(getAccount $port "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4" | jq ".Balance" | sed 's/"//g')
+    if [ -z ${BA2} ] || [ ${BA2} != ${EXPECTED2} ]; then
+        die "Expected balance to be ${EXPECTED2}, not ${BA2}"
+    fi
+done

--- a/tests/account-creation/request_2_2822_pay_to_account_1.json
+++ b/tests/account-creation/request_2_2822_pay_to_account_1.json
@@ -1,0 +1,25 @@
+{
+  "T": "transaction",
+  "H": {
+    "version": "",
+    "created": "2018-01-01T00:00:00.000000000Z",
+    "hash": "8KwArK8n6ZP5AgDdxxbt5vfZDSagN5VTYKwpsst4u94M",
+    "signature": "4g6HmiPQV1rRRhrQSWS7CS6Qt1m3MVuEeQgocWzGVXtuuqFJ8x9u6mY1z7hYDT5bEscYmQGX9jwKX8FYdUSDu6vN"
+  },
+  "B": {
+    "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",
+    "fee": "10000",
+    "checkpoint": "CvrDmmXV8YcQV3tr1vvPRT1UczajsZzE6ZhAM3kDfU5a-CvrDmmXV8YcQV3tr1vvPRT1UczajsZzE6ZhAM3kDfU5a",
+    "operations": [
+      {
+        "H": {
+          "type": "payment"
+        },
+        "B": {
+          "target": "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4",
+          "amount": "10000000000"
+        }
+      }
+    ]
+  }
+}

--- a/tests/account-creation/request_2_2822_pay_to_account_1.json.check
+++ b/tests/account-creation/request_2_2822_pay_to_account_1.json.check
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+set -xe
+export TEST_NAME=${BASH_SOURCE[0]}
+source $(dirname ${BASH_SOURCE[0]})/../utils.sh
+
+sleep 5
+
+EXPECTED1="9999999979999980000"
+EXPECTED2="20000000000"
+
+for ((port=2821;port<=2823;port++)); do
+    BA1=$(getAccount $port "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ" | jq ".Balance" | sed 's/"//g')
+    if [ -z ${BA1} ] || [ ${BA1} != ${EXPECTED1} ]; then
+        die "Expected balance to be ${EXPECTED1}, not ${BA1}"
+    fi
+    BA2=$(getAccount $port "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4" | jq ".Balance" | sed 's/"//g')
+    if [ -z ${BA2} ] || [ ${BA2} != ${EXPECTED2} ]; then
+        die "Expected balance to be ${EXPECTED2}, not ${BA2}"
+    fi
+done

--- a/tests/default_runner.sh
+++ b/tests/default_runner.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -xe
+source utils.sh
+
+if [ $# -ne 1 ]; then
+    die "Expected 1 argument (directory), not $#: $@"
+fi
+
+DIR=${1}
+
+cd $DIR
+echo "===== ${DIR}: Default test runner ====="
+
+for JSONFILE in $(find . -name "*.json" -type f | sort); do
+    PORT=$(echo "${JSONFILE}" | cut -d'_' -f3)
+    curl --insecure \
+         --request POST \
+         --header "Content-Type: application/json" \
+         --data "$(cat ${JSONFILE})" \
+         https://127.0.0.1:${PORT}/node/message \
+         >/dev/null 2>&1
+    # Intermediate checks
+    if [ -f ${JSONFILE}.check ]; then
+        bash -c ${JSONFILE}.check
+    fi
+done

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -xe
+
+if [ $# -ne 1 ]; then
+    echo 1>&2 "Error: Expected 1 argument (test directory), $# provided..."
+    exit 1
+fi
+
+# Make sure we're in the right directory
+cd -- `dirname ${BASH_SOURCE[0]}`
+TEST_DIR=${1}
+
+## Test suites can override the runner should they need to
+if [ -x ${TEST_DIR}/run.sh ] && [ -f ${TEST_DIR}/run.sh ]; then
+    exit 1
+else
+    ./default_runner.sh ${TEST_DIR}
+fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -xe
+
+# We need to use absolute path for the Docker container
+# So make sure we're in the right WD
+cd -- `dirname ${BASH_SOURCE[0]}`
+TEST_DIRS=$(find . -mindepth 1 -maxdepth 1 -type d -print)
+ROOT_DIR=".."
+export SEBAK_NODE_ARGS=""
+export SEBAK_GENESIS=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ
+
+# We can only have one trap active at a time, so just save the IDs of containers we started.
+# Single quotes around  trap ensure that the variable is evaluated at exit time.
+DOCKER_CONTAINERS=""
+trap 'if [ ! -z "${DOCKER_CONTAINERS}" ]; then docker rm -f ${DOCKER_CONTAINERS} || true; fi' EXIT
+
+## Build the docker container
+NODE_DOCKER_IMAGE=$(docker build -q --build-arg BUILD_MODE='test' --build-arg BUILD_PKG='./cmd/sebak' \
+                           --build-arg BUILD_ARGS='-coverpkg=./... -tags integration -c -o /go/bin/sebak' \
+                           ${ROOT_DIR} | cut -d: -f2)
+
+# Build the integration test container
+TESTS_DOCKER_IMAGE=$(docker build -q . | cut -d: -f2)
+
+for dir in ${TEST_DIRS}; do
+    # Setup our test environment
+    # We need to keep the container around after we stop it when we report coverage,
+    # because the reports are written on program's exit, which also means container's shutdown
+    # Also SUPER IMPORTANT: the `-test` args need to be before any other args, or they are simply ignored...
+    export NODE1=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node1.env \
+                          ${NODE_DOCKER_IMAGE} -test.coverprofile=coverage.txt node --genesis=${SEBAK_GENESIS})
+    export NODE2=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node2.env \
+                          ${NODE_DOCKER_IMAGE} -test.coverprofile=coverage.txt node --genesis=${SEBAK_GENESIS})
+    export NODE3=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node3.env \
+                          ${NODE_DOCKER_IMAGE} -test.coverprofile=coverage.txt node --genesis=${SEBAK_GENESIS})
+
+    DOCKER_CONTAINERS="${DOCKER_CONTAINERS} ${NODE1} ${NODE2} ${NODE3}"
+
+    # Give them a bit of time
+    sleep 3
+
+    # Run the tests
+    docker run --rm --network host ${TESTS_DOCKER_IMAGE} ${dir}
+
+    # Shut down the containers - we need to do so for integration reports to be written
+    docker stop ${NODE1} ${NODE2} ${NODE3}
+
+    # Copy integration tests
+    mkdir -p ${dir}/coverage/node{1,2,3}/
+    docker cp ${NODE1}:/sebak/coverage.txt ${dir}/coverage/node1/coverage.txt
+    docker cp ${NODE2}:/sebak/coverage.txt ${dir}/coverage/node2/coverage.txt
+    docker cp ${NODE3}:/sebak/coverage.txt ${dir}/coverage/node3/coverage.txt
+
+    # Cleanup
+    docker rm -f ${NODE1} ${NODE2} ${NODE3} || true
+done

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -1,0 +1,21 @@
+# Source me
+
+function die () # string message
+{
+    MESSAGE=${1:-"An error happened, but no message was provided"}
+    echo 1>&2 "[${TEST_NAME:-'Unknown test'}] Error: ${MESSAGE}"
+    exit 1
+}
+
+function getAccount () # u16 port, string addr
+{
+    if [ $# -ne 2 ]; then
+        die "2 arguments expected for getAccount, not $#"
+    fi
+
+    echo $(curl --insecure \
+                  --request GET \
+                  --header "Accept: application/json" \
+                  https://127.0.0.1:${1}/api/account/${2} \
+                  2>/dev/null)
+}


### PR DESCRIPTION
This is still an early draft of the principle.
Feel free to review the concept, and ask any questions / discuss the feature.
There's still a lot to implement to support what the README advertise, but I want to collect use cases first.

```
This adds the basic structure for integration tests,
as well as an integration test for account creation.

As opposed to `go test`, this is an end-to-end test which uses the production binary.
It does not rely on sebak in any way for testing, instead we store hardcoded requests
that we send to sebak, and observe the result.

It currently needs a few improvements to make it viable:
- There are random sleeps scattered in the code base
  We should probably use a more sensible retry mechanism instead
~- Code coverage is possible, but not as straightforward as expected.~
~  See https://blog.cloudflare.com/go-coverage-with-external-tests/~
- Generating requests is time consuming.
  We would greatly benefit from a way to log all traffic which is not Wireshark.
- I have concerns that this will grow into a monster of a shell script
```