### PR TITLE
Fix one race in `api_test`

### DIFF
--- a/lib/api_test.go
+++ b/lib/api_test.go
@@ -48,6 +48,7 @@ func TestGetAccountHandler(t *testing.T) {
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := ts.Client().Do(req)
 	require.Nil(t, err)
+	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
 	// Do stream Request to the Server
@@ -62,7 +63,6 @@ func TestGetAccountHandler(t *testing.T) {
 			require.Equal(t, prev+n, cba.GetBalance())
 			prev = cba.GetBalance()
 		}
-		resp.Body.Close()
 		wg.Done()
 	}()
 
@@ -86,6 +86,7 @@ func TestGetAccountHandler(t *testing.T) {
 	require.Nil(t, err)
 	resp, err = ts.Client().Do(req)
 	require.Nil(t, err)
+	defer resp.Body.Close()
 	reader = bufio.NewReader(resp.Body)
 	readByte, err := ioutil.ReadAll(reader)
 	require.Nil(t, err)
@@ -134,6 +135,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := ts.Client().Do(req)
 	require.Nil(t, err)
+	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
 	// Do stream Request to the Server
@@ -147,7 +149,6 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 			require.Nil(t, err)
 			require.Equal(t, txS, line)
 		}
-		resp.Body.Close()
 		wg.Done()
 	}()
 
@@ -170,6 +171,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	require.Nil(t, err)
 	resp, err = ts.Client().Do(req)
 	require.Nil(t, err)
+	defer resp.Body.Close()
 	reader = bufio.NewReader(resp.Body)
 	readByte, err := ioutil.ReadAll(reader)
 	require.Nil(t, err)
@@ -226,6 +228,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := ts.Client().Do(req)
 	require.Nil(t, err)
+	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
 	// Do stream Request to the Server
@@ -264,9 +267,10 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 	// No streaming
 	req, err = http.NewRequest("GET", url, nil)
 	require.Nil(t, err)
-	resp, err = ts.Client().Do(req)
+	resp2, err := ts.Client().Do(req)
 	require.Nil(t, err)
-	reader = bufio.NewReader(resp.Body)
+	defer resp2.Body.Close()
+	reader = bufio.NewReader(resp2.Body)
 	readByte, err := ioutil.ReadAll(reader)
 	require.Nil(t, err)
 	var receivedBos []BlockOperation
@@ -337,6 +341,7 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 	require.Nil(t, err)
 	resp, err := ts.Client().Do(req)
 	require.Nil(t, err)
+	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 	readByte, err := ioutil.ReadAll(reader)
 	require.Nil(t, err)
@@ -381,6 +386,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 	req.Header.Set("Accept", "text/event-stream")
 	resp, err := ts.Client().Do(req)
 	require.Nil(t, err)
+	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
 	// Do stream Request to the Server
@@ -394,7 +400,6 @@ func TestGetTransactionsHandler(t *testing.T) {
 			require.Equal(t, txS, line)
 		}
 
-		resp.Body.Close()
 		wg.Done()
 	}()
 
