### PR TITLE
Do not reconnect every second after the initial connection

### DIFF
--- a/lib/common/http2_client.go
+++ b/lib/common/http2_client.go
@@ -28,8 +28,8 @@ func NewHTTP2Client(timeout, idleTimeout time.Duration, keepAlive bool) (client 
 		IdleConnTimeout:   idleTimeout,
 		DisableKeepAlives: !keepAlive,
 		DialContext: (&net.Dialer{
-			Timeout:   1 * time.Second,
-			KeepAlive: 100000 * time.Second,
+			Timeout:   3 * time.Second,
+			KeepAlive: 1 * time.Second,
 			DualStack: true,
 		}).DialContext,
 	}

--- a/lib/network/http2_config.go
+++ b/lib/network/http2_config.go
@@ -28,7 +28,6 @@ func NewHTTP2NetworkConfigFromEndpoint(nodeName string, endpoint *common.Endpoin
 	var ReadTimeout time.Duration = 0
 	var ReadHeaderTimeout time.Duration = 0
 	var WriteTimeout time.Duration = 0
-	var IdleTimeout time.Duration = 5
 	var TLSCertFile, TLSKeyFile string
 
 	if ReadTimeout, err = time.ParseDuration(common.GetUrlQuery(query, "ReadTimeout", "0s")); err != nil {
@@ -55,14 +54,6 @@ func NewHTTP2NetworkConfigFromEndpoint(nodeName string, endpoint *common.Endpoin
 		return
 	}
 
-	if IdleTimeout, err = time.ParseDuration(common.GetUrlQuery(query, "IdleTimeout", "0s")); err != nil {
-		return
-	}
-	if IdleTimeout < 0*time.Second {
-		err = errors.New("invalid 'IdleTimeout'")
-		return
-	}
-
 	TLSCertFile = query.Get("TLSCertFile")
 	TLSKeyFile = query.Get("TLSKeyFile")
 
@@ -78,7 +69,7 @@ func NewHTTP2NetworkConfigFromEndpoint(nodeName string, endpoint *common.Endpoin
 		ReadTimeout:       ReadTimeout,
 		ReadHeaderTimeout: ReadHeaderTimeout,
 		WriteTimeout:      WriteTimeout,
-		IdleTimeout:       IdleTimeout,
+		IdleTimeout:       0,
 		TLSCertFile:       TLSCertFile,
 		TLSKeyFile:        TLSKeyFile,
 	}


### PR DESCRIPTION
```
Once we are connected to a node, stop sending `/connect` messages.
By setting an `idleTimeout` of `0` and `keepAlive` to `true`
we ensure that the connection is never closed.
We're still suffering from bugs when a node comes back up,
but since Sebak does not currently support it,
it isn't a problem.
```