### PR TITLE
Drop EOL Go 1.9; Add Go 1.11 and use it as default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/boscoin.io/sebak
   docker:
-    - image: circleci/golang:1.10
+    - image: circleci/golang:1.11
 
 workspace: &workspace
   attach_workspace:
@@ -51,9 +51,9 @@ jobs:
           name: run tests
           command: SEBAK_LOG_HANDLER=null GOCACHE=off go test -v -timeout 3m ./...
 
-  test_go1_9:
+  test_go1_11:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.11
     working_directory: /go/src/boscoin.io/sebak
     steps:
       - <<: *workspace
@@ -121,7 +121,7 @@ workflows:
       - test_go1_10:
           requires:
             - fmt
-      - test_go1_9:
+      - test_go1_11:
           requires:
             - fmt
       - generate_merged_tree:

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -18,10 +18,10 @@ type ISAAC struct {
 
 func NewISAAC(networkID []byte, node *sebaknode.LocalNode, votingThresholdPolicy sebakcommon.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		networkID: networkID,
-		Node:      node,
+		networkID:             networkID,
+		Node:                  node,
 		VotingThresholdPolicy: votingThresholdPolicy,
-		Boxes: NewBallotBoxes(),
+		Boxes:                 NewBallotBoxes(),
 	}
 
 	return


### PR DESCRIPTION
It was released a few days ago.
The docker images where dropped.
We depend on the CircleCI image which might be supported a bit longer, but let's update sooner than later.