### PR TITLE
Isaac one node test

### DIFF
--- a/lib/isaac_simulation_test.go
+++ b/lib/isaac_simulation_test.go
@@ -1,3 +1,8 @@
+/*
+	In this file, there are unittests assume that one node receive a message from validators,
+	and how the state of the node changes.
+*/
+
 package sebak
 
 import (
@@ -9,6 +14,14 @@ import (
 	"boscoin.io/sebak/lib/network"
 )
 
+/*
+TestIsaacSimulationProposer indicates the following:
+	1. Proceed for one round.
+	2. The node is the proposer of this round.
+	3. There are 5 nodes and threshold is 4.
+	3. The node receives the SIGN, ACCEPT messages in order from the other four validator nodes.
+	4. The node receives a ballot that exceeds the threshold, and the block is confirmed.
+*/
 func TestIsaacSimulationProposer(t *testing.T) {
 	nodeRunners := createTestNodeRunner(5)
 

--- a/lib/isaac_simulation_test.go
+++ b/lib/isaac_simulation_test.go
@@ -34,7 +34,7 @@ func TestIsaacSimulationProposer(t *testing.T) {
 
 	// Generate proposed ballot in nodeRunner
 	roundNumber := uint64(0)
-	err = nodeRunner.ProposeNewBallot(roundNumber)
+	err = nodeRunner.proposeNewBallot(roundNumber)
 	assert.Nil(t, err)
 	round := Round{
 		Number:      roundNumber,

--- a/lib/isaac_simulation_test.go
+++ b/lib/isaac_simulation_test.go
@@ -1,0 +1,132 @@
+package sebak
+
+import (
+	"testing"
+
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/assert"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+)
+
+func TestIsaacSimulationProposer(t *testing.T) {
+	nodeRunners := createTestNodeRunner(5)
+
+	tx, txByte := getTransaction(t)
+
+	message := sebaknetwork.Message{Type: sebaknetwork.MessageFromClient, Data: txByte}
+
+	nodeRunner := nodeRunners[0]
+
+	// `nodeRunner` is proposer's runner
+	nodeRunner.SetProposerCalculator(SelfProposerCalculator{})
+	proposer := nodeRunner.localNode
+
+	nodeRunner.Consensus().SetLatestConsensusedBlock(genesisBlock)
+
+	var err error
+	err = nodeRunner.handleMessageFromClient(message)
+
+	assert.Nil(t, err)
+	assert.True(t, nodeRunner.Consensus().TransactionPool.Has(tx.GetHash()))
+
+	// Generate proposed ballot in nodeRunner
+	roundNumber := uint64(0)
+	err = nodeRunner.ProposeNewBallot(roundNumber)
+	assert.Nil(t, err)
+	round := Round{
+		Number:      roundNumber,
+		BlockHeight: nodeRunner.Consensus().LatestConfirmedBlock.Height,
+		BlockHash:   nodeRunner.Consensus().LatestConfirmedBlock.Hash,
+		TotalTxs:    nodeRunner.Consensus().LatestConfirmedBlock.TotalTxs,
+	}
+	runningRounds := nodeRunner.Consensus().RunningRounds
+
+	// Check that the transaction is in RunningRounds
+	rr := runningRounds[round.Hash()]
+	txHashs := rr.Transactions[proposer.Address()]
+	assert.Equal(t, tx.GetHash(), txHashs[0])
+
+	ballotSIGN1 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[1].localNode)
+	err = receiveBallot(t, nodeRunner, ballotSIGN1)
+	assert.Nil(t, err)
+
+	ballotSIGN2 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[2].localNode)
+	err = receiveBallot(t, nodeRunner, ballotSIGN2)
+	assert.Nil(t, err)
+
+	ballotSIGN3 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[3].localNode)
+	err = receiveBallot(t, nodeRunner, ballotSIGN3)
+	assert.Nil(t, err)
+
+	ballotSIGN4 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[4].localNode)
+	err = receiveBallot(t, nodeRunner, ballotSIGN4)
+	assert.Nil(t, err)
+
+	assert.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateSIGN)))
+
+	ballotACCEPT1 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[1].localNode)
+	err = receiveBallot(t, nodeRunner, ballotACCEPT1)
+	assert.Nil(t, err)
+
+	ballotACCEPT2 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[2].localNode)
+	err = receiveBallot(t, nodeRunner, ballotACCEPT2)
+	assert.Nil(t, err)
+
+	ballotACCEPT3 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[3].localNode)
+	err = receiveBallot(t, nodeRunner, ballotACCEPT3)
+	assert.Nil(t, err)
+
+	ballotACCEPT4 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[4].localNode)
+	err = receiveBallot(t, nodeRunner, ballotACCEPT4)
+	assert.EqualError(t, err, "stop checker and return: ballot got consensus and will be stored")
+
+	assert.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateACCEPT)))
+
+	block := nodeRunner.Consensus().LatestConfirmedBlock
+	assert.Equal(t, proposer.Address(), block.Proposer)
+	assert.Equal(t, 1, len(block.Transactions))
+	assert.Equal(t, tx.GetHash(), block.Transactions[0])
+}
+
+func getTransaction(t *testing.T) (tx Transaction, txByte []byte) {
+	initialBalance := sebakcommon.Amount(1)
+	kpNewAccount, _ := keypair.Random()
+
+	tx = makeTransactionCreateAccount(kp, kpNewAccount.Address(), initialBalance)
+	tx.B.Checkpoint = account.Checkpoint
+	tx.Sign(kp, networkID)
+
+	var err error
+
+	txByte, err = tx.Serialize()
+	assert.Nil(t, err)
+
+	return
+}
+
+func generateBallot(t *testing.T, proposer *sebaknode.LocalNode, round Round, tx Transaction, ballotState sebakcommon.BallotState, sender *sebaknode.LocalNode) *Ballot {
+	ballot := NewBallot(proposer, round, []string{tx.GetHash()})
+	ballot.SetVote(sebakcommon.BallotStateINIT, VotingYES)
+	ballot.Sign(proposer.Keypair(), networkID)
+
+	ballot.SetSource(sender.Address())
+	ballot.SetVote(ballotState, VotingYES)
+	ballot.Sign(sender.Keypair(), networkID)
+
+	err := ballot.IsWellFormed(networkID)
+	assert.Nil(t, err)
+
+	return ballot
+}
+
+func receiveBallot(t *testing.T, nodeRunner *NodeRunner, ballot *Ballot) error {
+	data, err := ballot.Serialize()
+	assert.Nil(t, err)
+
+	ballotMessage := sebaknetwork.Message{Type: sebaknetwork.BallotMessage, Data: data}
+	err = nodeRunner.handleBallotMessage(ballotMessage)
+	return err
+}

