### PR TITLE
Cleanup some checkpoint-related code

### DIFF
--- a/lib/block_account.go
+++ b/lib/block_account.go
@@ -66,7 +66,11 @@ func (b *BlockAccount) Save(st *sebakstorage.LevelDBBackend) (err error) {
 		observer.BlockAccountObserver.Trigger(event, b)
 	}
 
-	bac := NewBlockAccountCheckpoint(b, b.Checkpoint)
+	bac := BlockAccountCheckpoint{
+		Checkpoint: b.Checkpoint,
+		Address:    b.Address,
+		Balance:    b.Balance,
+	}
 	err = bac.Save(st)
 
 	return
@@ -180,14 +184,6 @@ type BlockAccountCheckpoint struct {
 	Checkpoint string
 	Address    string
 	Balance    string
-}
-
-func NewBlockAccountCheckpoint(ba *BlockAccount, checkpoint string) BlockAccountCheckpoint {
-	return BlockAccountCheckpoint{
-		Checkpoint: checkpoint,
-		Address:    ba.Address,
-		Balance:    ba.Balance,
-	}
 }
 
 func GetBlockAccountCheckpointKey(address, checkpoint string) string {

--- a/lib/network/connection_manager.go
+++ b/lib/network/connection_manager.go
@@ -113,8 +113,6 @@ func (c *ConnectionManager) connectValidators() {
 	for _, v := range c.validators {
 		go c.connectingValidator(v)
 	}
-
-	select {}
 }
 
 func (c *ConnectionManager) connectingValidator(v *sebaknode.Validator) {

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -245,13 +245,12 @@ func (nr *NodeRunner) handleMessage() {
 			nr.log.Debug("got ballot", "message", message.Head(50))
 
 			checker := &NodeRunnerHandleBallotChecker{
-				GenesisBlockCheckpoint: sebakcommon.MakeGenesisCheckpoint(nr.networkID),
-				DefaultChecker:         sebakcommon.DefaultChecker{nr.handleBallotCheckerFuncs},
-				NodeRunner:             nr,
-				LocalNode:              nr.localNode,
-				NetworkID:              nr.networkID,
-				Message:                message,
-				VotingHole:             VotingNOTYET,
+				DefaultChecker: sebakcommon.DefaultChecker{nr.handleBallotCheckerFuncs},
+				NodeRunner:     nr,
+				LocalNode:      nr.localNode,
+				NetworkID:      nr.networkID,
+				Message:        message,
+				VotingHole:     VotingNOTYET,
 			}
 			if err = sebakcommon.RunChecker(checker, nr.handleBallotCheckerDeferFunc); err != nil {
 				if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {

--- a/lib/node_runner_checker.go
+++ b/lib/node_runner_checker.go
@@ -99,16 +99,15 @@ func CheckNodeRunnerHandleMessageBroadcast(c sebakcommon.Checker, args ...interf
 type NodeRunnerHandleBallotChecker struct {
 	sebakcommon.DefaultChecker
 
-	GenesisBlockCheckpoint string
-	NodeRunner             *NodeRunner
-	LocalNode              *sebaknode.LocalNode
-	NetworkID              []byte
-	Message                sebaknetwork.Message
-	Ballot                 Ballot
-	IsNew                  bool
-	VotingStateStaging     VotingStateStaging
-	VotingHole             VotingHole
-	WillBroadcast          bool
+	NodeRunner         *NodeRunner
+	LocalNode          *sebaknode.LocalNode
+	NetworkID          []byte
+	Message            sebaknetwork.Message
+	Ballot             Ballot
+	IsNew              bool
+	VotingStateStaging VotingStateStaging
+	VotingHole         VotingHole
+	WillBroadcast      bool
 }
 
 func (c *NodeRunnerHandleBallotChecker) GetTransaction() (tx Transaction) {

--- a/lib/test.go
+++ b/lib/test.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/btcsuite/btcutil/base58"
+	"boscoin.io/sebak/lib/common"
+
 	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
-
-	"boscoin.io/sebak/lib/common"
 )
 
 func testMakeBlockAccount() *BlockAccount {
@@ -98,7 +97,7 @@ func TestMakeTransaction(networkID []byte, n int) (kp *keypair.Full, tx Transact
 }
 
 func TestGenerateNewCheckpoint() string {
-	return base58.Encode([]byte(uuid.New().String()))
+	return uuid.New().String()
 }
 
 func TestMakeTransactionWithKeypair(networkID []byte, n int, srcKp *keypair.Full, targetKps ...*keypair.Full) (tx Transaction) {


### PR DESCRIPTION
Since I started to work on replacing checkpoints (again) this iteration, I stumbled upon a few places where they were not necessary, and they are good first place to act on.
I also included a mini commit which removes a needless (AFAICS, maybe there's something I'm not seeing @spikeekips ?) `select {}`

Best reviewed commit-by-commit.