### PR TITLE
Remove use of deprecated CloseNotifier

### DIFF
--- a/lib/api_account.go
+++ b/lib/api_account.go
@@ -57,7 +57,7 @@ func GetAccountHandler(storage *sebakstorage.LevelDBBackend) http.HandlerFunc {
 
 			event := fmt.Sprintf("iterate-%s", iterateId)
 			event += " " + fmt.Sprintf("address-%s", address)
-			streaming(observer.BlockAccountObserver, w, event, callBackFunc, readyChan)
+			streaming(observer.BlockAccountObserver, r, w, event, callBackFunc, readyChan)
 		default:
 			if ba, err = block.GetBlockAccount(storage, address); err != nil {
 				http.Error(w, "Error reading request body", http.StatusInternalServerError)
@@ -118,7 +118,7 @@ func GetAccountTransactionsHandler(storage *sebakstorage.LevelDBBackend) http.Ha
 
 			event := fmt.Sprintf("iterate-%s", iterateId)
 			event += " " + fmt.Sprintf("source-%s", address)
-			streaming(observer.BlockTransactionObserver, w, event, callBackFunc, readyChan)
+			streaming(observer.BlockTransactionObserver, r, w, event, callBackFunc, readyChan)
 		default:
 
 			var btl []BlockTransaction
@@ -182,7 +182,7 @@ func GetAccountOperationsHandler(storage *sebakstorage.LevelDBBackend) http.Hand
 			}
 			event := fmt.Sprintf("iterate-%s", iterateId)
 			event += " " + fmt.Sprintf("source-%s", address)
-			streaming(observer.BlockOperationObserver, w, event, callBackFunc, readyChan)
+			streaming(observer.BlockOperationObserver, r, w, event, callBackFunc, readyChan)
 		default:
 
 			var bol []BlockOperation

--- a/lib/api_transaction.go
+++ b/lib/api_transaction.go
@@ -46,7 +46,7 @@ func GetTransactionsHandler(storage *sebakstorage.LevelDBBackend) http.HandlerFu
 			}
 			event := "saved"
 			event += " " + fmt.Sprintf("iterate-%s", iterateId)
-			streaming(observer.BlockTransactionObserver, w, event, callBackFunc, readyChan)
+			streaming(observer.BlockTransactionObserver, r, w, event, callBackFunc, readyChan)
 		default:
 
 			var s []byte
@@ -105,7 +105,7 @@ func GetTransactionByHashHandler(storage *sebakstorage.LevelDBBackend) http.Hand
 
 			event := fmt.Sprintf("iterate-%s", iterateId)
 			event += " " + fmt.Sprintf("hash-%s", key)
-			streaming(observer.BlockTransactionObserver, w, event, callBackFunc, readyChan)
+			streaming(observer.BlockTransactionObserver, r, w, event, callBackFunc, readyChan)
 		default:
 
 			var s []byte


### PR DESCRIPTION
```
According to the official Golang documentation, CloseNotifier predates Context,
and the former is deprecated in favor of the later.
```