--- a/lib/isaac_simulation_test.go
+++ b/lib/isaac_simulation_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stellar/go/keypair"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network"
@@ -29,13 +29,13 @@ func TestIsaacSimulationProposer(t *testing.T) {
 	var err error
 	err = nodeRunner.handleMessageFromClient(message)
 
-	assert.Nil(t, err)
-	assert.True(t, nodeRunner.Consensus().TransactionPool.Has(tx.GetHash()))
+	require.Nil(t, err)
+	require.True(t, nodeRunner.Consensus().TransactionPool.Has(tx.GetHash()))
 
 	// Generate proposed ballot in nodeRunner
 	roundNumber := uint64(0)
 	err = nodeRunner.proposeNewBallot(roundNumber)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	round := Round{
 		Number:      roundNumber,
 		BlockHeight: nodeRunner.Consensus().LatestConfirmedBlock.Height,
@@ -47,48 +47,48 @@ func TestIsaacSimulationProposer(t *testing.T) {
 	// Check that the transaction is in RunningRounds
 	rr := runningRounds[round.Hash()]
 	txHashs := rr.Transactions[proposer.Address()]
-	assert.Equal(t, tx.GetHash(), txHashs[0])
+	require.Equal(t, tx.GetHash(), txHashs[0])
 
 	ballotSIGN1 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[1].localNode)
 	err = receiveBallot(t, nodeRunner, ballotSIGN1)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	ballotSIGN2 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[2].localNode)
 	err = receiveBallot(t, nodeRunner, ballotSIGN2)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	ballotSIGN3 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[3].localNode)
 	err = receiveBallot(t, nodeRunner, ballotSIGN3)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	ballotSIGN4 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[4].localNode)
 	err = receiveBallot(t, nodeRunner, ballotSIGN4)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