@@ -414,9 +419,10 @@ func TestGetTransactionsHandler(t *testing.T) {
 	// No streaming
 	req, err = http.NewRequest("GET", url, nil)
 	require.Nil(t, err)
-	resp, err = ts.Client().Do(req)
+	resp2, err := ts.Client().Do(req)
 	require.Nil(t, err)
-	reader = bufio.NewReader(resp.Body)
+	defer resp2.Body.Close()
+	reader = bufio.NewReader(resp2.Body)
 	readByte, err := ioutil.ReadAll(reader)
 	require.Nil(t, err)
 	var receivedBts []BlockTransaction

--- a/lib/api_test.go
+++ b/lib/api_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 
 	"boscoin.io/sebak/lib/block"
@@ -17,14 +16,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetAccountHandler(t *testing.T) {
-	var err error
-	var wg sync.WaitGroup
-	wg.Add(2)
-
 	// Setting Server
 	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
@@ -51,35 +47,33 @@ func TestGetAccountHandler(t *testing.T) {
 	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
-	// Do stream Request to the Server
-	go func() {
-		var n sebakcommon.Amount
-		for n = 0; n < 10; n++ {
-			line, err := reader.ReadBytes('\n')
-			require.Nil(t, err)
-			var cba = &block.BlockAccount{}
-			json.Unmarshal(line, cba)
-			require.Equal(t, ba.Address, cba.Address)
-			require.Equal(t, prev+n, cba.GetBalance())
-			prev = cba.GetBalance()
-		}
-		wg.Done()
-	}()
-
+	recv := make(chan struct{})
 	go func() {
 		// Makes Some Events
 		for n := 1; n < 20; n++ {
-			newBalance, err := ba.GetBalance().Add(sebakcommon.Amount(n))
-			require.Nil(t, err)
+			newBalance := ba.GetBalance().MustAdd(sebakcommon.Amount(n))
 			ba.Balance = newBalance.String()
-
 			ba.Save(storage)
+			if n <= 10 {
+				recv <- struct{}{}
+			}
 		}
-
-		wg.Done()
+		close(recv)
 	}()
 
-	wg.Wait()
+	// Do stream Request to the Server
+	var n sebakcommon.Amount
+	for n = 0; n < 10; n++ {
+		<-recv
+		line, err := reader.ReadBytes('\n')
+		require.Nil(t, err)
+		var cba = &block.BlockAccount{}
+		json.Unmarshal(line, cba)
+		require.Equal(t, ba.Address, cba.Address)
+		require.Equal(t, prev+n, cba.GetBalance())
+		prev = cba.GetBalance()
+	}
+	<-recv // Close
 
 	// No streaming
 	req, err = http.NewRequest("GET", url, nil)
@@ -99,9 +93,6 @@ func TestGetAccountHandler(t *testing.T) {
 
 func TestGetAccountTransactionsHandler(t *testing.T) {
 	var err error
-
-	var wg sync.WaitGroup
-	wg.Add(1)
 
 	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
@@ -138,33 +129,41 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
-	// Do stream Request to the Server
+	// Makes Some Events
+	recv := make(chan struct{})
 	go func() {
-		var n sebakcommon.Amount
-		for n = 0; n < 10; n++ {
-			line, err := reader.ReadBytes('\n')
-			require.Nil(t, err)
-			line = bytes.Trim(line, "\n\t ")
-			txS, err := bts[n].Serialize()
-			require.Nil(t, err)
-			require.Equal(t, txS, line)
+		for i := 0; i < 20; i++ {
+			tx := TestMakeTransactionWithKeypair(networkID, 1, kp)
+
+			a, err := tx.Serialize()
+			if !assert.Nil(t, err) {
+				panic(err)
+			}
+			bt := NewBlockTransactionFromTransaction(tx, a)
+			err = bt.Save(storage)
+			if !assert.Nil(t, err) {
+				panic(err)
+			}
+			bts = append(bts, bt)
+			if i < 10 {
+				recv <- struct{}{}
+			}
 		}
-		wg.Done()
+		close(recv)
 	}()
 
-	// Makes Some Events
-	for i := 0; i < 20; i++ {
-		tx := TestMakeTransactionWithKeypair(networkID, 1, kp)
-
-		a, err := tx.Serialize()
+	// Do stream Request to the Server
+	var n sebakcommon.Amount
+	for n = 0; n < 10; n++ {
+		<-recv
+		line, err := reader.ReadBytes('\n')
 		require.Nil(t, err)
-		bt := NewBlockTransactionFromTransaction(tx, a)
-		err = bt.Save(storage)
+		line = bytes.Trim(line, "\n\t ")
+		txS, err := bts[n].Serialize()
 		require.Nil(t, err)
-		bts = append(bts, bt)
+		require.Equal(t, txS, line)
 	}
-
-	wg.Wait()
+	<-recv // Wait for close
 
 	// No streaming
 	req, err = http.NewRequest("GET", url, nil)
@@ -189,10 +188,6 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 }
 
 func TestGetAccountOperationsHandler(t *testing.T) {
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
 	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
@@ -231,38 +226,45 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
-	// Do stream Request to the Server
+	// Makes Some Events
+	recv := make(chan struct{})
 	go func() {
-		var n sebakcommon.Amount
-		for n = 0; n < 10; n++ {
-			line, err := reader.ReadBytes('\n')
-			require.Nil(t, err)
-			line = bytes.Trim(line, "\n\t ")
-			txS, err := bos[n].Serialize()
-			require.Nil(t, err)
-			require.Equal(t, txS, line)
+		for i := 0; i < 20; i++ {
+			tx := TestMakeTransactionWithKeypair(networkID, 3, kp)
+			a, err := tx.Serialize()
+			if !assert.Nil(t, err) {
+				panic(err)
+			}
+			bt := NewBlockTransactionFromTransaction(tx, a)
+			bt.Save(storage)
+
+			for _, boHash := range bt.Operations {
+				var bo BlockOperation
+				bo, err = GetBlockOperation(storage, boHash)
+				if !assert.Nil(t, err) {
+					panic(err)
+				}
+				bos = append(bos, bo)
+			}
+			if i < 10 {
+				recv <- struct{}{}
+			}
 		}
-		resp.Body.Close()
-		wg.Done()
+		close(recv)
 	}()
 
-	// Makes Some Events
-	for i := 0; i < 20; i++ {
-		tx := TestMakeTransactionWithKeypair(networkID, 3, kp)
-		a, err := tx.Serialize()
+	// Do stream Request to the Server
+	var n sebakcommon.Amount
+	for n = 0; n < 10; n++ {
+		<-recv
+		line, err := reader.ReadBytes('\n')
 		require.Nil(t, err)
-		bt := NewBlockTransactionFromTransaction(tx, a)
-		bt.Save(storage)
-
-		for _, boHash := range bt.Operations {
-			var bo BlockOperation
-			bo, err = GetBlockOperation(storage, boHash)
-			require.Nil(t, err)
-			bos = append(bos, bo)
-		}
+		line = bytes.Trim(line, "\n\t ")
+		txS, err := bos[n].Serialize()
+		require.Nil(t, err)
+		require.Equal(t, txS, line)
 	}
-
-	wg.Wait()
+	<-recv // Wait for close
 
 	// No streaming
 	req, err = http.NewRequest("GET", url, nil)
@@ -287,10 +289,6 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 }
 
 func TestGetTransactionByHashHandler(t *testing.T) {
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
 	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
@@ -315,34 +313,29 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 	require.Nil(t, err)
 	req.Header.Set("Accept", "text/event-stream")
 
-	// Do stream Request to the Server
-	go func() {
-		resp, err := ts.Client().Do(req)
-		require.Nil(t, err)
-		reader := bufio.NewReader(resp.Body)
-		line, err := reader.ReadBytes('\n')
-		require.Nil(t, err)
-		line = bytes.Trim(line, "\n\t ")
-
-		serializedBt, err := bt.Serialize()
-		require.Nil(t, err)
-		require.Equal(t, serializedBt, line)
-
-		resp.Body.Close()
-		wg.Done()
-	}()
-
+	// Produce an event
 	bt.Save(storage)
 
-	wg.Wait()
-
-	// No streaming
-	req, err = http.NewRequest("GET", url, nil)
-	require.Nil(t, err)
+	// Do stream Request to the Server
 	resp, err := ts.Client().Do(req)
 	require.Nil(t, err)
 	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
+	line, err := reader.ReadBytes('\n')
+	require.Nil(t, err)
+	line = bytes.Trim(line, "\n\t ")
+
+	serializedBt, err := bt.Serialize()
+	require.Nil(t, err)
+	require.Equal(t, serializedBt, line)
+
+	// No streaming
+	req, err = http.NewRequest("GET", url, nil)
+	require.Nil(t, err)
+	resp2, err := ts.Client().Do(req)
+	require.Nil(t, err)
+	defer resp2.Body.Close()
+	reader = bufio.NewReader(resp2.Body)
 	readByte, err := ioutil.ReadAll(reader)
 	require.Nil(t, err)
 	var receivedBts BlockTransaction
@@ -353,10 +346,6 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 }
 
 func TestGetTransactionsHandler(t *testing.T) {
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-
 	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
@@ -389,32 +378,40 @@ func TestGetTransactionsHandler(t *testing.T) {
 	defer resp.Body.Close()
 	reader := bufio.NewReader(resp.Body)
 
-	// Do stream Request to the Server
+	// Producer
+	recv := make(chan struct{})
 	go func() {
-		for n := 0; n < 10; n++ {
-			line, err := reader.ReadBytes('\n')
-			require.Nil(t, err)
-			line = bytes.Trim(line, "\n\t ")
-			txS, err := bts[n].Serialize()
-			require.Nil(t, err)
-			require.Equal(t, txS, line)
-		}
+		for i := 0; i < 20; i++ {
+			_, tx := TestMakeTransaction(networkID, 1)
 
-		wg.Done()
+			a, err := tx.Serialize()
+			if !assert.Nil(t, err) {
+				panic(err)
+			}
+			bt := NewBlockTransactionFromTransaction(tx, a)
+			err = bt.Save(storage)
+			if !assert.Nil(t, err) {
+				panic(err)
+			}
+			bts = append(bts, bt)
+			if i < 10 {
+				recv <- struct{}{}
+			}
+		}
+		close(recv)
 	}()
 
-	for i := 0; i < 20; i++ {
-		_, tx := TestMakeTransaction(networkID, 1)
-
-		a, err := tx.Serialize()
+	// Do stream Request to the Server
+	for n := 0; n < 10; n++ {
+		<-recv
+		line, err := reader.ReadBytes('\n')
 		require.Nil(t, err)
-		bt := NewBlockTransactionFromTransaction(tx, a)
-		err = bt.Save(storage)
+		line = bytes.Trim(line, "\n\t ")
+		txS, err := bts[n].Serialize()
 		require.Nil(t, err)
-		bts = append(bts, bt)
+		require.Equal(t, txS, line)
 	}
-
-	wg.Wait()
+	<-recv // close
 
 	// No streaming
 	req, err = http.NewRequest("GET", url, nil)
@@ -435,5 +432,4 @@ func TestGetTransactionsHandler(t *testing.T) {
 		require.Equal(t, bt.Hash, receivedBts[i].Hash, "hash is not same")
 		i++
 	}
-
 }


### PR DESCRIPTION
```
Unfortunately, require.XXX cannot be used in a goroutine started by a test goroutine,
and has to be used in the test one.
This means that any code that consume events and check the result must not run in another goroutine.

This change also fixes a data race, where some data was accessed concurrently from 2 goroutines.
An array was appended to, and read from another goroutine, however synchronization was not
properly done and the race detector was complaining.
```

For the `require` issue I've submitted a report at https://github.com/stretchr/testify/issues/652
Regarding the race condition, one issue is that we were [reading an entry of an array](https://github.com/bosnet/sebak/blob/94f50fa6d33b0b15ec5239015f9eac1702a60e05/lib/api_test.go#L146) while [appending in another goroutine](https://github.com/bosnet/sebak/blob/94f50fa6d33b0b15ec5239015f9eac1702a60e05/lib/api_test.go#L163).