### PR TITLE
Jsvm api callcontract api wrapper 

### DIFF
--- a/lib/contract/jsvm/api_wrapper.go
+++ b/lib/contract/jsvm/api_wrapper.go
@@ -2,10 +2,11 @@ package jsvm
 
 import (
 	"boscoin.io/sebak/lib/contract/api"
+	"boscoin.io/sebak/lib/contract/payload"
 	"github.com/robertkrimen/otto"
 )
 
-func HelloWorldFunc(api api.API) func(call otto.FunctionCall) otto.Value {
+func HelloWorldFunc(api api.API) func(otto.FunctionCall) otto.Value {
 	return func(call otto.FunctionCall) otto.Value {
 		greeting, err := call.Argument(0).ToString()
 		if err != nil {
@@ -21,5 +22,46 @@ func HelloWorldFunc(api api.API) func(call otto.FunctionCall) otto.Value {
 			panic(err)
 		}
 		return retValue
+	}
+}
+
+func CallContractFunc(api api.API) func(otto.FunctionCall) otto.Value {
+	return func(call otto.FunctionCall) otto.Value {
+		address, err := call.Argument(0).ToString()
+		if err != nil {
+			panic(err)
+		}
+		method, err := call.Argument(1).ToString()
+		if err != nil {
+			panic(err)
+		}
+
+		var args []string
+		for _, a := range call.ArgumentList[1:] {
+			arg, err := a.ToString()
+			if err != nil {
+				panic(err)
+			}
+
+			args = append(args, arg) // TODO:
+		}
+
+		execCode := &payload.ExecCode{
+			ContractAddress: address,
+			Method:          method,
+			Args:            args,
+		}
+
+		retCode, err := api.CallContract(execCode)
+		if err != nil {
+			panic(err)
+		}
+
+		ret, err := otto.ToValue(string(retCode.Contents)) //TODO: It is a better if value.Value.Contents is `interface{}` ?
+		if err != nil {
+			panic(err)
+		}
+
+		return ret
 	}
 }

--- a/lib/contract/jsvm/api_wrapper_test.go
+++ b/lib/contract/jsvm/api_wrapper_test.go
@@ -1,0 +1,55 @@
+package jsvm
+
+import (
+	"testing"
+
+	"boscoin.io/sebak/lib/contract/context"
+	"boscoin.io/sebak/lib/contract/payload"
+	"boscoin.io/sebak/lib/contract/test"
+	"boscoin.io/sebak/lib/contract/value"
+)
+
+func TestJSVMCallContract(t *testing.T) {
+	testAddress := "testadress"
+
+	ctx := test.NewMockContext(testAddress, nil)
+	api := test.NewMockAPI(ctx, testAddress)
+
+	callc := func(ctx context.Context, execCode *payload.ExecCode) (*value.Value, error) {
+		if execCode.ContractAddress != "helloworld" {
+			t.Fatalf("execCode.ContractAddress have:%v want:%v", execCode.ContractAddress, "helloworld")
+		}
+
+		ret := &value.Value{
+			Type:     value.String,
+			Contents: []byte("world!"),
+		}
+		return ret, nil
+	}
+
+	api.SetCallContractFunc(callc)
+
+	code := `
+function HelloContract() {
+	ret = CallContract("helloworld","hello","world")
+	return ret
+}
+`
+	deployCode := &payload.DeployCode{
+		ContractAddress: testAddress,
+		Code:            []byte(code),
+		Type:            payload.JavaScript,
+	}
+	ex := NewOttoExecutor(ctx, api, deployCode)
+	excode := &payload.ExecCode{
+		ContractAddress: testAddress,
+		Method:          "HelloContract",
+	}
+	ret, err := ex.Execute(excode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ret == nil {
+		t.Fatal("ret is nil")
+	}
+}

--- a/lib/contract/jsvm/executor.go
+++ b/lib/contract/jsvm/executor.go
@@ -72,6 +72,7 @@ func (ex *OttoExecutor) Execute(c *payload.ExecCode) (retCode *value.Value, err 
 
 func (ex *OttoExecutor) RegisterFuncs() {
 	ex.VM.Set("HelloWorld", HelloWorldFunc(ex.api))
+	ex.VM.Set("CallContract", CallContractFunc(ex.api))
 }
 
 func contains(slice []string, item string) bool {

--- a/lib/contract/jsvm/executor_test.go
+++ b/lib/contract/jsvm/executor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_JSVM_Executor(t *testing.T) {
+func TestJSVMExecutor(t *testing.T) {
 	testAddress := "testadress"
 	testCode := `
 function Hello(helloarg){

--- a/lib/contract/test/api.go
+++ b/lib/contract/test/api.go
@@ -64,7 +64,7 @@ func (a *MockAPI) SetPutStorageItemFunc(f PutStorageItemFunc) {
 	a.putStorageItemFunc = f
 }
 
-func (a *MockAPI) SetCallContractfunc(f CallContractFunc) {
+func (a *MockAPI) SetCallContractFunc(f CallContractFunc) {
 	a.callContractFunc = f
 }
 

--- a/lib/contract/value/value.go
+++ b/lib/contract/value/value.go
@@ -2,8 +2,9 @@ package value
 
 import (
 	"encoding/binary"
-	"github.com/robertkrimen/otto"
 	"io"
+
+	"github.com/robertkrimen/otto"
 )
 
 type Type int


### PR DESCRIPTION
### Github Issue

Related to: #222 

### Background

I am not sure the `call contract` is needed with `jsvm`.  but `CallContract` is a part of  `ContractAPI` 

```
function HelloContract() {
	ret = CallContract("helloworld","hello","world") // contract address, method, args...
	return ret
}
```


