### PR TITLE
contract deploy/execute operation

### DIFF
--- a/lib/contract/deployer.go
+++ b/lib/contract/deployer.go
@@ -3,18 +3,19 @@ package contract
 import (
 	"boscoin.io/sebak/lib/contract/context"
 	"boscoin.io/sebak/lib/contract/jsvm"
+	"boscoin.io/sebak/lib/contract/payload"
 )
 
 type Deployer interface {
 	Deploy(code []byte) error
 }
 
-func NewDeployer(ctx *context.Context, codeType string) Deployer {
+func NewDeployer(ctx *context.Context, codeType payload.CodeType) Deployer {
 
 	var de Deployer
 
 	switch codeType {
-	case "otto":
+	case payload.JavaScript:
 		de = jsvm.NewDeployer(ctx)
 	default:
 		panic("not yet supported")
@@ -23,7 +24,7 @@ func NewDeployer(ctx *context.Context, codeType string) Deployer {
 
 }
 
-func Deploy(ctx *context.Context, codeType string, code []byte) (err error) {
+func Deploy(ctx *context.Context, codeType payload.CodeType, code []byte) (err error) {
 	deployer := NewDeployer(ctx, codeType)
 	err = deployer.Deploy(code)
 	return

--- a/lib/contract/payload/deploy.go
+++ b/lib/contract/payload/deploy.go
@@ -6,6 +6,7 @@ const (
 	Native CodeType = iota
 	JavaScript
 	WASM
+	NONE
 )
 
 type DeployCode struct {

--- a/lib/operation_contract_deploy.go
+++ b/lib/operation_contract_deploy.go
@@ -1,0 +1,103 @@
+package sebak
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/stellar/go/keypair"
+
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/contract/payload"
+	"boscoin.io/sebak/lib/contract/context"
+	"boscoin.io/sebak/lib/store/statestore"
+	"boscoin.io/sebak/lib/contract"
+)
+
+type OperationBodyContractDeploy struct {
+	Target string `json:"target"`
+	Amount Amount `json:"amount"`
+	CodeType int `json:"codeType"`
+	Code   string `json:"code"`
+}
+
+func NewOperationBodyContractDeploy(target string, amount Amount, codeType int, code string) OperationBodyContractDeploy {
+	return OperationBodyContractDeploy{
+		Target: target,
+		Amount: amount,
+		CodeType: codeType,
+		Code: code,
+	}
+}
+
+func (o OperationBodyContractDeploy) Serialize() (encoded []byte, err error) {
+	encoded, err = json.Marshal(o)
+	return
+}
+
+func (o OperationBodyContractDeploy) IsWellFormed([]byte) (err error) {
+	if _, err = keypair.Parse(o.Target); err != nil {
+		return
+	}
+
+	if int64(o.Amount) < 1 {
+		err = fmt.Errorf("invalid `Amount`")
+		return
+	}
+
+	if len(o.Code) == 0 {
+		err = fmt.Errorf("invalid `Code`")
+	}
+
+	return
+}
+
+func (o OperationBodyContractDeploy) Validate(st sebakstorage.LevelDBBackend) (err error) {
+	return
+}
+
+func (o OperationBodyContractDeploy) TargetAddress() string {
+	return o.Target
+}
+
+func (o OperationBodyContractDeploy) GetAmount() Amount {
+	return o.Amount
+}
+
+func (o OperationBodyContractDeploy) Do(st *sebakstorage.LevelDBBackend, tx Transaction) (err error) {
+	var baSource *BlockAccount
+	if baSource, err = GetBlockAccount(st, tx.B.Source); err != nil {
+		err = sebakerror.ErrorBlockAccountDoesNotExists
+		return
+	}
+	stateStore := statestore.NewStateStore(st)
+	stateClone := statestore.NewStateClone(stateStore)
+	ctx := &context.Context{
+		SenderAccount: baSource,
+		StateStore:    stateStore,
+		StateClone:    stateClone,
+	}
+
+
+	err = contract.Deploy(ctx, payload.CodeType(o.CodeType), []byte(o.Code)) //TODO: Where to pass the return value?
+	return
+}
+
+func FinishOperationBodyContractDeploy (st *sebakstorage.LevelDBBackend, tx Transaction, op Operation) (err error) {
+	var baSource *BlockAccount
+	if baSource, err = GetBlockAccount(st, tx.B.Source); err != nil {
+		err = sebakerror.ErrorBlockAccountDoesNotExists
+		return
+	}
+	stateStore := statestore.NewStateStore(st)
+	stateClone := statestore.NewStateClone(stateStore)
+	ctx := &context.Context{
+		SenderAccount: baSource,
+		StateStore:    stateStore,
+		StateClone:    stateClone,
+	}
+
+
+	err = contract.Deploy(ctx, payload.CodeType(op.B.(OperationBodyContractDeploy).CodeType), []byte(op.B.(OperationBodyContractDeploy).Code)) //TODO: Where to pass the return value?
+	return
+}

--- a/lib/operation_contract_execute.go
+++ b/lib/operation_contract_execute.go
@@ -1,0 +1,121 @@
+package sebak
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/stellar/go/keypair"
+
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/contract/payload"
+	"boscoin.io/sebak/lib/contract/context"
+	"boscoin.io/sebak/lib/store/statestore"
+	"boscoin.io/sebak/lib/contract"
+)
+
+type OperationBodyContractExecute struct {
+	Target string `json:"target"`
+	Amount Amount `json:"amount"`
+	Method string `json:"method"`
+	Args   []string `json:"args"`
+}
+
+func NewOperationBodyContractExecute(target string, amount Amount, method string, args []string) OperationBodyContractExecute {
+	return OperationBodyContractExecute{
+		Target: target,
+		Amount: amount,
+		Method: method,
+		Args: args,
+	}
+}
+
+func (o OperationBodyContractExecute) Serialize() (encoded []byte, err error) {
+	encoded, err = json.Marshal(o)
+	return
+}
+
+func (o OperationBodyContractExecute) IsWellFormed([]byte) (err error) {
+	if _, err = keypair.Parse(o.Target); err != nil {
+		return
+	}
+
+	if int64(o.Amount) < 1 {
+		err = fmt.Errorf("invalid `Amount`")
+		return
+	}
+
+	if len(o.Method) == 0 {
+		err = fmt.Errorf("invalid `Method`")
+	}
+
+	return
+}
+
+func (o OperationBodyContractExecute) Validate(st sebakstorage.LevelDBBackend) (err error) {
+	return
+}
+
+func (o OperationBodyContractExecute) TargetAddress() string {
+	return o.Target
+}
+
+func (o OperationBodyContractExecute) GetAmount() Amount {
+	return o.Amount
+}
+
+func (o OperationBodyContractExecute) Do(st *sebakstorage.LevelDBBackend, tx Transaction) (err error) {
+	var baSource, baTarget *BlockAccount
+	if baSource, err = GetBlockAccount(st, tx.B.Source); err != nil {
+		err = sebakerror.ErrorBlockAccountDoesNotExists
+		return
+	}
+	if baTarget, err = GetBlockAccount(st, o.TargetAddress()); err != nil {
+		err = sebakerror.ErrorBlockAccountDoesNotExists
+		return
+	}
+	stateStore := statestore.NewStateStore(st)
+	stateClone := statestore.NewStateClone(stateStore)
+	ctx := &context.Context{
+		SenderAccount: baSource,
+		StateStore:    stateStore,
+		StateClone:    stateClone,
+	}
+
+	exCode := &payload.ExecCode{
+		ContractAddress: baTarget.Address,
+		Method:          o.Method,
+		Args:            o.Args,
+	}
+
+	_, err = contract.Execute(ctx, exCode) //TODO: Where to pass the return value?
+	return
+}
+
+func FinishOperationBodyContractExecute (st *sebakstorage.LevelDBBackend, tx Transaction, op Operation) (err error) {
+	var baSource, baTarget *BlockAccount
+	if baSource, err = GetBlockAccount(st, tx.B.Source); err != nil {
+		err = sebakerror.ErrorBlockAccountDoesNotExists
+		return
+	}
+	if baTarget, err = GetBlockAccount(st, op.B.TargetAddress()); err != nil {
+		err = sebakerror.ErrorBlockAccountDoesNotExists
+		return
+	}
+	stateStore := statestore.NewStateStore(st)
+	stateClone := statestore.NewStateClone(stateStore)
+	ctx := &context.Context{
+		SenderAccount: baSource,
+		StateStore:    stateStore,
+		StateClone:    stateClone,
+	}
+
+	exCode := &payload.ExecCode{
+		ContractAddress: baTarget.Address,
+		Method:          op.B.(OperationBodyContractExecute).Method,
+		Args:            op.B.(OperationBodyContractExecute).Args,
+	}
+
+	_, err = contract.Execute(ctx, exCode) //TODO: Where to pass the return value?
+	return
+}

--- a/lib/operation_create_account.go
+++ b/lib/operation_create_account.go
@@ -47,6 +47,10 @@ func (o OperationBodyCreateAccount) TargetAddress() string {
 func (o OperationBodyCreateAccount) GetAmount() Amount {
 	return o.Amount
 }
+func (o OperationBodyCreateAccount) Do(st *sebakstorage.LevelDBBackend, tx Transaction) (err error) {
+	//TODO change FinishOperationCreateAccount to this
+	return
+}
 
 func FinishOperationCreateAccount(st *sebakstorage.LevelDBBackend, tx Transaction, op Operation) (err error) {
 	var baSource, baTarget *BlockAccount

--- a/lib/operation_payment.go
+++ b/lib/operation_payment.go
@@ -55,6 +55,11 @@ func (o OperationBodyPayment) GetAmount() Amount {
 	return o.Amount
 }
 
+func (o OperationBodyPayment) Do(st *sebakstorage.LevelDBBackend, tx Transaction) (err error) {
+	//TODO change FinishOperationPayment to this
+	return
+}
+
 func FinishOperationPayment(st *sebakstorage.LevelDBBackend, tx Transaction, op Operation) (err error) {
 	var baSource, baTarget *BlockAccount
 	if baSource, err = GetBlockAccount(st, tx.B.Source); err != nil {


### PR DESCRIPTION
New operation deploy/execute for contract 

When I write this features, I realize that we need more implementation for this.
- StateStore layer
- A passage for contract executor(like a wallet) to get the result of the execution

Additionally, I want to refactor FinishXXX as `Do` function.

