### PR TITLE
rename `CATCH-UP` to `SYNC`

### DIFF
--- a/lib/node/localNode.go
+++ b/lib/node/localNode.go
@@ -76,8 +76,8 @@ func (n *LocalNode) SetBooting() {
 	n.state = NodeStateBOOTING
 }
 
-func (n *LocalNode) SetCatchup() {
-	n.state = NodeStateCATCHUP
+func (n *LocalNode) SetSync() {
+	n.state = NodeStateSYNC
 }
 
 func (n *LocalNode) SetConsensus() {

--- a/lib/node/node.go
+++ b/lib/node/node.go
@@ -14,7 +14,7 @@ type Node interface {
 	Serialize() ([]byte, error)
 	State() NodeState
 	SetBooting()
-	SetCatchup()
+	SetSync()
 	SetConsensus()
 	SetTerminating()
 }

--- a/lib/node/node_state.go
+++ b/lib/node/node_state.go
@@ -9,7 +9,7 @@ type NodeState uint
 const (
 	NodeStateNONE NodeState = iota
 	NodeStateBOOTING
-	NodeStateCATCHUP
+	NodeStateSYNC
 	NodeStateCONSENSUS
 	NodeStateTERMINATING
 )
@@ -23,7 +23,7 @@ func (s NodeState) String() string {
 	case 1:
 		return "BOOTING"
 	case 2:
-		return "CATCHUP"
+		return "SYNC"
 	case 3:
 		return "CONSENSUS"
 	case 4:
@@ -44,7 +44,7 @@ func (s *NodeState) UnmarshalJSON(b []byte) (err error) {
 		c = 0
 	case "BOOTING":
 		c = 1
-	case "CATCHUP":
+	case "SYNC":
 		c = 2
 	case "CONSENSUS":
 		c = 3

--- a/lib/node/node_state_test.go
+++ b/lib/node/node_state_test.go
@@ -13,7 +13,7 @@ func TestNodeInitState(t *testing.T) {
 func TestNodeStateString(t *testing.T) {
 	require.Equal(t, NodeStateNONE.String(), "NONE")
 	require.Equal(t, NodeStateBOOTING.String(), "BOOTING")
-	require.Equal(t, NodeStateCATCHUP.String(), "CATCHUP")
+	require.Equal(t, NodeStateSYNC.String(), "SYNC")
 	require.Equal(t, NodeStateCONSENSUS.String(), "CONSENSUS")
 	require.Equal(t, NodeStateTERMINATING.String(), "TERMINATING")
 }
@@ -27,9 +27,9 @@ func TestNodeStateMarshalJSON(t *testing.T) {
 	require.Equal(t, err, nil)
 	require.Equal(t, "\"BOOTING\"", string(ret))
 
-	ret, err = NodeStateCATCHUP.MarshalJSON()
+	ret, err = NodeStateSYNC.MarshalJSON()
 	require.Equal(t, err, nil)
-	require.Equal(t, "\"CATCHUP\"", string(ret))
+	require.Equal(t, "\"SYNC\"", string(ret))
 
 	ret, err = NodeStateCONSENSUS.MarshalJSON()
 	require.Equal(t, err, nil)
@@ -50,9 +50,9 @@ func TestNodeStateUnmarshalJSON(t *testing.T) {
 	ns.UnmarshalJSON(nodeStateByteArray)
 	require.Equal(t, NodeStateBOOTING, ns)
 
-	nodeStateByteArray, _ = NodeStateCATCHUP.MarshalJSON()
+	nodeStateByteArray, _ = NodeStateSYNC.MarshalJSON()
 	ns.UnmarshalJSON(nodeStateByteArray)
-	require.Equal(t, NodeStateCATCHUP, ns)
+	require.Equal(t, NodeStateSYNC, ns)
 
 	nodeStateByteArray, _ = NodeStateCONSENSUS.MarshalJSON()
 	ns.UnmarshalJSON(nodeStateByteArray)

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -23,8 +23,8 @@ func TestNodeStateChange(t *testing.T) {
 	node.SetBooting()
 	require.Equal(t, NodeStateBOOTING, node.State())
 
-	node.SetCatchup()
-	require.Equal(t, NodeStateCATCHUP, node.State())
+	node.SetSync()
+	require.Equal(t, NodeStateSYNC, node.State())
 
 	node.SetConsensus()
 	require.Equal(t, NodeStateCONSENSUS, node.State())
@@ -52,10 +52,10 @@ func TestNodeMarshalJSON(t *testing.T) {
 	require.Equal(t, nil, err)
 	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "BOOTING")))
 
-	marshalNode.SetCatchup()
+	marshalNode.SetSync()
 	tmpByte, err = marshalNode.MarshalJSON()
 	require.Equal(t, nil, err)
-	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "CATCHUP")))
+	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "SYNC")))
 
 	marshalNode.SetConsensus()
 	tmpByte, err = marshalNode.MarshalJSON()

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -65,8 +65,8 @@ func (v *Validator) SetBooting() {
 	v.state = NodeStateBOOTING
 }
 
-func (v *Validator) SetCatchup() {
-	v.state = NodeStateCATCHUP
+func (v *Validator) SetSync() {
+	v.state = NodeStateSYNC
 }
 
 func (v *Validator) SetConsensus() {


### PR DESCRIPTION
Rename `CATCH-UP` to `SYNC`
Please check `SYNC` process in https://github.com/bosnet/sebak/wiki/How-to-SYNC-blocks-with-validators