### PR TITLE
Make genesis inline

### DIFF
--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -31,66 +31,104 @@ func init() {
 		Short: "initialize new network",
 		Args:  cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {
-			var err error
-			var kp keypair.KP
-			var balance sebak.Amount
-
-			if kp, err = keypair.Parse(args[0]); err != nil {
-				common.PrintFlagsError(c, "<public key>", err)
-				os.Exit(1)
+			flagName, err := MakeGenesisBlock(args[0], flagNetworkID, flagBalance, flagStorageConfigString)
+			if len(flagName) != 0 || err != nil {
+				common.PrintFlagsError(c, flagName, err)
 			}
-
-			if len(flagNetworkID) < 1 {
-				common.PrintFlagsError(c, "--network-id", errors.New("--network-id must be given"))
-			}
-
-			if balance, err = common.ParseAmountFromString(flagBalance); err != nil {
-				common.PrintFlagsError(c, "--balance", err)
-			}
-
-			if storageConfig, err = sebakstorage.NewConfigFromString(flagStorageConfigString); err != nil {
-				common.PrintFlagsError(c, "--storage", err)
-			}
-
-			st, err := sebakstorage.NewStorage(storageConfig)
-			if err != nil {
-				common.PrintFlagsError(c, "--storage", fmt.Errorf("failed to initialize storage: %v", err))
-			}
-
-			// check account is exists
-			if _, err = sebak.GetBlockAccount(st, kp.Address()); err == nil {
-				common.PrintFlagsError(c, "<public key>", errors.New("account is already created"))
-			}
-
-			// checkpoint of genesis block is created by `--network-id`
-			account := sebak.NewBlockAccount(
-				kp.Address(),
-				balance,
-				sebakcommon.MakeGenesisCheckpoint([]byte(flagNetworkID)),
-			)
-			account.Save(st)
 
 			fmt.Println("successfully created genesis block")
 		},
 	}
-
-	/*
-	 */
-
-	var err error
-	var currentDirectory string
-	if currentDirectory, err = os.Getwd(); err != nil {
-		common.PrintFlagsError(genesisCmd, "--storage", err)
-	}
-	if currentDirectory, err = filepath.Abs(currentDirectory); err != nil {
-		common.PrintFlagsError(genesisCmd, "--storage", err)
-	}
-
-	flagStorageConfigString = sebakcommon.GetENVValue("SEBAK_STORAGE", fmt.Sprintf("file://%s/db", currentDirectory))
 
 	genesisCmd.Flags().StringVar(&flagBalance, "balance", flagBalance, "initial balance of genesis block")
 	genesisCmd.Flags().StringVar(&flagStorageConfigString, "storage", flagStorageConfigString, "storage uri")
 	genesisCmd.Flags().StringVar(&flagNetworkID, "network-id", flagNetworkID, "network id")
 
 	rootCmd.AddCommand(genesisCmd)
+}
+
+//
+// Create a genesis block using the provided parameter
+//
+// This function is separate, and public, to allow it to be used from other modules
+// (at the moment, only `run`) so it can provide the same behavior (defaults, error messages).
+//
+// Params:
+//   address   = public address of the account owning the genesis block
+//   networkID = `--network-id` argument, used for the block's checkpoint
+//   balance   = Amount of coins to put in the account
+//               If not provided, `flagBalance`, which is the value set in the env
+//               when called from another module, will be used
+//   balance   = Amount of coins to put in the account
+//               If not provided, a default value will be used
+//
+// Returns:
+//   If an error happened, returns a tuple of (string, error).
+//   The string argument represent the name of the flag which errored,
+//   and error is the more detailed error.
+//   Note that only one needs be non-`nil` for it to be considered an error.
+//
+func MakeGenesisBlock(addressStr, networkID, balanceStr, storage string) (string, error) {
+	var balance sebak.Amount
+	var err error
+	var kp keypair.KP
+	var storageConfig *sebakstorage.Config
+
+	if kp, err = keypair.Parse(addressStr); err != nil {
+		return "<address>", err
+	}
+
+	if len(networkID) == 0 {
+		return "--network-id", errors.New("--network-id must be provided")
+	}
+
+	if len(balanceStr) == 0 {
+		balanceStr = initialBalance
+	}
+
+	if balance, err = common.ParseAmountFromString(balanceStr); err != nil {
+		return "--balance", err
+	}
+
+	// Use the default value
+	if len(storage) == 0 {
+		// We try to get the env value first, before doing IO which could fail
+		storage = sebakcommon.GetENVValue("SEBAK_STORAGE", "")
+		// No env, use the default (current directory)
+		if len(storage) == 0 {
+			if currentDirectory, err := os.Getwd(); err == nil {
+				if currentDirectory, err = filepath.Abs(currentDirectory); err == nil {
+					storage = fmt.Sprintf("file://%s/db", currentDirectory)
+				}
+			}
+			// If any of the previous condition failed
+			if len(storage) == 0 {
+				return "--storage", err
+			}
+		}
+	}
+
+	if storageConfig, err = sebakstorage.NewConfigFromString(storage); err != nil {
+		return "--storage", err
+	}
+
+	st, err := sebakstorage.NewStorage(storageConfig)
+	if err != nil {
+		return "--storage", fmt.Errorf("failed to initialize storage: %v", err)
+	}
+
+	// check account does not exists
+	if _, err = sebak.GetBlockAccount(st, kp.Address()); err == nil {
+		return "<public key>", errors.New("account is already created")
+	}
+
+	// checkpoint of genesis block is created by `--network-id`
+	account := sebak.NewBlockAccount(
+		kp.Address(),
+		balance,
+		sebakcommon.MakeGenesisCheckpoint([]byte(flagNetworkID)),
+	)
+	account.Save(st)
+	st.Close()
+	return "", nil
 }

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -61,11 +61,30 @@ var (
 
 func init() {
 	var err error
+	var flagGenesis string
 
 	nodeCmd = &cobra.Command{
 		Use:   "node",
 		Short: "Run sebak node",
 		Run: func(c *cobra.Command, args []string) {
+			// If `--genesis` was provided, perfom `sebak genesis` before starting the node
+			// This allows one-step startup from scratch, quite useful for testing
+			if len(flagGenesis) != 0 {
+				var balanceStr string
+				csv := strings.Split(flagGenesis, ",")
+				if len(csv) > 2 {
+					common.PrintFlagsError(nodeCmd, "--genesis",
+						errors.New("--genesis expects address[,balance], but more than 2 commas detected"))
+				}
+				if len(csv) == 2 {
+					balanceStr = csv[1]
+				}
+				flagName, err := MakeGenesisBlock(csv[0], flagNetworkID, balanceStr, flagStorageConfigString)
+				if len(flagName) != 0 || err != nil {
+					common.PrintFlagsError(c, flagName, err)
+				}
+			}
+
 			parseFlagsNode()
 
 			runNode()
@@ -83,6 +102,7 @@ func init() {
 	}
 	flagStorageConfigString = sebakcommon.GetENVValue("SEBAK_STORAGE", fmt.Sprintf("file://%s/db", currentDirectory))
 
+	nodeCmd.Flags().StringVar(&flagGenesis, "genesis", flagGenesis, "performs the 'genesis' command before running node. Syntax: key[,balance]")
 	nodeCmd.Flags().StringVar(&flagKPSecretSeed, "secret-seed", flagKPSecretSeed, "secret seed of this node")
 	nodeCmd.Flags().StringVar(&flagNetworkID, "network-id", flagNetworkID, "network id")
 	nodeCmd.Flags().StringVar(&flagLogLevel, "log-level", flagLogLevel, "log level, {crit, error, warn, info, debug}")

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
+if [ -f ".env" ]; then
+    source ./.env
+fi
+
 # This entrypoint has 2 modes: if any argument is provided to `docker run`, the
 # arguments are passed directly to sebak Otherwise, it just starts a node with the
 # environment file
@@ -8,8 +12,5 @@ if [ $# -gt 0 ]; then
     exec ./sebak $@
 else
     # Node mode
-    if [ -f ".env" ]; then
-      source ./.env
-    fi
     exec ./sebak node --genesis=${SEBAK_GENESIS_BLOCK} --log-level debug
 fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,6 +11,5 @@ else
     if [ -f ".env" ]; then
       source ./.env
     fi
-    ./sebak genesis ${SEBAK_GENESIS_BLOCK}
-    exec ./sebak node --log-level debug
+    exec ./sebak node --genesis=${SEBAK_GENESIS_BLOCK} --log-level debug
 fi

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -31,18 +31,17 @@ type LevelDBBackend struct {
 }
 
 func (st *LevelDBBackend) Init(config *Config) (err error) {
-	var sto leveldbStorage.Storage
-	if config.Scheme == "memory" {
-		sto = leveldbStorage.NewMemStorage()
-	} else if config.Scheme == "file" {
-		if sto, err = leveldbStorage.OpenFile(config.Path, false); err != nil {
+	var db *leveldb.DB
+
+	if config.Scheme == "file" {
+		if db, err = leveldb.OpenFile(config.Path, nil); err != nil {
 			return
 		}
-	}
-
-	var db *leveldb.DB
-	if db, err = leveldb.Open(sto, nil); err != nil {
-		return
+	} else if config.Scheme == "memory" {
+		sto := leveldbStorage.NewMemStorage()
+		if db, err = leveldb.Open(sto, nil); err != nil {
+			return
+		}
 	}
 
 	st.DB = db


### PR DESCRIPTION
```
Allows us to start the node with different argument,
which was not possible previously as 2 commands needed to be run.
```

Also contains a bugfix to properly close the storage.
Required for integration tests.