### PR TITLE
Re-enable Go cache for builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - <<: *workspace
       - run:
           name: run tests
-          command: SEBAK_LOG_HANDLER=null GOCACHE=off go test -v -timeout 3m ./...
+          command: SEBAK_LOG_HANDLER=null go test -v -timeout 3m ./...
 
   test_go1_11:
     docker:
@@ -59,7 +59,7 @@ jobs:
       - <<: *workspace
       - run:
           name: run tests
-          command: SEBAK_LOG_HANDLER=null GOCACHE=off go test -v -timeout 3m ./...
+          command: SEBAK_LOG_HANDLER=null go test -v -timeout 3m ./...
 
   generate_merged_tree:
     <<: *defaults
@@ -88,7 +88,7 @@ jobs:
           name: run tests
           command: |
             for pkg in $(go list ./... | grep -v vendor); do
-                SEBAK_LOG_HANDLER=null GOCACHE=off go test -v -timeout 3m -coverprofile=profile.out "$pkg"
+                SEBAK_LOG_HANDLER=null go test -v -timeout 3m -coverprofile=profile.out "$pkg"
                 if [ -f profile.out ]; then
                     cat profile.out >> coverage.txt
                     rm profile.out


### PR DESCRIPTION
It should not be a problem, and setting it to off is deprecated.
See https://golang.org/doc/go1.11#gocache