### PR TITLE
Integration Tests: Use retry and sleep for balance check

### DIFF
--- a/tests/account-creation/request_1_2821_create_account_1.json.check
+++ b/tests/account-creation/request_1_2821_create_account_1.json.check
@@ -4,18 +4,17 @@ set -xe
 export TEST_NAME=${BASH_SOURCE[0]}
 source $(dirname ${BASH_SOURCE[0]})/../utils.sh
 
-sleep 5
-
 EXPECTED1="9999999989999990000"
 EXPECTED2="10000000000"
 
 for ((port=2821;port<=2823;port++)); do
-    BA1=$(getAccount $port "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ" | jq ".Balance" | sed 's/"//g')
-    if [ -z ${BA1} ] || [ ${BA1} != ${EXPECTED1} ]; then
-        die "Expected balance to be ${EXPECTED1}, not ${BA1}"
+    checkedBalance=$(getAccountWithBalance $port "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ" ${EXPECTED1})
+    if [ $? -ne 0 ];then
+        die "Expected balance to be ${EXPECTED1}, not ${checkedBalance}"
     fi
-    BA2=$(getAccount $port "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4" | jq ".Balance" | sed 's/"//g')
-    if [ -z ${BA2} ] || [ ${BA2} != ${EXPECTED2} ]; then
-        die "Expected balance to be ${EXPECTED2}, not ${BA2}"
+
+    checkedBalance=$(getAccountWithBalance $port "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4" ${EXPECTED2})
+    if [ $? -ne 0 ];then
+        die "Expected balance to be ${EXPECTED2}, not ${checkedBalance}"
     fi
 done

--- a/tests/account-creation/request_2_2822_pay_to_account_1.json.check
+++ b/tests/account-creation/request_2_2822_pay_to_account_1.json.check
@@ -4,18 +4,17 @@ set -xe
 export TEST_NAME=${BASH_SOURCE[0]}
 source $(dirname ${BASH_SOURCE[0]})/../utils.sh
 
-sleep 5
-
 EXPECTED1="9999999979999980000"
 EXPECTED2="20000000000"
 
 for ((port=2821;port<=2823;port++)); do
-    BA1=$(getAccount $port "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ" | jq ".Balance" | sed 's/"//g')
-    if [ -z ${BA1} ] || [ ${BA1} != ${EXPECTED1} ]; then
-        die "Expected balance to be ${EXPECTED1}, not ${BA1}"
+    checkedBalance=$(getAccountWithBalance $port "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ" ${EXPECTED1})
+    if [ $? -ne 0 ]; then
+        die "Expected balance to be ${EXPECTED1}, not ${checkedBalance}"
     fi
-    BA2=$(getAccount $port "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4" | jq ".Balance" | sed 's/"//g')
-    if [ -z ${BA2} ] || [ ${BA2} != ${EXPECTED2} ]; then
-        die "Expected balance to be ${EXPECTED2}, not ${BA2}"
+
+    checkedBalance=$(getAccountWithBalance $port "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4" ${EXPECTED2})
+    if [ $? -ne 0 ]; then
+        die "Expected balance to be ${EXPECTED2}, not ${checkedBalance}"
     fi
 done

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -29,11 +29,7 @@ function getAccountWithBalance () # u16 port, string addr and expected balance
     balance=0
     for i in $(seq 30)
     do
-	    balance=$(curl --insecure \
-                  --request GET \
-                  --header "Accept: application/json" \
-                  https://127.0.0.1:${1}/api/account/${2} \
-                  2>/dev/null | jq ".Balance" | sed 's/"//g')
+	    balance=$(getAccount $1 $2 | jq ".Balance" | sed 's/"//g')
 	    if [ "$balance" == "$3" ];then
 		    return 0
 	    fi

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -19,3 +19,28 @@ function getAccount () # u16 port, string addr
                   https://127.0.0.1:${1}/api/account/${2} \
                   2>/dev/null)
 }
+
+function getAccountWithBalance () # u16 port, string addr and expected balance
+{
+    if [ $# -ne 3 ]; then
+        die "3 arguments expected for getAccountWithBalance, not $#"
+    fi
+
+    balance=0
+    for i in $(seq 30)
+    do
+	    balance=$(curl --insecure \
+                  --request GET \
+                  --header "Accept: application/json" \
+                  https://127.0.0.1:${1}/api/account/${2} \
+                  2>/dev/null | jq ".Balance" | sed 's/"//g')
+	    if [ "$balance" == "$3" ];then
+		    return 0
+	    fi
+	    sleep 0.3
+    done
+
+    echo $balance
+
+    return 1
+}


### PR DESCRIPTION
### Background

Recent PRs was failed to pass the integration test. It was caused that it does take more time as we expected(5 seconds) to finish the consensus of testing transaction.

> Don't complain this PR's name :)

### Solution
At first I increased the sleep time to 10 seconds and everything was good, but the matter was we can not convince the exact(or maximum) elapsed time to finish one transaction. This PR does not guess the maximum elapsed time, just checking the latest account information up to almost 10 seconds.