### PR TITLE
received data may not ordered. do not check the sequence

### DIFF
--- a/lib/api_test.go
+++ b/lib/api_test.go
@@ -218,10 +218,8 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 
 	require.Equal(t, len(btmap), len(receivedBts), "length is not same")
 
-	i := 0
 	for _, bt := range receivedBts {
 		require.Equal(t, bt.Hash, btmap[bt.Hash].Hash, "hash is not same")
-		i++
 	}
 }
 
@@ -324,10 +322,8 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 
 	require.Equal(t, len(bomap), len(receivedBos), "length is not same")
 
-	i := 0
 	for _, bo := range receivedBos {
 		require.Equal(t, bo.Hash, bomap[bo.Hash].Hash, "hash is not same")
-		i++
 	}
 }
 
@@ -479,9 +475,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 
 	require.Equal(t, len(receivedBts), len(receivedBts), "length is not same")
 
-	i := 0
 	for _, bt := range receivedBts {
 		require.Equal(t, bt.Hash, btmap[bt.Hash].Hash, "hash is not same")
-		i++
 	}
 }

--- a/lib/api_test.go
+++ b/lib/api_test.go
@@ -142,7 +142,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	kp, err := keypair.Random()
 	require.Nil(t, err)
 
-	var bts []BlockTransaction
+	var btmap = make(map[string]BlockTransaction)
 	for i := 0; i < 5; i++ {
 		tx := TestMakeTransactionWithKeypair(networkID, 1, kp)
 
@@ -151,7 +151,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 		bt := NewBlockTransactionFromTransaction(tx, a)
 		err = bt.Save(storage)
 		require.Nil(t, err)
-		bts = append(bts, bt)
+		btmap[bt.Hash] = bt
 	}
 
 	// Do a Request
@@ -180,7 +180,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 			if !assert.Nil(t, err) {
 				panic(err)
 			}
-			bts = append(bts, bt)
+			btmap[bt.Hash] = bt
 			if i < 10 {
 				recv <- struct{}{}
 			}
@@ -195,7 +195,9 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 		line, err := reader.ReadBytes('\n')
 		require.Nil(t, err)
 		line = bytes.Trim(line, "\n\t ")
-		txS, err := bts[n].Serialize()
+		var receivedBt BlockTransaction
+		json.Unmarshal(line, &receivedBt)
+		txS, err := btmap[receivedBt.Hash].Serialize()
 		require.Nil(t, err)
 		require.Equal(t, txS, line)
 	}
@@ -214,11 +216,11 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	var receivedBts []BlockTransaction
 	json.Unmarshal(readByte, &receivedBts)
 
-	require.Equal(t, len(bts), len(receivedBts), "length is not same")
+	require.Equal(t, len(btmap), len(receivedBts), "length is not same")
 
 	i := 0
-	for _, bt := range bts {
-		require.Equal(t, bt.Hash, receivedBts[i].Hash, "hash is not same")
+	for _, bt := range receivedBts {
+		require.Equal(t, bt.Hash, btmap[bt.Hash].Hash, "hash is not same")
 		i++
 	}
 }
@@ -239,7 +241,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 	kp, err := keypair.Random()
 	require.Nil(t, err)
 
-	var bos []BlockOperation
+	var bomap = make(map[string]BlockOperation)
 	for i := 0; i < 5; i++ {
 		tx := TestMakeTransactionWithKeypair(networkID, 3, kp)
 		a, err := tx.Serialize()
@@ -251,7 +253,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 			var bo BlockOperation
 			bo, err = GetBlockOperation(storage, boHash)
 			require.Nil(t, err)
-			bos = append(bos, bo)
+			bomap[bo.Hash] = bo
 		}
 	}
 	// Do a Request
@@ -283,7 +285,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 				if !assert.Nil(t, err) {
 					panic(err)
 				}
-				bos = append(bos, bo)
+				bomap[bo.Hash] = bo
 			}
 			if i < 10 {
 				recv <- struct{}{}
@@ -299,7 +301,9 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 		line, err := reader.ReadBytes('\n')
 		require.Nil(t, err)
 		line = bytes.Trim(line, "\n\t ")
-		txS, err := bos[n].Serialize()
+		var receivedBo BlockOperation
+		json.Unmarshal(line, &receivedBo)
+		txS, err := bomap[receivedBo.Hash].Serialize()
 		require.Nil(t, err)
 		require.Equal(t, txS, line)
 	}
@@ -318,11 +322,11 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 	var receivedBos []BlockOperation
 	json.Unmarshal(readByte, &receivedBos)
 
-	require.Equal(t, len(bos), len(receivedBos), "length is not same")
+	require.Equal(t, len(bomap), len(receivedBos), "length is not same")
 
 	i := 0
-	for _, bo := range bos {
-		require.Equal(t, bo.Hash, receivedBos[i].Hash, "hash is not same")
+	for _, bo := range receivedBos {
+		require.Equal(t, bo.Hash, bomap[bo.Hash].Hash, "hash is not same")
 		i++
 	}
 }
@@ -400,7 +404,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
-	var bts []BlockTransaction
+	var btmap = make(map[string]BlockTransaction)
 	for i := 0; i < 5; i++ {
 		_, tx := TestMakeTransaction(networkID, 1)
 
@@ -409,7 +413,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 		bt := NewBlockTransactionFromTransaction(tx, a)
 		err = bt.Save(storage)
 		require.Nil(t, err)
-		bts = append(bts, bt)
+		btmap[bt.Hash] = bt
 	}
 
 	// Do a Request
@@ -438,7 +442,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			if !assert.Nil(t, err) {
 				panic(err)
 			}
-			bts = append(bts, bt)
+			btmap[bt.Hash] = bt
 			if i < 10 {
 				recv <- struct{}{}
 			}
@@ -452,7 +456,9 @@ func TestGetTransactionsHandler(t *testing.T) {
 		line, err := reader.ReadBytes('\n')
 		require.Nil(t, err)
 		line = bytes.Trim(line, "\n\t ")
-		txS, err := bts[n].Serialize()
+		var receivedBt BlockTransaction
+		json.Unmarshal(line, &receivedBt)
+		txS, err := btmap[receivedBt.Hash].Serialize()
 		require.Nil(t, err)
 		require.Equal(t, txS, line)
 	}
@@ -471,11 +477,11 @@ func TestGetTransactionsHandler(t *testing.T) {
 	var receivedBts []BlockTransaction
 	json.Unmarshal(readByte, &receivedBts)
 
-	require.Equal(t, len(bts), len(receivedBts), "length is not same")
+	require.Equal(t, len(receivedBts), len(receivedBts), "length is not same")
 
 	i := 0
-	for _, bt := range bts {
-		require.Equal(t, bt.Hash, receivedBts[i].Hash, "hash is not same")
+	for _, bt := range receivedBts {
+		require.Equal(t, bt.Hash, btmap[bt.Hash].Hash, "hash is not same")
 		i++
 	}
 }


### PR DESCRIPTION
### Github Issue
Bug
### Background
Test failed randomly

### Solution
The received data sequence is not guaranteed due to go-observable on function is concurrent
Hence, remove the sequence check

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

