### PR TITLE
Remove yet another assert library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -156,14 +156,6 @@
   revision = "d34b9ff171c21ad295489235aec8b6626023cd04"
 
 [[projects]]
-  digest = "1:4244266b65ea535b8ebd109a327720821707b59f9a37bda738946d52ec69442d"
-  name = "github.com/magiconair/properties"
-  packages = ["assert"]
-  pruneopts = "NT"
-  revision = "c2353362d570a7bfa228149c62842019201cfb71"
-  version = "v1.8.0"
-
-[[projects]]
   digest = "1:e0a9ecd540b69f570f96c593b713268aad428e4a25a98f23467c59e6f69ab880"
   name = "github.com/mattn/go-colorable"
   packages = ["."]

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/inconshreveable/log15 v0.0.0-20171019012758-0decfc6c20d9
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2 // indirect
-	github.com/magiconair/properties v1.8.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.3 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2 h1:hRGSmZu7j271trc9sneMrpOW7GN5ngLm8YUZIPzf394=
 github.com/lib/pq v0.0.0-20180327071824-d34b9ff171c2/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
-github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=
-github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3 h1:ns/ykhmWi7G9O+8a448SecJU3nSMBXJfqQkl0upE1jI=

--- a/lib/statedb/statedb_test.go
+++ b/lib/statedb/statedb_test.go
@@ -1,11 +1,13 @@
 package statedb
 
 import (
+	"testing"
+
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/trie"
-	"github.com/magiconair/properties/assert"
-	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestStateDB(t *testing.T) {
@@ -31,6 +33,6 @@ func TestStateDB(t *testing.T) {
 	{
 		stateDB := New(Root, trie.NewEthDatabase(st))
 		gotValueHash := stateDB.GetState("dummy", keyHash)
-		assert.Equal(t, gotValueHash, valueHash)
+		require.Equal(t, gotValueHash, valueHash)
 	}
 }


### PR DESCRIPTION
```
We already have one library we widely depends on for test,
no need for another dependency
```