### PR TITLE
Add conf for ISAAC timeout features

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -65,7 +65,7 @@ var (
 	timeoutSIGN       time.Duration
 	timeoutACCEPT     time.Duration
 	timeoutALLCONFIRM time.Duration
-	transactionsLimit int
+	transactionsLimit uint64
 	logLevel          logging.Lvl
 	log               logging.Logger
 )
@@ -210,60 +210,39 @@ func parseFlagsNode() {
 		common.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
-	var tmpInt int
-	if tmpInt, err = strconv.Atoi(flagTimeoutINIT); err != nil {
+	var tmpUint64 uint64
+	if tmpUint64, err = strconv.ParseUint(flagTimeoutINIT, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-init", err)
-		timeoutINIT = 0
 	} else {
-		if tmpInt > 0 {
-			timeoutINIT = time.Duration(tmpInt) * time.Second
-		} else {
-			timeoutINIT = 0
-		}
+		timeoutINIT = time.Duration(tmpUint64) * time.Second
 	}
 
-	if tmpInt, err = strconv.Atoi(flagTimeoutSIGN); err != nil {
+	if tmpUint64, err = strconv.ParseUint(flagTimeoutSIGN, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-sign", err)
-		timeoutSIGN = 0
 	} else {
-		if tmpInt > 0 {
-			timeoutSIGN = time.Duration(tmpInt) * time.Second
-		} else {
-			timeoutSIGN = 0
-		}
+		timeoutSIGN = time.Duration(tmpUint64) * time.Second
 	}
 
-	if tmpInt, err = strconv.Atoi(flagTimeoutACCEPT); err != nil {
+	if tmpUint64, err = strconv.ParseUint(flagTimeoutACCEPT, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-accept", err)
-		timeoutACCEPT = 0
 	} else {
-		if tmpInt > 0 {
-			timeoutACCEPT = time.Duration(tmpInt) * time.Second
-		} else {
-			timeoutACCEPT = 0
-		}
+		timeoutACCEPT = time.Duration(tmpUint64) * time.Second
 	}
 
-	if tmpInt, err = strconv.Atoi(flagTimeoutALLCONFIRM); err != nil {
+	if tmpUint64, err = strconv.ParseUint(flagTimeoutALLCONFIRM, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-allconfirm", err)
-		timeoutALLCONFIRM = 0
 	} else {
-		if tmpInt > 0 {
-			timeoutALLCONFIRM = time.Duration(tmpInt) * time.Second
-		} else {
-			timeoutALLCONFIRM = 0
-		}
+		timeoutALLCONFIRM = time.Duration(tmpUint64) * time.Second
 	}
 
-	if transactionsLimit, err = strconv.Atoi(flagTransactionsLimit); err != nil {
+	if transactionsLimit, err = strconv.ParseUint(flagTransactionsLimit, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--transactions-limit", err)
-		if transactionsLimit < 0 {
-			transactionsLimit = 0
-		}
 	}
 
-	if threshold, err = strconv.Atoi(flagThreshold); err != nil {
+	if tmpUint64, err = strconv.ParseUint(flagThreshold, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--threshold", err)
+	} else {
+		threshold = int(tmpUint64)
 	}
 
 	if logLevel, err = logging.LvlFromString(flagLogLevel); err != nil {

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -210,35 +210,16 @@ func parseFlagsNode() {
 		common.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
-	var tmpUint64 uint64
-	if tmpUint64, err = strconv.ParseUint(flagTimeoutINIT, 10, 64); err != nil {
-		common.PrintFlagsError(nodeCmd, "--timeout-init", err)
-	} else {
-		timeoutINIT = time.Duration(tmpUint64) * time.Second
-	}
-
-	if tmpUint64, err = strconv.ParseUint(flagTimeoutSIGN, 10, 64); err != nil {
-		common.PrintFlagsError(nodeCmd, "--timeout-sign", err)
-	} else {
-		timeoutSIGN = time.Duration(tmpUint64) * time.Second
-	}
-
-	if tmpUint64, err = strconv.ParseUint(flagTimeoutACCEPT, 10, 64); err != nil {
-		common.PrintFlagsError(nodeCmd, "--timeout-accept", err)
-	} else {
-		timeoutACCEPT = time.Duration(tmpUint64) * time.Second
-	}
-
-	if tmpUint64, err = strconv.ParseUint(flagTimeoutALLCONFIRM, 10, 64); err != nil {
-		common.PrintFlagsError(nodeCmd, "--timeout-allconfirm", err)
-	} else {
-		timeoutALLCONFIRM = time.Duration(tmpUint64) * time.Second
-	}
+	timeoutINIT = getTimeout(flagTimeoutINIT, "--timeout-init")
+	timeoutSIGN = getTimeout(flagTimeoutSIGN, "--timeout-sign")
+	timeoutACCEPT = getTimeout(flagTimeoutACCEPT, "--timeout-accept")
+	timeoutALLCONFIRM = getTimeout(flagTimeoutALLCONFIRM, "--timeout-allconfirm")
 
 	if transactionsLimit, err = strconv.ParseUint(flagTransactionsLimit, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--transactions-limit", err)
 	}
 
+	var tmpUint64 uint64
 	if tmpUint64, err = strconv.ParseUint(flagThreshold, 10, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--threshold", err)
 	} else {
@@ -299,6 +280,16 @@ func parseFlagsNode() {
 	if flagVerbose {
 		http2.VerboseLogs = true
 	}
+}
+
+func getTimeout(timeoutStr string, errMessage string) time.Duration {
+	var timeoutDuration time.Duration
+	if tmpUint64, err := strconv.ParseUint(flagTimeoutINIT, 10, 64); err != nil {
+		common.PrintFlagsError(nodeCmd, errMessage, err)
+	} else {
+		timeoutDuration = time.Duration(tmpUint64) * time.Second
+	}
+	return timeoutDuration
 }
 
 func runNode() {

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -215,32 +215,51 @@ func parseFlagsNode() {
 		common.PrintFlagsError(nodeCmd, "--timeout-init", err)
 		timeoutINIT = 0
 	} else {
-		timeoutINIT = time.Duration(tmpInt) * time.Second
+		if tmpInt > 0 {
+			timeoutINIT = time.Duration(tmpInt) * time.Second
+		} else {
+			timeoutINIT = 0
+		}
 	}
 
 	if tmpInt, err = strconv.Atoi(flagTimeoutSIGN); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-sign", err)
 		timeoutSIGN = 0
 	} else {
-		timeoutSIGN = time.Duration(tmpInt) * time.Second
+		if tmpInt > 0 {
+			timeoutSIGN = time.Duration(tmpInt) * time.Second
+		} else {
+			timeoutSIGN = 0
+		}
 	}
 
 	if tmpInt, err = strconv.Atoi(flagTimeoutACCEPT); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-accept", err)
 		timeoutACCEPT = 0
 	} else {
-		timeoutACCEPT = time.Duration(tmpInt) * time.Second
+		if tmpInt > 0 {
+			timeoutACCEPT = time.Duration(tmpInt) * time.Second
+		} else {
+			timeoutACCEPT = 0
+		}
 	}
 
 	if tmpInt, err = strconv.Atoi(flagTimeoutALLCONFIRM); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-allconfirm", err)
 		timeoutALLCONFIRM = 0
 	} else {
-		timeoutALLCONFIRM = time.Duration(tmpInt) * time.Second
+		if tmpInt > 0 {
+			timeoutALLCONFIRM = time.Duration(tmpInt) * time.Second
+		} else {
+			timeoutALLCONFIRM = 0
+		}
 	}
 
 	if transactionsLimit, err = strconv.Atoi(flagTransactionsLimit); err != nil {
 		common.PrintFlagsError(nodeCmd, "--transactions-limit", err)
+		if transactionsLimit < 0 {
+			transactionsLimit = 0
+		}
 	}
 
 	if threshold, err = strconv.Atoi(flagThreshold); err != nil {
@@ -352,6 +371,9 @@ func runNode() {
 		}
 		if timeoutALLCONFIRM != 0 {
 			conf.TimeoutALLCONFIRM = timeoutALLCONFIRM
+		}
+		if transactionsLimit != 0 {
+			conf.TransactionsLimit = uint64(transactionsLimit)
 		}
 
 		if err != nil {

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -210,29 +210,33 @@ func parseFlagsNode() {
 		common.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
-	var tmpFloat float64
-	if tmpFloat, err = strconv.ParseFloat(flagTimeoutINIT, 64); err != nil {
+	var tmpInt int
+	if tmpInt, err = strconv.Atoi(flagTimeoutINIT); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-init", err)
+		timeoutINIT = 0
 	} else {
-		timeoutINIT = time.Duration(tmpFloat)
+		timeoutINIT = time.Duration(tmpInt) * time.Second
 	}
 
-	if tmpFloat, err = strconv.ParseFloat(flagTimeoutSIGN, 64); err != nil {
+	if tmpInt, err = strconv.Atoi(flagTimeoutSIGN); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-sign", err)
+		timeoutSIGN = 0
 	} else {
-		timeoutSIGN = time.Duration(tmpFloat)
+		timeoutSIGN = time.Duration(tmpInt) * time.Second
 	}
 
-	if tmpFloat, err = strconv.ParseFloat(flagTimeoutACCEPT, 64); err != nil {
+	if tmpInt, err = strconv.Atoi(flagTimeoutACCEPT); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-accept", err)
+		timeoutACCEPT = 0
 	} else {
-		timeoutACCEPT = time.Duration(tmpFloat)
+		timeoutACCEPT = time.Duration(tmpInt) * time.Second
 	}
 
-	if tmpFloat, err = strconv.ParseFloat(flagTimeoutALLCONFIRM, 64); err != nil {
+	if tmpInt, err = strconv.Atoi(flagTimeoutALLCONFIRM); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-allconfirm", err)
+		timeoutALLCONFIRM = 0
 	} else {
-		timeoutALLCONFIRM = time.Duration(tmpFloat)
+		timeoutALLCONFIRM = time.Duration(tmpInt) * time.Second
 	}
 
 	if transactionsLimit, err = strconv.Atoi(flagTransactionsLimit); err != nil {
@@ -260,9 +264,9 @@ func parseFlagsNode() {
 	logHandler = logging.CallerFileHandler(logHandler)
 
 	log = logging.New("module", "main")
-	log.SetHandler(logging.LvlFilterHandler(logging.LvlInfo, logHandler))
-	sebak.SetLogging(logging.LvlInfo, logHandler)
-	sebaknetwork.SetLogging(logging.LvlInfo, logHandler)
+	log.SetHandler(logging.LvlFilterHandler(logLevel, logHandler))
+	sebak.SetLogging(logLevel, logHandler)
+	sebaknetwork.SetLogging(logLevel, logHandler)
 
 	log.Info("Starting Sebak")
 
@@ -337,7 +341,11 @@ func runNode() {
 	{
 		nr, err := sebak.NewNodeRunner(flagNetworkID, localNode, policy, nt, isaac, st)
 		conf := sebak.NewNodeRunnerConfiguration()
-		conf.SetINIT(timeoutINIT).SetSIGN(timeoutSIGN).SetACCEPT(timeoutACCEPT).SetALLCONFIRM(timeoutALLCONFIRM).SetTxLimit(transactionsLimit)
+		conf.TimeoutINIT = timeoutINIT
+		conf.TimeoutSIGN = timeoutSIGN
+		conf.TimeoutACCEPT = timeoutACCEPT
+		conf.TimeoutALLCONFIRM = timeoutALLCONFIRM
+
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -46,11 +46,11 @@ var (
 	flagTLSKeyFile          string = sebakcommon.GetENVValue("SEBAK_TLS_KEY", "sebak.key")
 	flagValidators          string = sebakcommon.GetENVValue("SEBAK_VALIDATORS", "")
 	flagThreshold           string = sebakcommon.GetENVValue("SEBAK_THRESHOLD", "66")
-	flagTimeoutINIT         string = sebakcommon.GetENVValue("TIMEOUT_INIT", "2")
-	flagTimeoutSIGN         string = sebakcommon.GetENVValue("TIMEOUT_SIGN", "2")
-	flagTimeoutACCEPT       string = sebakcommon.GetENVValue("TIMEOUT_ACCEPT", "2")
-	flagTimeoutALLCONFIRM   string = sebakcommon.GetENVValue("TIMEOUT_ALLCONFIRM", "2")
-	flagTransactionsLimit   string = sebakcommon.GetENVValue("TRANSACTIONS_LIMIT", "1000")
+	flagTimeoutINIT         string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_INIT", "2")
+	flagTimeoutSIGN         string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_SIGN", "2")
+	flagTimeoutACCEPT       string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_ACCEPT", "2")
+	flagTimeoutALLCONFIRM   string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_ALLCONFIRM", "2")
+	flagTransactionsLimit   string = sebakcommon.GetENVValue("SEBAK_TRANSACTIONS_LIMIT", "1000")
 )
 
 var (
@@ -289,6 +289,9 @@ func getTimeout(timeoutStr string, errMessage string) time.Duration {
 	} else {
 		timeoutDuration = time.Duration(tmpUint64) * time.Second
 	}
+	if timeoutDuration == 0 {
+		timeoutDuration = 2 * time.Second
+	}
 	return timeoutDuration
 }
 
@@ -329,22 +332,14 @@ func runNode() {
 	var g run.Group
 	{
 		nr, err := sebak.NewNodeRunner(flagNetworkID, localNode, policy, nt, isaac, st)
-		conf := sebak.NewNodeRunnerConfiguration()
-		if timeoutINIT != 0 {
-			conf.TimeoutINIT = timeoutINIT
+		conf := &sebak.NodeRunnerConfiguration{
+			TimeoutINIT:       timeoutINIT,
+			TimeoutSIGN:       timeoutSIGN,
+			TimeoutACCEPT:     timeoutACCEPT,
+			TimeoutALLCONFIRM: timeoutALLCONFIRM,
+			TransactionsLimit: uint64(transactionsLimit),
 		}
-		if timeoutSIGN != 0 {
-			conf.TimeoutSIGN = timeoutSIGN
-		}
-		if timeoutACCEPT != 0 {
-			conf.TimeoutACCEPT = timeoutACCEPT
-		}
-		if timeoutALLCONFIRM != 0 {
-			conf.TimeoutALLCONFIRM = timeoutALLCONFIRM
-		}
-		if transactionsLimit != 0 {
-			conf.TransactionsLimit = uint64(transactionsLimit)
-		}
+		nr.SetConf(conf)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -341,10 +341,18 @@ func runNode() {
 	{
 		nr, err := sebak.NewNodeRunner(flagNetworkID, localNode, policy, nt, isaac, st)
 		conf := sebak.NewNodeRunnerConfiguration()
-		conf.TimeoutINIT = timeoutINIT
-		conf.TimeoutSIGN = timeoutSIGN
-		conf.TimeoutACCEPT = timeoutACCEPT
-		conf.TimeoutALLCONFIRM = timeoutALLCONFIRM
+		if timeoutINIT != 0 {
+			conf.TimeoutINIT = timeoutINIT
+		}
+		if timeoutSIGN != 0 {
+			conf.TimeoutSIGN = timeoutSIGN
+		}
+		if timeoutACCEPT != 0 {
+			conf.TimeoutACCEPT = timeoutACCEPT
+		}
+		if timeoutALLCONFIRM != 0 {
+			conf.TimeoutALLCONFIRM = timeoutALLCONFIRM
+		}
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -126,8 +126,8 @@ func init() {
 	nodeCmd.Flags().StringVar(&flagThreshold, "threshold", flagThreshold, "threshold")
 	nodeCmd.Flags().StringVar(&flagTimeoutINIT, "timeout-init", flagTimeoutINIT, "timeout of the init state")
 	nodeCmd.Flags().StringVar(&flagTimeoutSIGN, "timeout-sign", flagTimeoutSIGN, "timeout of the sign state")
-	nodeCmd.Flags().StringVar(&flagTimeoutACCEPT, "timeout-accept", flagTimeoutACCEPT, "timeout of  the accept state")
-	nodeCmd.Flags().StringVar(&flagTimeoutALLCONFIRM, "timeout-allconfirm", flagTimeoutALLCONFIRM, "timeout for the allconfirm state")
+	nodeCmd.Flags().StringVar(&flagTimeoutACCEPT, "timeout-accept", flagTimeoutACCEPT, "timeout of the accept state")
+	nodeCmd.Flags().StringVar(&flagTimeoutALLCONFIRM, "timeout-allconfirm", flagTimeoutALLCONFIRM, "timeout of the allconfirm state")
 	nodeCmd.Flags().StringVar(&flagTransactionsLimit, "transactions-limit", flagTransactionsLimit, "transactions limit in a ballot")
 
 	rootCmd.AddCommand(nodeCmd)

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/net/http2"
 
@@ -60,10 +61,10 @@ var (
 	storageConfig     *sebakstorage.Config
 	validators        []*sebaknode.Validator
 	threshold         int
-	timeoutINIT       float64
-	timeoutSIGN       float64
-	timeoutACCEPT     float64
-	timeoutALLCONFIRM float64
+	timeoutINIT       time.Duration
+	timeoutSIGN       time.Duration
+	timeoutACCEPT     time.Duration
+	timeoutALLCONFIRM time.Duration
 	transactionsLimit int
 	logLevel          logging.Lvl
 	log               logging.Logger
@@ -209,20 +210,29 @@ func parseFlagsNode() {
 		common.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
-	if timeoutINIT, err = strconv.ParseFloat(flagTimeoutINIT, 64); err != nil {
+	var tmpFloat float64
+	if tmpFloat, err = strconv.ParseFloat(flagTimeoutINIT, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-init", err)
+	} else {
+		timeoutINIT = time.Duration(tmpFloat)
 	}
 
-	if timeoutSIGN, err = strconv.ParseFloat(flagTimeoutSIGN, 64); err != nil {
+	if tmpFloat, err = strconv.ParseFloat(flagTimeoutSIGN, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-sign", err)
+	} else {
+		timeoutSIGN = time.Duration(tmpFloat)
 	}
 
-	if timeoutACCEPT, err = strconv.ParseFloat(flagTimeoutACCEPT, 64); err != nil {
+	if tmpFloat, err = strconv.ParseFloat(flagTimeoutACCEPT, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-accept", err)
+	} else {
+		timeoutACCEPT = time.Duration(tmpFloat)
 	}
 
-	if timeoutALLCONFIRM, err = strconv.ParseFloat(flagTimeoutALLCONFIRM, 64); err != nil {
+	if tmpFloat, err = strconv.ParseFloat(flagTimeoutALLCONFIRM, 64); err != nil {
 		common.PrintFlagsError(nodeCmd, "--timeout-allconfirm", err)
+	} else {
+		timeoutALLCONFIRM = time.Duration(tmpFloat)
 	}
 
 	if transactionsLimit, err = strconv.Atoi(flagTransactionsLimit); err != nil {
@@ -327,8 +337,7 @@ func runNode() {
 	{
 		nr, err := sebak.NewNodeRunner(flagNetworkID, localNode, policy, nt, isaac, st)
 		conf := sebak.NewNodeRunnerConfiguration()
-		conf.SetINIT(timeoutINIT).SetSIGN(timeoutSIGN).SetACCEPT(timeoutACCEPT).SetALLCONFIRM(timeoutALLCONFIRM)
-		// nr.SetConf(conf)
+		conf.SetINIT(timeoutINIT).SetSIGN(timeoutSIGN).SetACCEPT(timeoutACCEPT).SetALLCONFIRM(timeoutALLCONFIRM).SetTxLimit(transactionsLimit)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -313,7 +313,7 @@ func (nr *NodeRunner) handleBallotMessage(message sebaknetwork.Message) (err err
 	err = sebakcommon.RunChecker(baseChecker, nr.handleMessageCheckerDeferFunc)
 	if err != nil {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
-			nr.log.Error("failed to handle ballot", "error", err, "state", "base")
+			nr.log.Error("failed to handle ballot", "error", err, "nodeRunnerStateManager", "base")
 			return
 		}
 	}
@@ -343,7 +343,7 @@ func (nr *NodeRunner) handleBallotMessage(message sebaknetwork.Message) (err err
 	err = sebakcommon.RunChecker(checker, nr.handleMessageCheckerDeferFunc)
 	if err != nil {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
-			nr.log.Error("failed to handle ballot", "error", err, "state", baseChecker.Ballot.State())
+			nr.log.Error("failed to handle ballot", "error", err, "nodeRunnerStateManager", baseChecker.Ballot.State())
 			return
 		}
 	}

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -313,7 +313,7 @@ func (nr *NodeRunner) handleBallotMessage(message sebaknetwork.Message) (err err
 	err = sebakcommon.RunChecker(baseChecker, nr.handleMessageCheckerDeferFunc)
 	if err != nil {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
-			nr.log.Error("failed to handle ballot", "error", err, "nodeRunnerStateManager", "base")
+			nr.log.Error("failed to handle ballot", "error", err, "state", "base")
 			return
 		}
 	}
@@ -343,7 +343,7 @@ func (nr *NodeRunner) handleBallotMessage(message sebaknetwork.Message) (err err
 	err = sebakcommon.RunChecker(checker, nr.handleMessageCheckerDeferFunc)
 	if err != nil {
 		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
-			nr.log.Error("failed to handle ballot", "error", err, "nodeRunnerStateManager", baseChecker.Ballot.State())
+			nr.log.Error("failed to handle ballot", "error", err, "state", baseChecker.Ballot.State())
 			return
 		}
 	}

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -148,6 +148,9 @@ func (nr *NodeRunner) SetProposerCalculator(c ProposerCalculator) {
 	nr.proposerCalculator = c
 }
 
+func (nr *NodeRunner) SetConf(conf *NodeRunnerConfiguration) {
+}
+
 func (nr *NodeRunner) Ready() {
 	nr.network.SetContext(nr.ctx)
 	nr.network.AddHandler(nr.ctx, AddAPIHandlers(nr.storage))

--- a/lib/node_runner_configuration.go
+++ b/lib/node_runner_configuration.go
@@ -17,33 +17,19 @@ type NodeRunnerConfiguration struct {
 	TimeoutACCEPT     time.Duration
 	TimeoutALLCONFIRM time.Duration
 
-	TransactionsLimit int
+	TransactionsLimit uint64
 }
 
 func NewNodeRunnerConfiguration() *NodeRunnerConfiguration {
 	p := NodeRunnerConfiguration{}
-	p.SetINIT(2).SetSIGN(2).SetACCEPT(2).SetALLCONFIRM(2).SetTxLimit(1000)
+
+	p.TimeoutINIT = 2 * time.Second
+	p.TimeoutSIGN = 2 * time.Second
+	p.TimeoutACCEPT = 2 * time.Second
+	p.TimeoutALLCONFIRM = 2 * time.Second
+	p.TransactionsLimit = uint64(1000)
+
 	return &p
-}
-
-func (n *NodeRunnerConfiguration) SetINIT(t time.Duration) *NodeRunnerConfiguration {
-	n.TimeoutINIT = t
-	return n
-}
-
-func (n *NodeRunnerConfiguration) SetSIGN(t time.Duration) *NodeRunnerConfiguration {
-	n.TimeoutSIGN = t
-	return n
-}
-
-func (n *NodeRunnerConfiguration) SetACCEPT(t time.Duration) *NodeRunnerConfiguration {
-	n.TimeoutACCEPT = t
-	return n
-}
-
-func (n *NodeRunnerConfiguration) SetALLCONFIRM(t time.Duration) *NodeRunnerConfiguration {
-	n.TimeoutALLCONFIRM = t
-	return n
 }
 
 func (n *NodeRunnerConfiguration) GetTimeout(ballotState sebakcommon.BallotState) time.Duration {
@@ -57,9 +43,4 @@ func (n *NodeRunnerConfiguration) GetTimeout(ballotState sebakcommon.BallotState
 	default:
 		return 0
 	}
-}
-
-func (n *NodeRunnerConfiguration) SetTxLimit(i int) *NodeRunnerConfiguration {
-	n.TransactionsLimit = i
-	return n
 }

--- a/lib/node_runner_configuration.go
+++ b/lib/node_runner_configuration.go
@@ -26,23 +26,23 @@ func NewNodeRunnerConfiguration() *NodeRunnerConfiguration {
 	return &p
 }
 
-func (n *NodeRunnerConfiguration) SetINIT(f float64) *NodeRunnerConfiguration {
-	n.TimeoutINIT = Millisecond(f)
+func (n *NodeRunnerConfiguration) SetINIT(t time.Duration) *NodeRunnerConfiguration {
+	n.TimeoutINIT = t
 	return n
 }
 
-func (n *NodeRunnerConfiguration) SetSIGN(f float64) *NodeRunnerConfiguration {
-	n.TimeoutSIGN = Millisecond(f)
+func (n *NodeRunnerConfiguration) SetSIGN(t time.Duration) *NodeRunnerConfiguration {
+	n.TimeoutSIGN = t
 	return n
 }
 
-func (n *NodeRunnerConfiguration) SetACCEPT(f float64) *NodeRunnerConfiguration {
-	n.TimeoutACCEPT = Millisecond(f)
+func (n *NodeRunnerConfiguration) SetACCEPT(t time.Duration) *NodeRunnerConfiguration {
+	n.TimeoutACCEPT = t
 	return n
 }
 
-func (n *NodeRunnerConfiguration) SetALLCONFIRM(f float64) *NodeRunnerConfiguration {
-	n.TimeoutALLCONFIRM = Millisecond(f)
+func (n *NodeRunnerConfiguration) SetALLCONFIRM(t time.Duration) *NodeRunnerConfiguration {
+	n.TimeoutALLCONFIRM = t
 	return n
 }
 
@@ -62,8 +62,4 @@ func (n *NodeRunnerConfiguration) GetTimeout(ballotState sebakcommon.BallotState
 func (n *NodeRunnerConfiguration) SetTxLimit(i int) *NodeRunnerConfiguration {
 	n.TransactionsLimit = i
 	return n
-}
-
-func Millisecond(f float64) time.Duration {
-	return time.Millisecond * time.Duration(int(f*1000))
 }

--- a/lib/node_runner_configuration.go
+++ b/lib/node_runner_configuration.go
@@ -1,0 +1,71 @@
+//
+// Struct that bridges together components of a node
+//
+// NodeRunner bridges together the connection, storage and `LocalNode`.
+// In this regard, it can be seen as a single node, and is used as such
+// in unit tests.
+//
+package sebak
+
+import (
+	"time"
+
+	"boscoin.io/sebak/lib/common"
+)
+
+type NodeRunnerConfiguration struct {
+	TimeoutINIT       time.Duration
+	TimeoutSIGN       time.Duration
+	TimeoutACCEPT     time.Duration
+	TimeoutALLCONFIRM time.Duration
+
+	TransactionsLimit int
+}
+
+func NewNodeRunnerConfiguration() *NodeRunnerConfiguration {
+	p := NodeRunnerConfiguration{}
+	p.SetINIT(2).SetSIGN(2).SetACCEPT(2).SetALLCONFIRM(2).SetTxLimit(1000)
+	return &p
+}
+
+func (n *NodeRunnerConfiguration) SetINIT(f float64) *NodeRunnerConfiguration {
+	n.TimeoutINIT = Millisecond(f)
+	return n
+}
+
+func (n *NodeRunnerConfiguration) SetSIGN(f float64) *NodeRunnerConfiguration {
+	n.TimeoutSIGN = Millisecond(f)
+	return n
+}
+
+func (n *NodeRunnerConfiguration) SetACCEPT(f float64) *NodeRunnerConfiguration {
+	n.TimeoutACCEPT = Millisecond(f)
+	return n
+}
+
+func (n *NodeRunnerConfiguration) SetALLCONFIRM(f float64) *NodeRunnerConfiguration {
+	n.TimeoutALLCONFIRM = Millisecond(f)
+	return n
+}
+
+func (n *NodeRunnerConfiguration) GetTimeout(ballotState sebakcommon.BallotState) time.Duration {
+	switch ballotState {
+	case sebakcommon.BallotStateINIT:
+		return n.TimeoutINIT
+	case sebakcommon.BallotStateSIGN:
+		return n.TimeoutSIGN
+	case sebakcommon.BallotStateACCEPT:
+		return n.TimeoutACCEPT
+	default:
+		return 0
+	}
+}
+
+func (n *NodeRunnerConfiguration) SetTxLimit(i int) *NodeRunnerConfiguration {
+	n.TransactionsLimit = i
+	return n
+}
+
+func Millisecond(f float64) time.Duration {
+	return time.Millisecond * time.Duration(int(f*1000))
+}

--- a/lib/node_runner_configuration.go
+++ b/lib/node_runner_configuration.go
@@ -1,9 +1,7 @@
 //
-// Struct that bridges together components of a node
-//
-// NodeRunner bridges together the connection, storage and `LocalNode`.
-// In this regard, it can be seen as a single node, and is used as such
-// in unit tests.
+// NodeRunnerConfiguration has timeout features and transaction limit.
+// The NodeRunnerConfiguration is included in NodeRunnerStateManager and
+// these timeout features are used in ISAAC consensus.
 //
 package sebak
 

--- a/lib/node_runner_configuration_test.go
+++ b/lib/node_runner_configuration_test.go
@@ -1,35 +1,41 @@
-//
-// Struct that bridges together components of a node
-//
-// NodeRunner bridges together the connection, storage and `LocalNode`.
-// In this regard, it can be seen as a single node, and is used as such
-// in unit tests.
-//
+/*
+	In this file, there are unittests for checking NodeRunnerConfiguration struct.
+*/
 package sebak
 
 import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+/*
+	TestConfigurationDefault tests the default timeout values.
+*/
 func TestConfigurationDefault(t *testing.T) {
 	n := NewNodeRunnerConfiguration()
-	assert.Equal(t, n.TimeoutINIT, 2*time.Second)
-	assert.Equal(t, n.TimeoutSIGN, 2*time.Second)
-	assert.Equal(t, n.TimeoutACCEPT, 2*time.Second)
-	assert.Equal(t, n.TimeoutALLCONFIRM, 2*time.Second)
-	assert.Equal(t, n.TransactionsLimit, 1000)
+	require.Equal(t, n.TimeoutINIT, 2*time.Second)
+	require.Equal(t, n.TimeoutSIGN, 2*time.Second)
+	require.Equal(t, n.TimeoutACCEPT, 2*time.Second)
+	require.Equal(t, n.TimeoutALLCONFIRM, 2*time.Second)
+	require.Equal(t, uint64(1000), n.TransactionsLimit)
 }
 
+/*
+	TestConfigurationSetAndGet tests setting timeout fields and checking.
+*/
 func TestConfigurationSetAndGet(t *testing.T) {
 	n := NewNodeRunnerConfiguration()
-	n.SetINIT(3).SetSIGN(1).SetACCEPT(1).SetALLCONFIRM(2).SetTxLimit(500)
+	n.TimeoutINIT = 3 * time.Second
+	n.TimeoutSIGN = 1 * time.Second
+	n.TimeoutACCEPT = 1 * time.Second
+	n.TimeoutALLCONFIRM = 2 * time.Second
+	n.TransactionsLimit = uint64(500)
 
-	assert.Equal(t, n.TimeoutINIT, 3*time.Second)
-	assert.Equal(t, n.TimeoutSIGN, 1*time.Second)
-	assert.Equal(t, n.TimeoutACCEPT, 1*time.Second)
-	assert.Equal(t, n.TimeoutALLCONFIRM, 2*time.Second)
-	assert.Equal(t, n.TransactionsLimit, 500)
+	require.Equal(t, n.TimeoutINIT, 3*time.Second)
+	require.Equal(t, n.TimeoutSIGN, 1*time.Second)
+	require.Equal(t, n.TimeoutACCEPT, 1*time.Second)
+	require.Equal(t, n.TimeoutALLCONFIRM, 2*time.Second)
+	require.Equal(t, uint64(500), n.TransactionsLimit)
 }

--- a/lib/node_runner_configuration_test.go
+++ b/lib/node_runner_configuration_test.go
@@ -1,0 +1,35 @@
+//
+// Struct that bridges together components of a node
+//
+// NodeRunner bridges together the connection, storage and `LocalNode`.
+// In this regard, it can be seen as a single node, and is used as such
+// in unit tests.
+//
+package sebak
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfigurationDefault(t *testing.T) {
+	n := NewNodeRunnerConfiguration()
+	assert.Equal(t, n.TimeoutINIT, 2*time.Second)
+	assert.Equal(t, n.TimeoutSIGN, 2*time.Second)
+	assert.Equal(t, n.TimeoutACCEPT, 2*time.Second)
+	assert.Equal(t, n.TimeoutALLCONFIRM, 2*time.Second)
+	assert.Equal(t, n.TransactionsLimit, 1000)
+}
+
+func TestConfigurationSetAndGet(t *testing.T) {
+	n := NewNodeRunnerConfiguration()
+	n.SetINIT(3).SetSIGN(1).SetACCEPT(1).SetALLCONFIRM(2).SetTxLimit(500)
+
+	assert.Equal(t, n.TimeoutINIT, 3*time.Second)
+	assert.Equal(t, n.TimeoutSIGN, 1*time.Second)
+	assert.Equal(t, n.TimeoutACCEPT, 1*time.Second)
+	assert.Equal(t, n.TimeoutALLCONFIRM, 2*time.Second)
+	assert.Equal(t, n.TransactionsLimit, 500)
+}


### PR DESCRIPTION
### Background
This is second part of the new `ISAAC` implementation.
According to the new `ISAAC` design, 4 Timeout features are needed.
And I guess, the number of transactions in one block is needed to be set because we don't know the appropriate number yet. So we should experiment with these 5 features(4 timeout and 1 n of tx).

### Solution
Add these features.

### Comment
`NodeRunnerConfiguration` is included in `NodeRunnerStateManager` and it is set in run.go:331. `NodeRunnerStateManager` will be uploaded within next pr.
