### PR TITLE
add lock object because of fixing test fail

### DIFF
--- a/lib/node_runner_create_account_test.go
+++ b/lib/node_runner_create_account_test.go
@@ -40,6 +40,7 @@ func TestNodeRunnerCreateAccount(t *testing.T) {
 
 	var dones []VotingStateStaging
 	var finished []string
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
 		if err == nil {
 			return
@@ -48,6 +49,9 @@ func TestNodeRunnerCreateAccount(t *testing.T) {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); ok {
 			return
 		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
 
 		checker := c.(*NodeRunnerHandleBallotChecker)
 		if _, found := sebakcommon.InStringArray(finished, checker.LocalNode.Alias()); found {
@@ -137,6 +141,7 @@ func TestNodeRunnerCreateAccountInvalidCheckpoint(t *testing.T) {
 
 	var dones []VotingStateStaging
 	var finished []string
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
 		if err == nil {
 			return
@@ -145,6 +150,9 @@ func TestNodeRunnerCreateAccountInvalidCheckpoint(t *testing.T) {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); ok {
 			return
 		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
 
 		checker := c.(*NodeRunnerHandleBallotChecker)
 		if _, found := sebakcommon.InStringArray(finished, checker.LocalNode.Alias()); found {
@@ -228,6 +236,7 @@ func TestNodeRunnerCreateAccountSufficient(t *testing.T) {
 
 	var dones []VotingStateStaging
 	var finished []string
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
 		if err == nil {
 			return
@@ -236,6 +245,9 @@ func TestNodeRunnerCreateAccountSufficient(t *testing.T) {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); ok {
 			return
 		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
 
 		checker := c.(*NodeRunnerHandleBallotChecker)
 		if _, found := sebakcommon.InStringArray(finished, checker.LocalNode.Alias()); found {
@@ -321,6 +333,7 @@ func TestNodeRunnerCreateAccountInsufficient(t *testing.T) {
 
 	var dones []VotingStateStaging
 	var finished []string
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
 		if err == nil {
 			return
@@ -329,6 +342,9 @@ func TestNodeRunnerCreateAccountInsufficient(t *testing.T) {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); ok {
 			return
 		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
 
 		checker := c.(*NodeRunnerHandleBallotChecker)
 		if _, found := sebakcommon.InStringArray(finished, checker.LocalNode.Alias()); found {

--- a/lib/node_runner_isaac_test.go
+++ b/lib/node_runner_isaac_test.go
@@ -129,7 +129,7 @@ func TestNodeRunnerConsensusSameSourceWillBeIgnored(t *testing.T) {
 	nr0 := nodeRunners[0]
 	firstTx := makeTransaction(nr0.Node().Keypair())
 	secondTx := makeTransaction(nr0.Node().Keypair())
-
+	var mutex = &sync.Mutex{}
 	var handleBallotCheckerFuncs = []sebakcommon.CheckerFunc{
 		CheckNodeRunnerHandleBallotIsWellformed,
 		CheckNodeRunnerHandleBallotCheckIsNew,
@@ -144,6 +144,9 @@ func TestNodeRunnerConsensusSameSourceWillBeIgnored(t *testing.T) {
 			}
 
 			if checker.VotingStateStaging.State == sebakcommon.BallotStateSIGN {
+				mutex.Lock()
+				defer mutex.Unlock()
+
 				err = sebakcommon.CheckerErrorStop{"stop consensus, because it is in SIGN state"}
 				wg.Done()
 				return
@@ -164,7 +167,7 @@ func TestNodeRunnerConsensusSameSourceWillBeIgnored(t *testing.T) {
 
 	client := nr0.Network().GetClient(nr0.Node().Endpoint())
 
-	wg.Add(3)
+	wg.Add(numberOfNodes)
 	client.SendMessage(firstTx)
 	wg.Wait()
 
@@ -190,6 +193,8 @@ func TestNodeRunnerConsensusSameSourceWillBeIgnored(t *testing.T) {
 		}
 
 		if _, ok := err.(sebakcommon.CheckerErrorStop); ok {
+			mutex.Lock()
+			defer mutex.Unlock()
 			wg.Done()
 			return
 		}
@@ -276,7 +281,9 @@ func TestNodeRunnerConsensusSameSourceWillNotIgnored(t *testing.T) {
 		return
 	}
 
-	var lastVotingStateStaging []VotingStateStaging
+	var finished []string
+	var dones []VotingStateStaging
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
 		if err == nil {
 			return
@@ -295,8 +302,16 @@ func TestNodeRunnerConsensusSameSourceWillNotIgnored(t *testing.T) {
 			return
 		}
 
-		lastVotingStateStaging = append(lastVotingStateStaging, checker.VotingStateStaging)
+		mutex.Lock()
+		defer mutex.Unlock()
+
+		if _, found := sebakcommon.InStringArray(finished, checker.LocalNode.Alias()); found {
+			return
+		}
+		finished = append(finished, checker.LocalNode.Alias())
+		dones = append(dones, checker.VotingStateStaging)
 		wg.Done()
+
 	}
 
 	var secondHandleBallotCheckerFuncs = []sebakcommon.CheckerFunc{
@@ -309,7 +324,6 @@ func TestNodeRunnerConsensusSameSourceWillNotIgnored(t *testing.T) {
 		// instead of `CheckNodeRunnerHandleBallotVotingHole`
 		func(c sebakcommon.Checker, args ...interface{}) (err error) {
 			checker := c.(*NodeRunnerHandleBallotChecker)
-
 			checker.VotingHole = VotingYES
 
 			return
@@ -322,16 +336,16 @@ func TestNodeRunnerConsensusSameSourceWillNotIgnored(t *testing.T) {
 	}
 
 	wg = sync.WaitGroup{}
-	wg.Add(3)
+	wg.Add(numberOfNodes)
 	client.SendMessage(secondTx)
 	wg.Wait()
 
-	if len(lastVotingStateStaging) != 3 {
+	if len(dones) != numberOfNodes {
 		t.Error("failed to get consensus")
 		return
 	}
 
-	for _, vs := range lastVotingStateStaging {
+	for _, vs := range dones {
 		if !vs.IsClosed() {
 			t.Error("failed to close consensus")
 			return

--- a/lib/node_runner_isaac_test.go
+++ b/lib/node_runner_isaac_test.go
@@ -311,7 +311,6 @@ func TestNodeRunnerConsensusSameSourceWillNotIgnored(t *testing.T) {
 		finished = append(finished, checker.LocalNode.Alias())
 		dones = append(dones, checker.VotingStateStaging)
 		wg.Done()
-
 	}
 
 	var secondHandleBallotCheckerFuncs = []sebakcommon.CheckerFunc{

--- a/lib/node_runner_memory_network_test.go
+++ b/lib/node_runner_memory_network_test.go
@@ -148,7 +148,6 @@ func createNodeRunnersWithReady(n int) []*NodeRunner {
 
 	for _, nr := range nodeRunners {
 		go nr.Start()
-		//defer nr.Stop()
 	}
 
 	T := time.NewTicker(100 * time.Millisecond)
@@ -376,7 +375,10 @@ func TestMemoryNetworkHandleMessageCheckHasMessage(t *testing.T) {
 		},
 	}
 
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
+		mutex.Lock()
+		defer mutex.Unlock()
 		if n == 1 {
 			defer wg.Done()
 		}
@@ -446,7 +448,10 @@ func TestMemoryNetworkHandleMessageAddBallot(t *testing.T) {
 		},
 	}
 
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
+		mutex.Lock()
+		defer mutex.Unlock()
 		if n == 1 {
 			defer wg.Done()
 		}

--- a/lib/node_runner_payment_test.go
+++ b/lib/node_runner_payment_test.go
@@ -46,6 +46,7 @@ func TestNodeRunnerPayment(t *testing.T) {
 
 	var dones []VotingStateStaging
 	var finished []string
+	var mutex = &sync.Mutex{}
 	var deferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
 		if err == nil {
 			return
@@ -54,6 +55,9 @@ func TestNodeRunnerPayment(t *testing.T) {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); ok {
 			return
 		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
 
 		checker := c.(*NodeRunnerHandleBallotChecker)
 		if _, found := sebakcommon.InStringArray(finished, checker.LocalNode.Alias()); found {
@@ -129,6 +133,7 @@ func doConsensus(nodeRunners []*NodeRunner, tx Transaction) []VotingStateStaging
 
 	var dones []VotingStateStaging
 	var finished []string
+	var mutex = &sync.Mutex{}
 	var ballotDeferFunc sebakcommon.CheckerDeferFunc = func(n int, c sebakcommon.Checker, err error) {
 		if err == nil {
 			return
@@ -137,6 +142,9 @@ func doConsensus(nodeRunners []*NodeRunner, tx Transaction) []VotingStateStaging
 		if _, ok := err.(sebakcommon.CheckerErrorStop); ok {
 			return
 		}
+
+		mutex.Lock()
+		defer mutex.Unlock()
 
 		checker := c.(*NodeRunnerHandleBallotChecker)
 		if _, found := sebakcommon.InStringArray(finished, checker.LocalNode.Alias()); found {


### PR DESCRIPTION
### Github Issue
<!--
    Add the github issue number if exists(ex. Fixes #1, Closes #1 or Resolves #1).
-->
Resolves #163 

### Background
<!--
    Explain why this pull request was created.
-->
"negative WaitGroup counter" error occurs because multiple goroutines that is more than nodes enter CheckerDeferFunc simultaneously

### Solution
<!-- 
    Explain how you solved this problem.
-->
add locking object