### PR TITLE
Using API blueprint for API document

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,8 @@
+FORMAT: 1A
+HOST: https://localhost:12345/api
+
+# Sebak Client API
+SEBAK, the next BOScoin Tokennet with ISAAC consensus protocol 
+
+<!-- partial(v1/accounts.md) -->
+<!-- partial(v1/models.md) -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,23 @@
+# API documents with [API blueprint](https://apiblueprint.org/)
+
+Install [snowboard](https://github.com/bukalapak/snowboard).
+
+Generate HTML document:
+
+```
+$ snowboard html -o output API.md
+```
+
+Serve HTML document:
+
+```
+$ snowboard html -o output -s API.md
+```
+
+Open <http://localhost:8088>.
+
+Validate API document:
+
+```
+$ snowboard lint API.md
+```

--- a/docs/v1/accounts.md
+++ b/docs/v1/accounts.md
@@ -1,0 +1,18 @@
+# Group Accounts
+Account API
+
+## An account [/account/{address}]
+Retrieve all accounts
+
++ Parameters
+
+    + address: `GDVSXU343JMRBXGW3F5WLRMH6L6HFZ6IYMVMFSDUDJPNTXUGNOXC2R5Y` (string, required) - a public address
+
+### Retrieve an account [GET]
+Retrieve an account by the address
+
++ Response 200 (text/plain; charset=utf-8)
+
+       + Attributes (Account)
+
++ Response 404 (text/plain; charset=utf-8)

--- a/docs/v1/models.md
+++ b/docs/v1/models.md
@@ -1,0 +1,8 @@
+## Data Structures
+
+### Account
++ Address: GDVSXU343JMRBXGW3F5WLRMH6L6HFZ6IYMVMFSDUDJPNTXUGNOXC2R5Y (string, required)
++ Balance: 1000000000000 (string, required)
++ Checkpoint: 5q1dAkXXSBNnmYZU7XWQmGGev-5q1dAkXXSBNnmYZU7XWQmGGev (string, required)
++ CodeHash: null (string)
++ RootHash: 0x0000000000000000000000000000000000000000000000000000000000000000 (string, required)


### PR DESCRIPTION
### Github Issue
Related to #274

### Background
It's another approach for API document which is different with #300 . 
[API blueprint](https://apiblueprint.org/) is API document format.

### Pros
* API blueprint is compatible with markdown. So, it's human-readable in GitHub before generating HTML.
* It doesn't disrupt our source code. API document needs much text. I dislike too many comments above the source code.

### Cons
* We should care about API document. Because it is not generated from our source. We should write them. Otherwise, it will be outdated quickly.
* Default theme is not so good even though we can customize it.
* There is no "Try it out" feature.

<img width="1236" alt="2018-09-03 12 53 14" src="https://user-images.githubusercontent.com/390146/44966863-b573c680-af78-11e8-959c-64a602de1c7a.png">
