### PR TITLE
Add statedb in storage pkg

### DIFF
--- a/lib/storage/dbbackend.go
+++ b/lib/storage/dbbackend.go
@@ -1,0 +1,17 @@
+package sebakstorage
+
+type DBBackend interface {
+	Has(string) (bool, error)
+	Get(string, interface{}) error
+	New(string, interface{}) error
+	Set(string, interface{}) error
+	Remove(string) error
+
+	GetIterator(prefix string, reverse bool) (func() (IterItem, bool), func())
+
+	News(...Item) error
+	Sets(...Item) error
+
+	Commit() error
+	Discard() error
+}

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -200,6 +200,21 @@ func (st *LevelDBBackend) Set(k string, v interface{}) (err error) {
 	return
 }
 
+func (st *LevelDBBackend) put(k string, v interface{}) (err error) {
+	var encoded []byte
+	serializable, ok := v.(sebakcommon.Serializable)
+	if ok {
+		encoded, err = serializable.Serialize()
+	} else {
+		encoded, err = sebakcommon.EncodeJSONValue(v)
+	}
+	if err != nil {
+		return
+	}
+	err = st.core.Put(st.makeKey(k), encoded, nil)
+	return
+}
+
 func (st *LevelDBBackend) Sets(vs ...Item) (err error) {
 	if len(vs) < 1 {
 		err = errors.New("empty values")

--- a/lib/storage/statedb.go
+++ b/lib/storage/statedb.go
@@ -4,6 +4,8 @@ import (
 	"sort"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+
 	"github.com/btcsuite/btcutil/base58"
 )
 
@@ -83,7 +85,9 @@ func (s *StateDB) MakeHash() ([]byte, error) {
 	hashes := make([][]byte, 0, len(ks))
 	for _, k := range ks {
 		bs, err := s.levelDB.GetRaw(k)
-		if err != nil {
+		if err == sebakerror.ErrorStorageRecordDoesNotExist {
+			bs = nil
+		} else if err != nil {
 			return nil, err
 		}
 		h := sebakcommon.MakeHash(bs)

--- a/lib/storage/statedb.go
+++ b/lib/storage/statedb.go
@@ -1,0 +1,110 @@
+package sebakstorage
+
+import (
+	"sort"
+
+	"boscoin.io/sebak/lib/common"
+	"github.com/btcsuite/btcutil/base58"
+)
+
+type StateDB struct {
+	levelDB     *LevelDBBackend
+	changedkeys map[string]bool
+}
+
+func NewStateDB(st *LevelDBBackend) *StateDB {
+	db := &StateDB{
+		levelDB: st,
+		// If we need thread safety, we should use sync.Map insteads map
+		changedkeys: make(map[string]bool),
+	}
+	return db
+}
+
+func (s *StateDB) Has(k string) (bool, error) {
+	return s.levelDB.Has(k)
+}
+
+func (s *StateDB) Get(k string, i interface{}) error {
+	return s.levelDB.Get(k, i)
+}
+
+func (s *StateDB) New(k string, i interface{}) error {
+	s.changedkeys[k] = true
+	return s.levelDB.New(k, i)
+}
+
+func (s *StateDB) Set(k string, i interface{}) error {
+	s.changedkeys[k] = true
+	return s.levelDB.Set(k, i)
+}
+
+func (s *StateDB) Remove(k string) error {
+	s.changedkeys[k] = true
+	return s.levelDB.Remove(k)
+}
+
+func (s *StateDB) GetIterator(prefix string, reverse bool) (func() (IterItem, bool), func()) {
+	return s.levelDB.GetIterator(prefix, reverse)
+}
+
+func (s *StateDB) News(vs ...Item) error {
+	for _, v := range vs {
+		s.changedkeys[v.Key] = true
+	}
+
+	return s.levelDB.News(vs...)
+}
+
+func (s *StateDB) Sets(vs ...Item) error {
+	for _, v := range vs {
+		s.changedkeys[v.Key] = true
+	}
+
+	return s.levelDB.Sets(vs...)
+}
+
+func (s *StateDB) Commit() error {
+	return s.levelDB.Commit()
+}
+
+func (s *StateDB) Discard() error {
+	return s.levelDB.Discard()
+}
+
+func (s *StateDB) MakeHash() ([]byte, error) {
+	ks := make([]string, 0, len(s.changedkeys))
+
+	for k, v := range s.changedkeys {
+		if !v {
+			continue
+		}
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+
+	hashes := make([][]byte, 0, len(ks))
+	for _, k := range ks {
+		bs, err := s.levelDB.GetRaw(k)
+		if err != nil {
+			return nil, err
+		}
+		h := sebakcommon.MakeHash(bs)
+		hashes = append(hashes, h)
+	}
+
+	h, err := sebakcommon.MakeObjectHash(hashes)
+	if err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+func (s *StateDB) MakeHashString() (string, error) {
+	h, err := s.MakeHash()
+	if err != nil {
+		return "", err
+	}
+
+	return base58.Encode(h), nil
+}

--- a/lib/storage/statedb_test.go
+++ b/lib/storage/statedb_test.go
@@ -38,10 +38,16 @@ func TestStateDBNewCommit(t *testing.T) {
 
 	a := &Account{"address"}
 
-	sdb.New("a1", a)
+	if err := sdb.New("b1", a); err != nil {
+		t.Fatal(err)
+	}
 
-	if len(sdb.changedkeys) != 1 {
-		t.Fatal("statedb.changedkeys != 1")
+	if err := sdb.New("a1", a); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sdb.changedkeys) != 2 {
+		t.Fatal("statedb.changedkeys != 2")
 	}
 
 	hash, err := sdb.MakeHashString()
@@ -49,12 +55,14 @@ func TestStateDBNewCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	if hash == "" {
-		t.Fatal("hash == ''")
+		t.Error("hash == ''")
 	}
 
 	a.Address = "changed_address"
 
-	sdb.Set("a1", a)
+	if err := sdb.Set("a1", a); err != nil {
+		t.Fatal(err)
+	}
 
 	hash2, err := sdb.MakeHashString()
 	if err != nil {
@@ -70,6 +78,16 @@ func TestStateDBNewCommit(t *testing.T) {
 		t.Fatal(err)
 	} else if ok {
 		t.Fatal("a1 exists in db!")
+	}
+
+	if err := sdb.Remove("b1"); err != nil {
+		t.Fatal(err)
+	}
+
+	if hash3, err := sdb.MakeHashString(); err != nil {
+		t.Fatal(err)
+	} else if hash == hash3 {
+		t.Error("hash == hash3")
 	}
 
 	if err := sdb.Commit(); err != nil {
@@ -90,9 +108,8 @@ func TestStateDBNewCommit(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		t.Logf("a1.Addr:%v", a1.Address)
-
 		if a1.Address != a.Address {
+			t.Logf("a1.Addr:%v", a1.Address)
 			t.Error("a1.Address != a.Address")
 		}
 	}

--- a/lib/storage/statedb_test.go
+++ b/lib/storage/statedb_test.go
@@ -1,0 +1,99 @@
+package sebakstorage
+
+import (
+	"testing"
+)
+
+func newTestStateDB(t *testing.T) (*LevelDBBackend, *LevelDBBackend, *StateDB) {
+	st, err := NewTestMemoryLevelDBBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts, err := st.OpenTransaction()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sdb := NewStateDB(ts)
+
+	return st, ts, sdb
+}
+
+func TestStateDBInterface(t *testing.T) {
+	var sdb DBBackend
+	_, _, sdb = newTestStateDB(t)
+	if _, err := sdb.Has("hello"); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestStateDBNewCommit(t *testing.T) {
+
+	st, _, sdb := newTestStateDB(t)
+	defer st.Close()
+
+	type Account struct {
+		Address string
+	}
+
+	a := &Account{"address"}
+
+	sdb.New("a1", a)
+
+	if len(sdb.changedkeys) != 1 {
+		t.Fatal("statedb.changedkeys != 1")
+	}
+
+	hash, err := sdb.MakeHashString()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hash == "" {
+		t.Fatal("hash == ''")
+	}
+
+	a.Address = "changed_address"
+
+	sdb.Set("a1", a)
+
+	hash2, err := sdb.MakeHashString()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if hash == hash2 {
+		t.Logf("hash:%v hash2:%v", hash, hash2)
+		t.Error("hash == hash2")
+	}
+
+	if ok, err := st.Has("a1"); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatal("a1 exists in db!")
+	}
+
+	if err := sdb.Commit(); err != nil {
+		t.Fatal(err)
+	}
+
+	if ok, err := st.Has("a1"); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatal("a1 is nil in db after commit!")
+	}
+
+	{
+		var (
+			a1 *Account
+		)
+		if err := st.Get("a1", &a1); err != nil {
+			t.Fatal(err)
+		}
+
+		t.Logf("a1.Addr:%v", a1.Address)
+
+		if a1.Address != a.Address {
+			t.Error("a1.Address != a.Address")
+		}
+	}
+}


### PR DESCRIPTION
### Github Issue
- related: #224 #225 

### Background

- To `*LevelDBBackend` compatibility, The `StateDB`  is implemented by `DBBackend` interface.

```
type DBBackend interface {
	Has(string) (bool, error)
	Get(string, interface{}) error
	New(string, interface{}) error
	Set(string, interface{}) error
	Remove(string) error

	GetIterator(prefix string, reverse bool) (func() (IterItem, bool), func())

	News(...Item) error
	Sets(...Item) error

	Commit() error
	Discard() error
}
```


### Solution

- `StateDB` just keeps  `changedKeys` from  `Set` and `New` methods to make a hash for simple `stateRoot` for contract. 
- Another operations just pass to inner `*LevelDBBackend` in `StateDB`
- `*LevelDBBackend` added `put` method for using the `StateDB`.  This method is not public. so It just uses in `sebakstroage`. 

### Possible Drawbacks

- The interface can be changed by another need of using methods of `LevelDBBackend`. 
- Try to work together `FinishTransaction` and `FinshBallot` too. :-)



