### PR TITLE
Fix build error on alpine linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG BUILD_MODE="install"
 ARG BUILD_ARGS=''
 ARG BUILD_PKG="./..."
 
-RUN apk add --no-cache git openssh
+RUN apk add --no-cache git openssh gcc musl-dev linux-headers
 RUN go get github.com/ahmetb/govvv
 
 ## Note that we do not get the dependencies anew


### PR DESCRIPTION
requires the following pakcages on Alpine Linux.

* gcc
* linux-headers (stdio.h)
* musl-dev (stdlib.h)

```
Step 1/20 : FROM golang:alpine AS builder
 ---> 22e024490b47
Step 2/20 : LABEL maintainer="BOSCoin Developers <devteam@boscoin.io>"
 ---> Using cache
 ---> 0aa6ca9eab98
Step 3/20 : COPY ./ /go/src/boscoin.io/sebak
 ---> d6435c3f314e
Step 4/20 : WORKDIR /go/src/boscoin.io/sebak
 ---> Running in 6706b8321dd5
Removing intermediate container 6706b8321dd5
 ---> 784447c9e160
Step 5/20 : ARG BUILD_MODE="install"
 ---> Running in 907020bb2bd0
Removing intermediate container 907020bb2bd0
 ---> 2af2966c67d5
Step 6/20 : ARG BUILD_ARGS=''
 ---> Running in bbe1505a9702
Removing intermediate container bbe1505a9702
 ---> 8009edc293c4
Step 7/20 : ARG BUILD_PKG="./..."
 ---> Running in 7417a81ddc20
Removing intermediate container 7417a81ddc20
 ---> a0d2eb225157
Step 8/20 : RUN apk add --no-cache git openssh
 ---> Running in 272f58bcc23c
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.7/community/x86_64/APKINDEX.tar.gz
(1/11) Installing libssh2 (1.8.0-r2)
(2/11) Installing libcurl (7.61.0-r0)
(3/11) Installing expat (2.2.5-r0)
(4/11) Installing pcre2 (10.30-r0)
(5/11) Installing git (2.15.2-r0)
(6/11) Installing openssh-keygen (7.5_p1-r8)
(7/11) Installing openssh-client (7.5_p1-r8)
(8/11) Installing openssh-sftp-server (7.5_p1-r8)
(9/11) Installing openssh-server-common (7.5_p1-r8)
(10/11) Installing openssh-server (7.5_p1-r8)
(11/11) Installing openssh (7.5_p1-r8)
Executing busybox-1.27.2-r7.trigger
OK: 23 MiB in 23 packages
Removing intermediate container 272f58bcc23c
 ---> eabe700bd22d
Step 9/20 : RUN go get github.com/ahmetb/govvv
 ---> Running in 0ee4caa738fd
Removing intermediate container 0ee4caa738fd
 ---> 4cbeb87f85ad
Step 10/20 : RUN if [ ! -d vendor ]; then go get github.com/golang/dep/cmd/dep; dep ensure -v; fi
 ---> Running in cda566659ca2
# Gopkg.lock is out of sync with Gopkg.toml and project imports:
github.com/stretchr/testify/assert: imported or required, but missing from Gopkg.lock's input-imports

Root project is "boscoin.io/sebak"
 17 transitively valid internal packages
 25 external packages imported from 17 projects
(0)   ✓ select (root)
(1)	? attempt github.com/GianlucaGuarini/go-observable with 1 pkgs; at least 1 versions to try
(1)	    try github.com/GianlucaGuarini/go-observable@master
(1)	✓ select github.com/GianlucaGuarini/go-observable@master w/1 pkgs
(2)	? attempt github.com/btcsuite/btcutil with 1 pkgs; at least 1 versions to try
(2)	    try github.com/btcsuite/btcutil@master
(2)	✓ select github.com/btcsuite/btcutil@master w/1 pkgs
(3)	? attempt github.com/ethereum/go-ethereum with 4 pkgs; at least 1 versions to try
(3)	    try github.com/ethereum/go-ethereum@v1.8.13
(3)	✓ select github.com/ethereum/go-ethereum@v1.8.13 w/11 pkgs
(4)	? attempt github.com/btcsuite/btcd with 1 pkgs; at least 1 versions to try
(4)	    try github.com/btcsuite/btcd@master
(4)	✓ select github.com/btcsuite/btcd@master w/1 pkgs
(5)	? attempt github.com/go-stack/stack with 1 pkgs; at least 1 versions to try
(5)	    try github.com/go-stack/stack@v1.7.0
(5)	✓ select github.com/go-stack/stack@v1.7.0 w/1 pkgs
(6)	? attempt github.com/satori/go.uuid with 1 pkgs; at least 1 versions to try
(6)	    try github.com/satori/go.uuid@v1.2.0
(6)	✓ select github.com/satori/go.uuid@v1.2.0 w/1 pkgs
(7)	? attempt github.com/google/uuid with 1 pkgs; at least 1 versions to try
(7)	    try github.com/google/uuid@0.2
(7)	✓ select github.com/google/uuid@0.2 w/1 pkgs
(8)	? attempt github.com/stellar/go with 1 pkgs; at least 1 versions to try
(8)	    try github.com/stellar/go@master
(8)	✓ select github.com/stellar/go@master w/7 pkgs
(9)	? attempt github.com/agl/ed25519 with 1 pkgs; at least 1 versions to try
(9)	    try github.com/agl/ed25519@master
(9)	✓ select github.com/agl/ed25519@master w/2 pkgs
(10)  ? attempt github.com/magiconair/properties with 1 pkgs; at least 1 versions to try
(10)      try github.com/magiconair/properties@v1.8.0
(10)  ✓ select github.com/magiconair/properties@v1.8.0 w/1 pkgs
(11)  ? attempt github.com/stretchr/testify with 2 pkgs; at least 1 versions to try
(11)      try github.com/stretchr/testify@v1.2.2
(11)  ✓ select github.com/stretchr/testify@v1.2.2 w/2 pkgs
(12)  ? attempt github.com/davecgh/go-spew with 1 pkgs; at least 1 versions to try
(12)      try github.com/davecgh/go-spew@v1.1.0
(12)  ✓ select github.com/davecgh/go-spew@v1.1.0 w/1 pkgs
(13)  ? attempt github.com/syndtr/goleveldb with 5 pkgs; at least 1 versions to try
(13)      try github.com/syndtr/goleveldb@master
(13)  ✓ select github.com/syndtr/goleveldb@master w/12 pkgs
(14)  ? attempt github.com/nullstyle/go-xdr with 1 pkgs; at least 1 versions to try
(14)      try github.com/nullstyle/go-xdr@master
(14)  ✓ select github.com/nullstyle/go-xdr@master w/1 pkgs
(15)  ? attempt github.com/gorilla/handlers with 1 pkgs; at least 1 versions to try
(15)      try github.com/gorilla/handlers@v1.3.0
(15)  ✓ select github.com/gorilla/handlers@v1.3.0 w/1 pkgs
(16)  ? attempt github.com/pkg/errors with 1 pkgs; at least 1 versions to try
(16)      try github.com/pkg/errors@v0.8.0
(16)  ✓ select github.com/pkg/errors@v0.8.0 w/1 pkgs
(17)  ? attempt gopkg.in/yaml.v2 with 1 pkgs; at least 1 versions to try
(17)      try gopkg.in/yaml.v2@v2.2.1
(17)  ✓ select gopkg.in/yaml.v2@v2.2.1 w/1 pkgs
(18)  ? attempt github.com/oklog/run with 1 pkgs; at least 1 versions to try
(18)      try github.com/oklog/run@v1.0.0
(18)  ✓ select github.com/oklog/run@v1.0.0 w/1 pkgs
(19)  ? attempt github.com/inconshreveable/log15 with 1 pkgs; at least 1 versions to try
(19)      try github.com/inconshreveable/log15@v2.13
(19)  ✓ select github.com/inconshreveable/log15@v2.13 w/1 pkgs
(20)  ? revisit github.com/syndtr/goleveldb to add 2 pkgs
(20)    ✓ include 4 more pkgs from github.com/syndtr/goleveldb@master
(20)  ? attempt github.com/mattn/go-colorable with 1 pkgs; at least 1 versions to try
(21)      try github.com/mattn/go-colorable@v0.0.9
(21)  ✓ select github.com/mattn/go-colorable@v0.0.9 w/1 pkgs
(21)  ? attempt github.com/gorilla/mux with 1 pkgs; at least 1 versions to try
(22)      try github.com/gorilla/mux@v1.6.2
(22)  ✓ select github.com/gorilla/mux@v1.6.2 w/1 pkgs
(22)  ? attempt github.com/gorilla/context with 1 pkgs; at least 1 versions to try
(23)      try github.com/gorilla/context@v1.1.1
(23)  ✓ select github.com/gorilla/context@v1.1.1 w/1 pkgs
(23)  ? attempt github.com/lib/pq with 1 pkgs; at least 1 versions to try
(24)      try github.com/lib/pq@master
(24)  ✓ select github.com/lib/pq@master w/2 pkgs
(24)  ? attempt golang.org/x/crypto with 1 pkgs; at least 1 versions to try
(25)      try golang.org/x/crypto@master
(25)  ✓ select golang.org/x/crypto@master w/2 pkgs
(25)  ? attempt github.com/mattn/go-isatty with 1 pkgs; at least 1 versions to try
(26)      try github.com/mattn/go-isatty@v0.0.3
(26)  ✓ select github.com/mattn/go-isatty@v0.0.3 w/1 pkgs
(26)  ? attempt github.com/pmezard/go-difflib with 1 pkgs; at least 1 versions to try
(27)      try github.com/pmezard/go-difflib@v1.0.0
(27)  ✓ select github.com/pmezard/go-difflib@v1.0.0 w/1 pkgs
(27)  ? attempt github.com/golang/snappy with 1 pkgs; at least 1 versions to try
(28)      try github.com/golang/snappy@master
(28)  ✓ select github.com/golang/snappy@master w/1 pkgs
(28)  ? attempt golang.org/x/net with 1 pkgs; at least 1 versions to try
(29)      try golang.org/x/net@master
(29)  ✓ select golang.org/x/net@master w/5 pkgs
(29)  ? attempt gopkg.in/karalabe/cookiejar.v2 with 1 pkgs; at least 1 versions to try
(30)      try gopkg.in/karalabe/cookiejar.v2@v2
(30)  ✓ select gopkg.in/karalabe/cookiejar.v2@v2 w/1 pkgs
(30)  ? attempt github.com/spf13/cobra with 1 pkgs; at least 1 versions to try
(31)      try github.com/spf13/cobra@v0.0.3
(31)  ✓ select github.com/spf13/cobra@v0.0.3 w/1 pkgs
(31)  ? attempt github.com/inconshreveable/mousetrap with 1 pkgs; at least 1 versions to try
(32)      try github.com/inconshreveable/mousetrap@v1.0
(32)  ✓ select github.com/inconshreveable/mousetrap@v1.0 w/1 pkgs
(32)  ? attempt github.com/spf13/pflag with 1 pkgs; at least 1 versions to try
(33)      try github.com/spf13/pflag@v1.0.1
(33)  ✓ select github.com/spf13/pflag@v1.0.1 w/1 pkgs
(33)  ? attempt golang.org/x/text with 3 pkgs; at least 1 versions to try
(34)      try golang.org/x/text@v0.3.0
(34)  ✓ select golang.org/x/text@v0.3.0 w/14 pkgs
(34)  ? attempt golang.org/x/sys with 1 pkgs; at least 1 versions to try
(35)      try golang.org/x/sys@master
(35)  ✓ select golang.org/x/sys@master w/1 pkgs
(35)  ? revisit golang.org/x/sys to add 1 pkgs
(36)    ✓ include 1 more pkgs from golang.org/x/sys@master
  ✓ found solution with 83 packages from 34 projects

Solver wall times by segment:
     b-source-exists: 3m57.2830959s
  b-deduce-proj-root:    5.5689544s
         b-list-pkgs:    3.3321261s
              b-gmal:    1.8515333s
             satisfy:     24.1416ms
         select-atom:     20.7766ms
            new-atom:      7.7792ms
         select-root:      2.4198ms
               other:      1.6007ms
            add-atom:       857.9µs

  TOTAL: 4m8.0932855s

(1/34) Wrote github.com/google/uuid@0.2
(2/34) Wrote github.com/inconshreveable/mousetrap@v1.0
(3/34) Wrote github.com/go-stack/stack@v1.7.0
(4/34) Wrote github.com/lib/pq@master
(5/34) Wrote github.com/syndtr/goleveldb@master
(6/34) Wrote github.com/pmezard/go-difflib@v1.0.0
(7/34) Wrote github.com/oklog/run@v1.0.0
(8/34) Wrote github.com/golang/snappy@master
(9/34) Wrote gopkg.in/karalabe/cookiejar.v2@v2
(10/34) Wrote github.com/spf13/pflag@v1.0.1
(11/34) Wrote github.com/davecgh/go-spew@v1.1.0
(12/34) Wrote github.com/gorilla/mux@v1.6.2
(13/34) Wrote golang.org/x/crypto@master
(14/34) Wrote github.com/GianlucaGuarini/go-observable@master
(15/34) Wrote golang.org/x/sys@master
(16/34) Wrote github.com/stretchr/testify@v1.2.2
(17/34) Wrote github.com/inconshreveable/log15@v2.13
(18/34) Wrote github.com/stellar/go@master
(19/34) Wrote github.com/pkg/errors@v0.8.0
(20/34) Wrote github.com/mattn/go-colorable@v0.0.9
(21/34) Wrote github.com/spf13/cobra@v0.0.3
(22/34) Wrote github.com/agl/ed25519@master
(23/34) Wrote github.com/satori/go.uuid@v1.2.0
(24/34) Wrote github.com/mattn/go-isatty@v0.0.3
(25/34) Wrote github.com/gorilla/context@v1.1.1
(26/34) Wrote github.com/nullstyle/go-xdr@master
(27/34) Wrote gopkg.in/yaml.v2@v2.2.1
(28/34) Wrote github.com/btcsuite/btcutil@master
(29/34) Wrote github.com/gorilla/handlers@v1.3.0
(30/34) Wrote github.com/magiconair/properties@v1.8.0
(31/34) Wrote golang.org/x/net@master
(32/34) Wrote github.com/btcsuite/btcd@master
(33/34) Wrote golang.org/x/text@v0.3.0
(34/34) Wrote github.com/ethereum/go-ethereum@v1.8.13
Removing intermediate container cda566659ca2
 ---> 1357549b51b1
Step 11/20 : RUN go $BUILD_MODE $BUILD_ARGS -ldflags="$(govvv -pkg boscoin.io/sebak/lib/version -flags)" -v $BUILD_PKG
 ---> Running in 7e7e4f6129ec
boscoin.io/sebak/lib/error
boscoin.io/sebak/vendor/github.com/btcsuite/btcutil/base58
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/common/hexutil
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/crypto/sha3
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/rlp
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/common
boscoin.io/sebak/vendor/github.com/satori/go.uuid
boscoin.io/sebak/vendor/golang.org/x/sys/cpu
boscoin.io/sebak/vendor/golang.org/x/crypto/blake2b
boscoin.io/sebak/vendor/golang.org/x/net/http/httpguts
boscoin.io/sebak/vendor/golang.org/x/net/http2/hpack
boscoin.io/sebak/vendor/golang.org/x/crypto/argon2
boscoin.io/sebak/vendor/golang.org/x/text/transform
boscoin.io/sebak/vendor/golang.org/x/text/unicode/bidi
boscoin.io/sebak/vendor/golang.org/x/text/unicode/norm
boscoin.io/sebak/vendor/golang.org/x/text/secure/bidirule
boscoin.io/sebak/vendor/github.com/spf13/pflag
boscoin.io/sebak/vendor/golang.org/x/net/idna
boscoin.io/sebak/vendor/golang.org/x/net/lex/httplex
boscoin.io/sebak/vendor/golang.org/x/net/http2
boscoin.io/sebak/vendor/github.com/spf13/cobra
boscoin.io/sebak/vendor/gopkg.in/yaml.v2
boscoin.io/sebak/lib/common
boscoin.io/sebak/vendor/github.com/agl/ed25519/edwards25519
boscoin.io/sebak/cmd/sebak/common
boscoin.io/sebak/vendor/github.com/stellar/go/hash
boscoin.io/sebak/vendor/github.com/pkg/errors
boscoin.io/sebak/vendor/github.com/agl/ed25519
boscoin.io/sebak/vendor/github.com/lib/pq/oid
boscoin.io/sebak/vendor/github.com/stellar/go/support/errors
boscoin.io/sebak/vendor/github.com/lib/pq
boscoin.io/sebak/vendor/github.com/nullstyle/go-xdr/xdr3
boscoin.io/sebak/vendor/github.com/stellar/go/crc16
boscoin.io/sebak/vendor/github.com/stellar/go/strkey
boscoin.io/sebak/vendor/github.com/GianlucaGuarini/go-observable
boscoin.io/sebak/lib/observer
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/util
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/cache
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/comparer
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/storage
boscoin.io/sebak/vendor/github.com/stellar/go/xdr
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/errors
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/filter
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/iterator
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/journal
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/memdb
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/opt
boscoin.io/sebak/vendor/github.com/golang/snappy
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb/table
boscoin.io/sebak/vendor/github.com/syndtr/goleveldb/leveldb
boscoin.io/sebak/vendor/github.com/stellar/go/network
boscoin.io/sebak/vendor/github.com/stellar/go/keypair
boscoin.io/sebak/cmd/sebak/cmd/key
boscoin.io/sebak/vendor/github.com/google/uuid
boscoin.io/sebak/lib/node
boscoin.io/sebak/vendor/github.com/gorilla/handlers
boscoin.io/sebak/vendor/github.com/gorilla/mux
boscoin.io/sebak/lib/storage
boscoin.io/sebak/lib/block
boscoin.io/sebak/vendor/github.com/go-stack/stack
boscoin.io/sebak/vendor/github.com/mattn/go-isatty
boscoin.io/sebak/lib/version
boscoin.io/sebak/vendor/github.com/mattn/go-colorable
boscoin.io/sebak/vendor/github.com/oklog/run
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/log
boscoin.io/sebak/vendor/github.com/inconshreveable/log15
boscoin.io/sebak/lib/network
boscoin.io/sebak/lib/common/test
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/metrics
boscoin.io/sebak/lib
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/ethdb
boscoin.io/sebak/cmd/sebak/cmd/wallet
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/common/math
boscoin.io/sebak/cmd/sebak/cmd
boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/crypto/secp256k1
# boscoin.io/sebak/vendor/github.com/ethereum/go-ethereum/crypto/secp256k1
exec: "gcc": executable file not found in $PATH
boscoin.io/sebak/vendor/gopkg.in/karalabe/cookiejar.v2/collections/prque
boscoin.io/sebak/cmd/sebak
The command '/bin/sh -c go $BUILD_MODE $BUILD_ARGS -ldflags="$(govvv -pkg boscoin.io/sebak/lib/version -flags)" -v $BUILD_PKG' returned a non-zero code: 2
```