### PR TITLE
Negative wait group error in `TestNodeRunnerSaveBlock`

### DIFF
--- a/lib/node_runner_test.go
+++ b/lib/node_runner_test.go
@@ -272,7 +272,7 @@ func TestNodeRunnerSaveBlock(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(numberOfNodes)
 	checkerDeferFunc := func(n int, checker sebakcommon.Checker, err error) {
-		if _, ok := err.(sebakcommon.CheckerStop); !ok {
+		if _, ok := err.(CheckerStopCloseConsensus); !ok {
 			return
 		}
 		wg.Done()


### PR DESCRIPTION
### Github Issue

resolves #303 

### Solution
In `new-proposer` branch, there is some special error, [`CheckerStopCloseConsensus`](https://github.com/bosnet/sebak/blob/620aa454fcec13d81b8c975897ed10031ced584a/lib/node_runner_checker.go#L13). It will be occurred when consensus finished https://github.com/bosnet/sebak/blob/620aa454fcec13d81b8c975897ed10031ced584a/lib/node_runner_checker.go#L458

To check whether consensus is finished or not, checking `CheckerStopCloseConsensus` in defer func will be helpful.