### PR TITLE
EventStream

### DIFF
--- a/lib/api_stream.go
+++ b/lib/api_stream.go
@@ -10,8 +10,8 @@ import (
 )
 
 type EventStream struct {
-	Events      []string
-	ContentType string
+	events      []string
+	contentType string
 	observer    *observable.Observable
 	beforeFunc  func()
 	onFunc      OnFunc
@@ -19,7 +19,8 @@ type EventStream struct {
 
 type OnFunc func(args ...interface{}) ([]byte, error)
 
-var DefaultContentType = "application/json"
+const DefaultContentType = "application/json"
+
 var OnSerializableFunc = func(args ...interface{}) ([]byte, error) {
 	s, ok := args[1].(common.Serializable)
 	if !ok {
@@ -35,14 +36,14 @@ var OnSerializableFunc = func(args ...interface{}) ([]byte, error) {
 
 func NewEventStream(ob *observable.Observable, event ...string) *EventStream {
 	e := &EventStream{
-		Events:   event,
+		events:   event,
 		observer: ob,
 	}
 	return e
 }
 
 func (s *EventStream) SetContentType(ct string) {
-	s.ContentType = ct
+	s.contentType = ct
 }
 
 func (s *EventStream) Before(beforeFunc func()) {
@@ -69,7 +70,7 @@ func (s *EventStream) Start(w http.ResponseWriter, r *http.Request) func() {
 		return func() {}
 	}
 
-	event := strings.Join(s.Events, " ")
+	event := strings.Join(s.events, " ")
 	msg := make(chan []byte)
 	stop := make(chan struct{})
 
@@ -109,10 +110,10 @@ func (s *EventStream) Start(w http.ResponseWriter, r *http.Request) func() {
 		go s.beforeFunc()
 	}
 
-	if s.ContentType == "" {
-		s.ContentType = DefaultContentType
+	if s.contentType == "" {
+		s.contentType = DefaultContentType
 	}
-	w.Header().Set("Content-Type", s.ContentType)
+	w.Header().Set("Content-Type", s.contentType)
 
 	return func() {
 		defer s.observer.Off(event, onFunc)

--- a/lib/api_stream.go
+++ b/lib/api_stream.go
@@ -6,22 +6,23 @@ import (
 	"strings"
 
 	common "boscoin.io/sebak/lib/common"
-	"github.com/GianlucaGuarini/go-observable"
+	observable "github.com/GianlucaGuarini/go-observable"
 )
-
-type EventStream struct {
-	events      []string
-	contentType string
-	observer    *observable.Observable
-	beforeFunc  func()
-	onFunc      OnFunc
-}
-
-type OnFunc func(args ...interface{}) ([]byte, error)
 
 const DefaultContentType = "application/json"
 
-var OnSerializableFunc = func(args ...interface{}) ([]byte, error) {
+type EventStream struct {
+	contentType string
+	renderFunc  RenderFunc
+	request     *http.Request
+	writer      http.ResponseWriter
+	flusher     http.Flusher
+	err         error
+}
+
+type RenderFunc func(args ...interface{}) ([]byte, error)
+
+var RenderSerializableFunc = func(args ...interface{}) ([]byte, error) {
 	s, ok := args[1].(common.Serializable)
 	if !ok {
 		return nil, fmt.Errorf("this is not serializable") // TODO(anarcher): Error type
@@ -34,69 +35,81 @@ var OnSerializableFunc = func(args ...interface{}) ([]byte, error) {
 	return bs, nil
 }
 
-func NewEventStream(ob *observable.Observable, event ...string) *EventStream {
-	e := &EventStream{
-		events:   event,
-		observer: ob,
+func NewDefaultEventStream(w http.ResponseWriter, r *http.Request) *EventStream {
+	return NewEventStream(w, r, RenderSerializableFunc, DefaultContentType)
+}
+
+func NewEventStream(w http.ResponseWriter, r *http.Request, renderFunc RenderFunc, ct string) *EventStream {
+	es := &EventStream{
+		request:     r,
+		writer:      w,
+		renderFunc:  renderFunc,
+		contentType: ct,
 	}
-	return e
-}
 
-func (s *EventStream) SetContentType(ct string) {
-	s.contentType = ct
-}
-
-func (s *EventStream) Before(beforeFunc func()) {
-	s.beforeFunc = beforeFunc
-}
-
-func (s *EventStream) On(onFunc OnFunc) {
-	s.onFunc = onFunc
-}
-
-func (s *EventStream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	s.Run(w, r)
-}
-
-func (s *EventStream) Run(w http.ResponseWriter, r *http.Request) {
-	s.Start(w, r)()
-}
-
-func (s *EventStream) Start(w http.ResponseWriter, r *http.Request) func() {
+	w.Header().Set("Content-Type", es.contentType)
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		es.err = fmt.Errorf("http: can't do chunked response ")
+	} else {
+		es.flusher = flusher
+	}
+
+	return es
+}
+
+func (s *EventStream) Render(args ...interface{}) {
+	if s.err != nil {
+		return
+	}
+	var bs []byte
+	var renderArgs []interface{}
+	renderArgs = append(renderArgs, "pre")
+	renderArgs = append(renderArgs, args...)
+	if payload, err := s.renderFunc(renderArgs...); err != nil {
+		bs = s.errMessage(err)
+	} else {
+		bs = payload
+	}
+
+	fmt.Fprintf(s.writer, "%s\n", bs)
+	s.flusher.Flush()
+}
+
+func (s *EventStream) Run(ob *observable.Observable, events ...string) {
+	s.Start(ob, events...)()
+}
+
+func (s *EventStream) Start(ob *observable.Observable, events ...string) func() {
+	if s.err != nil {
+		http.Error(s.writer, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return func() {}
 	}
 
-	event := strings.Join(s.events, " ")
+	event := strings.Join(events, " ")
 	msg := make(chan []byte)
 	stop := make(chan struct{})
 
 	onFunc := func(args ...interface{}) {
-		fn := s.onFunc
-		if fn == nil {
-			fn = OnSerializableFunc
-		}
-
 		var (
 			payload []byte
 			err     error
 		)
 
 		if len(args) > 1 {
-			payload, err = fn(args...)
+			payload, err = s.renderFunc(args...)
 		} else {
 			var as []interface{}
 			as = append(as, event)
 			as = append(as, args...)
-			payload, err = fn(as...)
+			payload, err = s.renderFunc(as...)
 		}
 
 		if err != nil {
 			//TODO(anarcher): We need error representation (e.g. HTTPError type?)
-			msg <- []byte(fmt.Sprintf("{ \"err\": \"%s\"}", err.Error()))
+			msg <- s.errMessage(err)
 		}
 		select {
 		case msg <- payload:
@@ -104,29 +117,24 @@ func (s *EventStream) Start(w http.ResponseWriter, r *http.Request) func() {
 			return
 		}
 	}
-	s.observer.On(event, onFunc)
-
-	if s.beforeFunc != nil {
-		go s.beforeFunc()
-	}
-
-	if s.contentType == "" {
-		s.contentType = DefaultContentType
-	}
-	w.Header().Set("Content-Type", s.contentType)
+	ob.On(event, onFunc)
 
 	return func() {
-		defer s.observer.Off(event, onFunc)
+		defer ob.Off(event, onFunc)
 
 		for {
 			select {
 			case payload := <-msg:
-				fmt.Fprintf(w, "%s\n", payload)
-				flusher.Flush()
-			case <-r.Context().Done():
+				fmt.Fprintf(s.writer, "%s\n", payload)
+				s.flusher.Flush()
+			case <-s.request.Context().Done():
 				close(stop)
 				return
 			}
 		}
 	}
+}
+
+func (s *EventStream) errMessage(err error) []byte {
+	return []byte(fmt.Sprintf("{ \"err\": \"%s\"}", err.Error()))
 }

--- a/lib/api_stream.go
+++ b/lib/api_stream.go
@@ -1,0 +1,131 @@
+package sebak
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	common "boscoin.io/sebak/lib/common"
+	"github.com/GianlucaGuarini/go-observable"
+)
+
+type EventStream struct {
+	Events      []string
+	ContentType string
+	observer    *observable.Observable
+	beforeFunc  func()
+	onFunc      OnFunc
+}
+
+type OnFunc func(args ...interface{}) ([]byte, error)
+
+var DefaultContentType = "application/json"
+var OnSerializableFunc = func(args ...interface{}) ([]byte, error) {
+	s, ok := args[1].(common.Serializable)
+	if !ok {
+		return nil, fmt.Errorf("this is not serializable") // TODO(anarcher): Error type
+	}
+
+	bs, err := s.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	return bs, nil
+}
+
+func NewEventStream(ob *observable.Observable, event ...string) *EventStream {
+	e := &EventStream{
+		Events:   event,
+		observer: ob,
+	}
+	return e
+}
+
+func (s *EventStream) SetContentType(ct string) {
+	s.ContentType = ct
+}
+
+func (s *EventStream) Before(beforeFunc func()) {
+	s.beforeFunc = beforeFunc
+}
+
+func (s *EventStream) On(onFunc OnFunc) {
+	s.onFunc = onFunc
+}
+
+func (s *EventStream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	s.Run(w, r)
+}
+
+func (s *EventStream) Run(w http.ResponseWriter, r *http.Request) {
+	s.Start(w, r)()
+}
+
+func (s *EventStream) Start(w http.ResponseWriter, r *http.Request) func() {
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return func() {}
+	}
+
+	event := strings.Join(s.Events, " ")
+	msg := make(chan []byte)
+	stop := make(chan struct{})
+
+	onFunc := func(args ...interface{}) {
+		fn := s.onFunc
+		if fn == nil {
+			fn = OnSerializableFunc
+		}
+
+		var (
+			payload []byte
+			err     error
+		)
+
+		if len(args) > 1 {
+			payload, err = fn(args...)
+		} else {
+			var as []interface{}
+			as = append(as, event)
+			as = append(as, args...)
+			payload, err = fn(as...)
+		}
+
+		if err != nil {
+			//TODO(anarcher): We need error representation (e.g. HTTPError type?)
+			msg <- []byte(fmt.Sprintf("{ \"err\": \"%s\"}", err.Error()))
+		}
+		select {
+		case msg <- payload:
+		case <-stop:
+			return
+		}
+	}
+	s.observer.On(event, onFunc)
+
+	if s.beforeFunc != nil {
+		go s.beforeFunc()
+	}
+
+	if s.ContentType == "" {
+		s.ContentType = DefaultContentType
+	}
+	w.Header().Set("Content-Type", s.ContentType)
+
+	return func() {
+		defer s.observer.Off(event, onFunc)
+
+		for {
+			select {
+			case payload := <-msg:
+				fmt.Fprintf(w, "%s\n", payload)
+				flusher.Flush()
+			case <-r.Context().Done():
+				close(stop)
+				return
+			}
+		}
+	}
+}

--- a/lib/api_stream_test.go
+++ b/lib/api_stream_test.go
@@ -1,0 +1,142 @@
+package sebak
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"boscoin.io/sebak/lib/block"
+	observable "github.com/GianlucaGuarini/go-observable"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIStreamRun(t *testing.T) {
+	tests := []struct {
+		name       string
+		makeStream func(*observable.Observable) *EventStream
+		trigger    func(*observable.Observable)
+		respFunc   func(testing.TB, *http.Response)
+	}{
+		{
+			"default",
+			func(ob *observable.Observable) *EventStream {
+				es := NewEventStream(ob, "test1")
+				return es
+			},
+			func(ob *observable.Observable) {
+				ob.Trigger("test1", block.NewBlockAccount("hello", 100, "tx1-tx1"))
+			},
+			func(t testing.TB, res *http.Response) {
+				s := bufio.NewScanner(res.Body)
+				s.Scan()
+
+				var ba block.BlockAccount
+				require.Nil(t, json.Unmarshal(s.Bytes(), &ba))
+				require.Nil(t, s.Err())
+				require.Equal(t, ba, *block.NewBlockAccount("hello", 100, "tx1-tx1"))
+			},
+		},
+		{
+			"onFunc",
+			func(ob *observable.Observable) *EventStream {
+				es := NewEventStream(ob, "test1")
+				es.On(func(args ...interface{}) ([]byte, error) {
+					s, ok := args[1].(*block.BlockAccount)
+					if !ok {
+						return nil, fmt.Errorf("this is not serializable")
+					}
+					bs, err := s.Serialize()
+					if err != nil {
+						return nil, err
+					}
+					return bs, nil
+
+				})
+				return es
+			},
+			func(ob *observable.Observable) {
+				ob.Trigger("test1", block.NewBlockAccount("hello", 100, "tx1-tx1"))
+			},
+			func(t testing.TB, res *http.Response) {
+				s := bufio.NewScanner(res.Body)
+				s.Scan()
+
+				var ba block.BlockAccount
+				require.Nil(t, json.Unmarshal(s.Bytes(), &ba))
+				require.Nil(t, s.Err())
+				require.Equal(t, ba, *block.NewBlockAccount("hello", 100, "tx1-tx1"))
+			},
+		},
+		{
+			"beforeFunc",
+			func(ob *observable.Observable) *EventStream {
+				es := NewEventStream(ob, "test1")
+				es.Before(func() {
+					ob.Trigger("test1", block.NewBlockAccount("hello", 100, "tx1-tx1"))
+				})
+				return es
+			},
+			nil,
+			func(t testing.TB, res *http.Response) {
+				s := bufio.NewScanner(res.Body)
+				s.Scan()
+
+				var ba block.BlockAccount
+				require.Nil(t, json.Unmarshal(s.Bytes(), &ba))
+				require.Nil(t, s.Err())
+				require.Equal(t, ba, *block.NewBlockAccount("hello", 100, "tx1-tx1"))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ready := make(chan chan struct{})
+			ob := observable.New()
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				es := test.makeStream(ob)
+				run := es.Start(w, r)
+
+				if test.trigger != nil {
+					c := <-ready
+					close(c)
+				}
+
+				run()
+			}))
+			defer ts.Close()
+
+			if test.trigger != nil {
+				go func() {
+					c := make(chan struct{})
+					ready <- c
+					<-c
+					test.trigger(ob)
+				}()
+			}
+
+			req, err := http.NewRequest("GET", ts.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, cancel := context.WithCancel(req.Context())
+			defer cancel()
+
+			req = req.WithContext(ctx)
+
+			res, err := ts.Client().Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer res.Body.Close()
+
+			test.respFunc(t, res)
+		})
+	}
+}


### PR DESCRIPTION
### Github Issue

Related to #299 

### Background

It is a refactoring `streaming` func


### Solution

I think we can use it like below:

```
event := fmt.Sprintf("address-%s", address)
es := NewDefaultEventStream(w, r)
es.Render(blk)
es.Run(observer.BlockAccountObserver, event)
```

- If you have an implementation of `common.Serializable` interface, You don't need to add `es.On(onFunc)`.  A `OnSerializableFunc` handle it by default.  it's optional. 
 

### Possible Drawbacks

- For testing, I have to do to `EventStream.Start` returns `func()`.  If we need other needs, we will change the `func` to `struct`.
- No source comment. If this PR is approved, I will add comments about it. 
- For preventing data race condition, we should use  `go-observable@dev` branch.  It has already contained our `Gopkg.lock`. :-) 

 