-	assert.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateSIGN)))
+	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateSIGN)))
 
 	ballotACCEPT1 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[1].localNode)
 	err = receiveBallot(t, nodeRunner, ballotACCEPT1)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	ballotACCEPT2 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[2].localNode)
 	err = receiveBallot(t, nodeRunner, ballotACCEPT2)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	ballotACCEPT3 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[3].localNode)
 	err = receiveBallot(t, nodeRunner, ballotACCEPT3)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	ballotACCEPT4 := generateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[4].localNode)
 	err = receiveBallot(t, nodeRunner, ballotACCEPT4)
-	assert.EqualError(t, err, "stop checker and return: ballot got consensus and will be stored")
+	require.EqualError(t, err, "stop checker and return: ballot got consensus and will be stored")
 
-	assert.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateACCEPT)))
+	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateACCEPT)))
 
 	block := nodeRunner.Consensus().LatestConfirmedBlock
-	assert.Equal(t, proposer.Address(), block.Proposer)
-	assert.Equal(t, 1, len(block.Transactions))
-	assert.Equal(t, tx.GetHash(), block.Transactions[0])
+	require.Equal(t, proposer.Address(), block.Proposer)
+	require.Equal(t, 1, len(block.Transactions))
+	require.Equal(t, tx.GetHash(), block.Transactions[0])
 }
 
 func getTransaction(t *testing.T) (tx Transaction, txByte []byte) {
@@ -102,7 +102,7 @@ func getTransaction(t *testing.T) (tx Transaction, txByte []byte) {
 	var err error
 
 	txByte, err = tx.Serialize()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	return
 }
@@ -117,14 +117,14 @@ func generateBallot(t *testing.T, proposer *sebaknode.LocalNode, round Round, tx
 	ballot.Sign(sender.Keypair(), networkID)
 
 	err := ballot.IsWellFormed(networkID)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	return ballot
 }
 
 func receiveBallot(t *testing.T, nodeRunner *NodeRunner, ballot *Ballot) error {
 	data, err := ballot.Serialize()
-	assert.Nil(t, err)
+	require.Nil(t, err)
 
 	ballotMessage := sebaknetwork.Message{Type: sebaknetwork.BallotMessage, Data: data}
 	err = nodeRunner.handleBallotMessage(ballotMessage)

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -10,7 +10,6 @@ package sebak
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"time"
 
@@ -67,14 +66,19 @@ var DefaultHandleACCEPTBallotCheckerFuncs = []sebakcommon.CheckerFunc{
 	ACCEPTBallotStore,
 }
 
+type ProposerCalculator interface {
+	Calculate(nr *NodeRunner, blockHeight uint64, roundNumber uint64) string
+}
+
 type NodeRunner struct {
-	networkID         []byte
-	localNode         *sebaknode.LocalNode
-	policy            sebakcommon.VotingThresholdPolicy
-	network           sebaknetwork.Network
-	consensus         *ISAAC
-	connectionManager *sebaknetwork.ConnectionManager
-	storage           *sebakstorage.LevelDBBackend
+	networkID          []byte
+	localNode          *sebaknode.LocalNode
+	policy             sebakcommon.VotingThresholdPolicy
+	network            sebaknetwork.Network
+	consensus          *ISAAC
+	connectionManager  *sebaknetwork.ConnectionManager
+	storage            *sebakstorage.LevelDBBackend
+	proposerCalculator ProposerCalculator
 
 	handleMessageFromClientCheckerFuncs []sebakcommon.CheckerFunc
 	handleBaseBallotCheckerFuncs        []sebakcommon.CheckerFunc
@@ -111,6 +115,8 @@ func NewNodeRunner(
 	nr.ctx = context.WithValue(nr.ctx, "networkID", nr.networkID)
 	nr.ctx = context.WithValue(nr.ctx, "storage", nr.storage)
 
+	nr.SetProposerCalculator(SimpleProposerCalculator{})
+
 	nr.connectionManager = sebaknetwork.NewConnectionManager(
 		nr.localNode,
 		nr.network,
@@ -126,6 +132,20 @@ func NewNodeRunner(
 	nr.SetHandleACCEPTBallotCheckerFuncs(DefaultHandleACCEPTBallotCheckerFuncs...)
 
 	return
+}
+
+type SimpleProposerCalculator struct {
+}
+
+func (c SimpleProposerCalculator) Calculate(nr *NodeRunner, blockHeight uint64, roundNumber uint64) string {
+	candidates := sort.StringSlice(nr.connectionManager.AllValidators())
+	candidates.Sort()
+
+	return candidates[(blockHeight+roundNumber)%uint64(len(candidates))]
+}
+
+func (nr *NodeRunner) SetProposerCalculator(c ProposerCalculator) {
+	nr.proposerCalculator = c
 }
 
 func (nr *NodeRunner) Ready() {
@@ -373,14 +393,7 @@ func (nr *NodeRunner) startRound() {
 }
 
 func (nr *NodeRunner) CalculateProposer(blockHeight uint64, roundNumber uint64) string {
-	candidates := sort.StringSlice(nr.connectionManager.AllValidators())
-	candidates.Sort()
-
-	var hashedNumber int
-	for _, i := range sebakcommon.MakeHash([]byte(fmt.Sprintf("%d+%d", blockHeight, roundNumber))) {
-		hashedNumber += int(i)
-	}
-	return candidates[hashedNumber%len(candidates)]
+	return nr.proposerCalculator.Calculate(nr, blockHeight, roundNumber)
 }
 
 func (nr *NodeRunner) StartNewRound(roundNumber uint64) {
@@ -433,7 +446,7 @@ func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
 	go func() {
 		<-timer.C
 
-		if err := nr.proposeNewBallot(roundNumber); err != nil {
+		if err := nr.ProposeNewBallot(roundNumber); err != nil {
 			nr.log.Error("failed to proposeNewBallot", "round", roundNumber, "error", err)
 			go nr.StartNewRound(roundNumber)
 		}
@@ -442,7 +455,7 @@ func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
 	return
 }
 
-func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
+func (nr *NodeRunner) ProposeNewBallot(roundNumber uint64) error {
 	// start new round
 	round := Round{
 		Number:      roundNumber,

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -446,7 +446,7 @@ func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
 	go func() {
 		<-timer.C
 
-		if err := nr.proposeNewBallot(roundNumber); err != nil {
+		if err := nr.ProposeNewBallot(roundNumber); err != nil {
 			nr.log.Error("failed to proposeNewBallot", "round", roundNumber, "error", err)
 			go nr.StartNewRound(roundNumber)
 		}
@@ -455,7 +455,7 @@ func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
 	return
 }
 
-func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
+func (nr *NodeRunner) ProposeNewBallot(roundNumber uint64) error {
 	// start new round
 	round := Round{
 		Number:      roundNumber,

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -446,7 +446,7 @@ func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
 	go func() {
 		<-timer.C
 
-		if err := nr.ProposeNewBallot(roundNumber); err != nil {
+		if err := nr.proposeNewBallot(roundNumber); err != nil {
 			nr.log.Error("failed to proposeNewBallot", "round", roundNumber, "error", err)
 			go nr.StartNewRound(roundNumber)
 		}
@@ -455,7 +455,7 @@ func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
 	return
 }
 
-func (nr *NodeRunner) ProposeNewBallot(roundNumber uint64) error {
+func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
 	// start new round
 	round := Round{
 		Number:      roundNumber,

--- a/lib/node_runner_memory_network_test.go
+++ b/lib/node_runner_memory_network_test.go
@@ -59,33 +59,3 @@ func makeTransactionPayment(kpSource *keypair.Full, target string, amount sebakc
 
 	return
 }
-
-func makeTransactionCreateAccount(kpSource *keypair.Full, target string, amount sebakcommon.Amount) (tx Transaction) {
-	opb := NewOperationBodyCreateAccount(target, sebakcommon.Amount(amount))
-
-	op := Operation{
-		H: OperationHeader{
-			Type: OperationCreateAccount,
-		},
-		B: opb,
-	}
-
-	txBody := TransactionBody{
-		Source:     kpSource.Address(),
-		Fee:        BaseFee,
-		Checkpoint: uuid.New().String(),
-		Operations: []Operation{op},
-	}
-
-	tx = Transaction{
-		T: "transaction",
-		H: TransactionHeader{
-			Created: sebakcommon.NowISO8601(),
-			Hash:    txBody.MakeHashString(),
-		},
-		B: txBody,
-	}
-	tx.Sign(kpSource, networkID)
-
-	return
-}

--- a/lib/node_runner_message_checker.go
+++ b/lib/node_runner_message_checker.go
@@ -5,7 +5,7 @@
 	The process is as follows :
 	1. TransactionUnmarshal: Unmarshal the received message in transaction
 	2. HasTransaction: The transaction that already exists does not proceed anymore
-	3. History: Save History
+	3. SaveTransactionHistory: Save History
 	4. PushIntoTransactionPool: Insert into transaction pool
 	5. BroadcastTransaction: Passing a transaction to all known Validators.
 */

--- a/lib/node_runner_message_checker_test.go
+++ b/lib/node_runner_message_checker_test.go
@@ -8,7 +8,23 @@ import (
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/storage"
 )
+
+func MakeNodeRunner() (*NodeRunner, *sebaknode.LocalNode) {
+	kp, _ := keypair.Random()
+
+	nodeEndpoint := &sebakcommon.Endpoint{Scheme: "https", Host: "https://locahost:5000"}
+	localNode, _ := sebaknode.NewLocalNode(kp, nodeEndpoint, "")
+
+	vth, _ := NewDefaultVotingThresholdPolicy(66, 66)
+	is, _ := NewISAAC(networkID, localNode, vth)
+	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	network, _ := createNetMemoryNetwork()
+	nodeRunner, _ := NewNodeRunner(string(networkID), localNode, vth, network, is, st)
+	return nodeRunner, localNode
+}
 
 func TestMessageChecker(t *testing.T) {
 	_, validTx := TestMakeTransaction(networkID, 1)
@@ -29,39 +45,39 @@ func TestMessageChecker(t *testing.T) {
 		Message:        validMessage,
 	}
 
-	err = TransactionUnmarshal(checker)
-	require.Nil(t, err)
-	require.Equal(t, checker.Transaction, validTx)
+	err = CheckNodeRunnerHandleMessageTransactionUnmarshal(checker)
+	assert.Nil(t, err)
+	assert.Equal(t, checker.Transaction, validTx)
 
-	err = HasTransaction(checker)
-	require.Nil(t, err)
+	err = CheckNodeRunnerHandleMessageHasTransactionAlready(checker)
+	assert.Nil(t, err)
 
-	err = SaveTransactionHistory(checker)
-	require.Nil(t, err)
+	err = CheckNodeRunnerHandleMessageHistory(checker)
+	assert.Nil(t, err)
 	var found bool
 	found, err = ExistsBlockTransactionHistory(checker.NodeRunner.Storage(), checker.Transaction.GetHash())
-	require.True(t, found)
+	assert.True(t, found)
 
-	err = PushIntoTransactionPool(checker)
-	require.Nil(t, err)
-	require.True(t, checker.NodeRunner.Consensus().TransactionPool.Has(validTx.GetHash()))
+	err = CheckNodeRunnerHandleMessagePushIntoTransactionPool(checker)
+	assert.Nil(t, err)
+	assert.True(t, checker.NodeRunner.Consensus().TransactionPool.Has(validTx.GetHash()))
 
-	// BroadcastTransaction(checker) is not suitable in unittest
+	// CheckNodeRunnerHandleMessageTransactionBroadcast(checker) is not suitable in unittest
 
-	err = HasTransaction(checker)
-	require.Equal(t, err, sebakerror.ErrorNewButKnownMessage)
+	err = CheckNodeRunnerHandleMessageHasTransactionAlready(checker)
+	assert.Equal(t, err, sebakerror.ErrorNewButKnownMessage)
 
-	err = SaveTransactionHistory(checker)
-	require.Equal(t, err, sebakerror.ErrorNewButKnownMessage)
+	err = CheckNodeRunnerHandleMessageHistory(checker)
+	assert.Equal(t, err, sebakerror.ErrorNewButKnownMessage)
 
-	err = PushIntoTransactionPool(checker)
-	require.Nil(t, err)
+	err = CheckNodeRunnerHandleMessagePushIntoTransactionPool(checker)
+	assert.Nil(t, err)
 
 	var CheckerFuncs = []sebakcommon.CheckerFunc{
-		TransactionUnmarshal,
-		HasTransaction,
-		SaveTransactionHistory,
-		PushIntoTransactionPool,
+		CheckNodeRunnerHandleMessageTransactionUnmarshal,
+		CheckNodeRunnerHandleMessageHasTransactionAlready,
+		CheckNodeRunnerHandleMessageHistory,
+		CheckNodeRunnerHandleMessagePushIntoTransactionPool,
 	}
 
 	checker.DefaultChecker = sebakcommon.DefaultChecker{CheckerFuncs}

--- a/lib/node_runner_test.go
+++ b/lib/node_runner_test.go
@@ -14,16 +14,6 @@ import (
 	"github.com/stellar/go/keypair"
 )
 
-var (
-	kp           *keypair.Full
-	account      *block.BlockAccount
-	genesisBlock Block
-)
-
-func init() {
-	kp, _ = keypair.Random()
-}
-
 func createTestNodeRunner(n int) []*NodeRunner {
 	var ns []*sebaknetwork.MemoryNetwork
 	var nodes []*sebaknode.LocalNode

--- a/lib/node_runner_test.go
+++ b/lib/node_runner_test.go
@@ -15,8 +15,9 @@ import (
 )
 
 var (
-	kp      *keypair.Full
-	account *block.BlockAccount
+	kp           *keypair.Full
+	account      *block.BlockAccount
+	genesisBlock Block
 )
 
 func init() {
@@ -54,7 +55,7 @@ func createTestNodeRunner(n int) []*NodeRunner {
 		st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
 
 		account.Save(st)
-		MakeGenesisBlock(st, *account)
+		genesisBlock = MakeGenesisBlock(st, *account)
 
 		nr, err := NewNodeRunner(string(networkID), v, p, ns[i], is, st)
 		if err != nil {

--- a/lib/proposer_calculator_test.go
+++ b/lib/proposer_calculator_test.go
@@ -1,0 +1,25 @@
+package sebak
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type SelfProposerCalculator struct {
+}
+
+func (c SelfProposerCalculator) Calculate(nr *NodeRunner, _ uint64, _ uint64) string {
+	return nr.localNode.Address()
+}
+
+func TestProposerCalculator(t *testing.T) {
+	nodeRunners := createTestNodeRunner(1)
+
+	nodeRunner := nodeRunners[0]
+	nodeRunner.SetProposerCalculator(SelfProposerCalculator{})
+
+	assert.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(0, 1))
+	assert.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(0, 2))
+	assert.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(1, 2))
+}

--- a/lib/test.go
+++ b/lib/test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"testing"
 
 	"github.com/google/uuid"
 	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network"
@@ -157,4 +159,44 @@ func TestMakeTransactionWithKeypair(networkID []byte, n int, srcKp *keypair.Full
 	tx.Sign(srcKp, networkID)
 
 	return
+}
+
+func GetTransaction(t *testing.T) (tx Transaction, txByte []byte) {
+	initialBalance := sebakcommon.Amount(1)
+	kpNewAccount, _ := keypair.Random()
+
+	tx = makeTransactionCreateAccount(kp, kpNewAccount.Address(), initialBalance)
+	tx.B.Checkpoint = account.Checkpoint
+	tx.Sign(kp, networkID)
+
+	var err error
+
+	txByte, err = tx.Serialize()
+	require.Nil(t, err)
+
+	return
+}
+
+func GenerateBallot(t *testing.T, proposer *sebaknode.LocalNode, round Round, tx Transaction, ballotState sebakcommon.BallotState, sender *sebaknode.LocalNode) *Ballot {
+	ballot := NewBallot(proposer, round, []string{tx.GetHash()})
+	ballot.SetVote(sebakcommon.BallotStateINIT, VotingYES)
+	ballot.Sign(proposer.Keypair(), networkID)
+
+	ballot.SetSource(sender.Address())
+	ballot.SetVote(ballotState, VotingYES)
+	ballot.Sign(sender.Keypair(), networkID)
+
+	err := ballot.IsWellFormed(networkID)
+	require.Nil(t, err)
+
+	return ballot
+}
+
+func ReceiveBallot(t *testing.T, nodeRunner *NodeRunner, ballot *Ballot) error {
+	data, err := ballot.Serialize()
+	require.Nil(t, err)
+
+	ballotMessage := sebaknetwork.Message{Type: sebaknetwork.BallotMessage, Data: data}
+	err = nodeRunner.handleBallotMessage(ballotMessage)
+	return err
 }


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->
Related #200 

### Background
1. I think we need test for node state transition. Then we can easily understand how a node state changes easily.

### Solution
1. Add `TestIsaacSimulationProposer`

### Comment
1. After merging this pr, I'm going to add similar test for node which is not proposer.
1. You should check only [comparing link](https://github.com/Charleslee522/sebak/compare/noderunner-message-checker...Charleslee522:isaac-one-node-test).
1. This change could be merged after merging #240
1. ~~I changed HandleMessageFromClient and HandleBallotMessage methods to be exported for testing. If it is not appropriate, then I will find another way.~~

