### PR TITLE
Add FOSSA to check licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CLA assistant](https://cla-assistant.io/readme/badge/bosnet/sebak)](https://cla-assistant.io/bosnet/sebak)
 [![](https://tokei.rs/b1/github/bosnet/sebak?category=lines)](https://github.com/bosnet/sebak)
 [![codecov](https://codecov.io/gh/bosnet/sebak/branch/master/graph/badge.svg)](https://codecov.io/gh/bosnet/sebak)
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbosnet%2Fsebak.svg?type=shield)](https://app.fossa.io/projects/git%2Bgithub.com%2Fbosnet%2Fsebak?ref=badge_shield)
 
 SEBAK is the core node for [BOScoin](https://boscoin.io) Tokennet.
 
@@ -14,3 +15,6 @@ Please read our [Getting Started page](https://github.com/bosnet/sebak/wiki) on 
 ## Contribution
 
 We welcome contributions by the community. Please open issues for any bug you find, or for enhancement requests. Pull requests are also very welcome. Before submitting, please read the [contribution guidelines](CONTRIBUTING.md).
+
+## License
+[![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fbosnet%2Fsebak.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fbosnet%2Fsebak?ref=badge_large)


### PR DESCRIPTION
### Github Issue
N/A

### Background
As we discussed last week, we need to check if we violate licenses.

### Solution
FOSSA is a service to check licenses of dependencies which we are using.
[Current report](https://app.fossa.io/projects/git%2Bgithub.com%2Fbosnet%2Fsebak) is warning there is a possibility we violate licenses. I don't know what it means yet because of I'
ve never saw this kind of violation before.

<img width="1111" alt="2018-09-03 16 30 48" src="https://user-images.githubusercontent.com/390146/44973212-c29fae00-af96-11e8-873c-1d00e675f2d0.png">

We should check how to use it.