### PR TITLE
Use a list of all validators to calculate the proposer

### DIFF
--- a/lib/network/connection_manager.go
+++ b/lib/network/connection_manager.go
@@ -99,8 +99,14 @@ func (c *ConnectionManager) AllConnected() []string {
 	return connected
 }
 
-func (c *ConnectionManager) RoundCandidates() []string {
-	return append(c.AllConnected(), c.localNode.Address())
+// Returns:
+//   A list of all validators, including self
+func (c *ConnectionManager) AllValidators() []string {
+	var validators []string
+	for address := range c.validators {
+		validators = append(validators, address)
+	}
+	return append(validators, c.localNode.Address())
 }
 
 func (c *ConnectionManager) CountConnected() int {

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -373,7 +373,7 @@ func (nr *NodeRunner) startRound() {
 }
 
 func (nr *NodeRunner) CalculateProposer(blockHeight uint64, roundNumber uint64) string {
-	candidates := sort.StringSlice(nr.connectionManager.RoundCandidates())
+	candidates := sort.StringSlice(nr.connectionManager.AllValidators())
 	candidates.Sort()
 
 	var hashedNumber int


### PR DESCRIPTION
```
To calculate the proposer, we should obviously not depend on the node state,
but something that is shared by everyone.
At the moment we can work under the assumption that the validator list will be the same for everyone.
However, there's no way we can assume that the list of connected nodes is the same for everyone,
or that we should base any part of the consensus on that.
```

This will be red until #240 is merged.