### PR TITLE
Fix #190: `exec` sebak to properly handle signals

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,12 +5,12 @@
 # environment file
 if [ $# -gt 0 ]; then
     # Argument mode
-    ./sebak $@
+    exec ./sebak $@
 else
     # Node mode
     if [ -f ".env" ]; then
       source ./.env
     fi
     ./sebak genesis ${SEBAK_GENESIS_BLOCK}
-    ./sebak node --log-level debug
+    exec ./sebak node --log-level debug
 fi


### PR DESCRIPTION
```
When Docker starts the container, the main process is the `sh` process running `entrypoint.sh`.
As a result, when one runs `docker stop ${CONTAINER_NAME}`, the signal is sent to `sh`,
which doesn't forward it to `sebak`, leading to us not being able to gracefully stop and `SIGKILL`
being sent after the timeout (10s by default).
Using `exec` we replace the `sh` process with `sebak`,
solving this issue in the simplest way.
```