### PR TITLE
Modify `Round` package `sebak` to `round`

### DIFF
--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -12,6 +12,7 @@ import (
 	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/round"
 	"boscoin.io/sebak/lib/storage"
 )
 
@@ -20,7 +21,7 @@ type Ballot struct {
 	B BallotBody
 }
 
-func NewBallot(localNode *sebaknode.LocalNode, round Round, transactions []string) (b *Ballot) {
+func NewBallot(localNode *sebaknode.LocalNode, round round.Round, transactions []string) (b *Ballot) {
 	body := BallotBody{
 		Source: localNode.Address(),
 		Proposed: BallotBodyProposed{
@@ -116,7 +117,7 @@ func (b Ballot) Source() string {
 	return b.B.Source
 }
 
-func (b Ballot) Round() Round {
+func (b Ballot) Round() round.Round {
 	return b.B.Proposed.Round
 }
 
@@ -216,10 +217,10 @@ type BallotHeader struct {
 }
 
 type BallotBodyProposed struct {
-	Confirmed    string   `json:"confirmed"` // created time, ISO8601
-	Proposer     string   `json:"proposer"`
-	Round        Round    `json:"round"`
-	Transactions []string `json:"transactions"`
+	Confirmed    string      `json:"confirmed"` // created time, ISO8601
+	Proposer     string      `json:"proposer"`
+	Round        round.Round `json:"round"`
+	Transactions []string    `json:"transactions"`
 }
 
 type BallotBody struct {

--- a/lib/ballot_test.go
+++ b/lib/ballot_test.go
@@ -11,6 +11,7 @@ import (
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/round"
 )
 
 func TestErrorBallotHasOverMaxTransactionsInBallot(t *testing.T) {
@@ -22,7 +23,7 @@ func TestErrorBallotHasOverMaxTransactionsInBallot(t *testing.T) {
 	MaxTransactionsInBallot = 2
 
 	_, node := createNetMemoryNetwork()
-	round := Round{Number: 0, BlockHeight: 1, BlockHash: "hahaha", TotalTxs: 1}
+	round := round.Round{Number: 0, BlockHeight: 1, BlockHash: "hahaha", TotalTxs: 1}
 	_, tx := TestMakeTransaction(networkID, 1)
 
 	ballot := NewBallot(node, round, []string{tx.GetHash()})
@@ -48,12 +49,7 @@ func TestBallotHash(t *testing.T) {
 
 	nodeRunner := nodeRunners[0]
 
-	// `nodeRunner` is proposer's runner
-	nodeRunner.SetProposerCalculator(SelfProposerCalculator{})
-
-	nodeRunner.Consensus().SetLatestConsensusedBlock(genesisBlock)
-
-	round := Round{
+	round := round.Round{
 		Number:      0,
 		BlockHeight: nodeRunner.Consensus().LatestConfirmedBlock.Height,
 		BlockHash:   nodeRunner.Consensus().LatestConfirmedBlock.Hash,
@@ -71,7 +67,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 	endpoint, _ := sebakcommon.NewEndpointFromString("https://localhost:1000")
 	node, _ := sebaknode.NewLocalNode(kp, endpoint, "")
 
-	round := Round{Number: 0, BlockHeight: 0, BlockHash: "", TotalTxs: 0}
+	round := round.Round{Number: 0, BlockHeight: 0, BlockHash: "", TotalTxs: 0}
 
 	updateBallot := func(ballot *Ballot) {
 		ballot.H.Hash = ballot.B.MakeHashString()

--- a/lib/block.go
+++ b/lib/block.go
@@ -9,6 +9,7 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/round"
 	"boscoin.io/sebak/lib/storage"
 )
 
@@ -22,10 +23,10 @@ type Block struct {
 	Transactions []string `json:"transactions"` /* []Transaction.GetHash() */
 	//PrevConsensusResult ConsensusResult
 
-	Hash      string `json:"hash"`
-	Confirmed string `json:"confirmed"`
-	Proposer  string `json:"proposer"` /* Node.Address() */
-	Round     Round  `json:"round"`
+	Hash      string      `json:"hash"`
+	Confirmed string      `json:"confirmed"`
+	Proposer  string      `json:"proposer"` /* Node.Address() */
+	Round     round.Round `json:"round"`
 }
 
 func (bck Block) Serialize() (encoded []byte, err error) {
@@ -40,7 +41,7 @@ func (bck Block) String() string {
 
 func MakeGenesisBlock(st *sebakstorage.LevelDBBackend, account block.BlockAccount) Block {
 	proposer := "" // null proposer
-	round := Round{
+	round := round.Round{
 		Number:      0,
 		BlockHeight: 0,
 		BlockHash:   base58.Encode(sebakcommon.MustMakeObjectHash(account)),
@@ -60,7 +61,7 @@ func MakeGenesisBlock(st *sebakstorage.LevelDBBackend, account block.BlockAccoun
 	return b
 }
 
-func NewBlock(proposer string, round Round, transactions []string, confirmed string) Block {
+func NewBlock(proposer string, round round.Round, transactions []string, confirmed string) Block {
 	b := &Block{
 		Header:       *NewBlockHeader(round, uint64(len(transactions)), getTransactionRoot(transactions)),
 		Transactions: transactions,

--- a/lib/block_header.go
+++ b/lib/block_header.go
@@ -2,6 +2,8 @@ package sebak
 
 import (
 	"time"
+
+	"boscoin.io/sebak/lib/round"
 )
 
 type Header struct {
@@ -15,7 +17,7 @@ type Header struct {
 	// TODO smart contract fields
 }
 
-func NewBlockHeader(round Round, currentTxs uint64, txRoot string) *Header {
+func NewBlockHeader(round round.Round, currentTxs uint64, txRoot string) *Header {
 	return &Header{
 		PrevBlockHash:    round.BlockHash,
 		Timestamp:        time.Now(),

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -129,8 +129,8 @@ type ISAAC struct {
 
 func NewISAAC(networkID []byte, node *sebaknode.LocalNode, votingThresholdPolicy sebakcommon.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		NetworkID: networkID,
-		Node:      node,
+		NetworkID:             networkID,
+		Node:                  node,
 		VotingThresholdPolicy: votingThresholdPolicy,
 		TransactionPool:       NewTransactionPool(),
 		RunningRounds:         map[string]*RunningRound{},

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -4,171 +4,9 @@ import (
 	"errors"
 
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/round"
 )
-
-type RoundVoteResult map[ /* Node.Address() */ string]sebakcommon.VotingHole
-
-type RoundVote struct {
-	SIGN   RoundVoteResult
-	ACCEPT RoundVoteResult
-}
-
-func NewRoundVote(ballot Ballot) (rv *RoundVote) {
-	rv = &RoundVote{
-		SIGN:   RoundVoteResult{},
-		ACCEPT: RoundVoteResult{},
-	}
-
-	rv.Vote(ballot)
-
-	return rv
-}
-
-func (rv *RoundVote) IsVoted(ballot Ballot) bool {
-	result := rv.GetResult(ballot.State())
-
-	_, found := result[ballot.Source()]
-	return found
-}
-
-func (rv *RoundVote) IsVotedByNode(state sebakcommon.BallotState, node string) bool {
-	result := rv.GetResult(state)
-
-	_, found := result[node]
-	return found
-}
-
-func (rv *RoundVote) Vote(ballot Ballot) (isNew bool, err error) {
-	if ballot.IsFromProposer() {
-		return
-	}
-
-	result := rv.GetResult(ballot.State())
-	_, isNew = result[ballot.Source()]
-	result[ballot.Source()] = ballot.Vote()
-
-	return
-}
-
-func (rv *RoundVote) GetResult(state sebakcommon.BallotState) (result RoundVoteResult) {
-	if !state.IsValidForVote() {
-		return
-	}
-
-	switch state {
-	case sebakcommon.BallotStateSIGN:
-		result = rv.SIGN
-	case sebakcommon.BallotStateACCEPT:
-		result = rv.ACCEPT
-	}
-
-	return result
-}
-
-func (rv *RoundVote) CanGetVotingResult(policy sebakcommon.VotingThresholdPolicy, state sebakcommon.BallotState) (RoundVoteResult, sebakcommon.VotingHole, bool) {
-	threshold := policy.Threshold(state)
-	if threshold < 1 {
-		return RoundVoteResult{}, sebakcommon.VotingNOTYET, false
-	}
-
-	result := rv.GetResult(state)
-	if len(result) < int(threshold) {
-		return result, sebakcommon.VotingNOTYET, false
-	}
-
-	var yes, no int
-	for _, votingHole := range result {
-		switch votingHole {
-		case sebakcommon.VotingYES:
-			yes++
-		case sebakcommon.VotingNO:
-			no++
-		}
-	}
-
-	log.Debug(
-		"check threshold in isaac",
-		"threshold", threshold,
-		"yes", yes,
-		"no", no,
-		"policy", policy,
-		"state", state,
-	)
-
-	if yes >= threshold {
-		return result, sebakcommon.VotingYES, true
-	} else if no >= threshold {
-		return result, sebakcommon.VotingNO, true
-	}
-
-	// check draw!
-	total := policy.Validators()
-	voted := yes + no
-	if total-voted < threshold-yes && total-voted < threshold-no { // draw
-		return result, sebakcommon.VotingNO, true
-	}
-
-	return result, sebakcommon.VotingNOTYET, false
-}
-
-type RunningRound struct {
-	sebakcommon.SafeLock
-
-	Round        Round
-	Proposer     string                              // LocalNode's `Proposer`
-	Transactions map[ /* Proposer */ string][]string /* Transaction.Hash */
-	Voted        map[ /* Proposer */ string]*RoundVote
-}
-
-func NewRunningRound(proposer string, ballot Ballot) (*RunningRound, error) {
-	transactions := map[string][]string{
-		ballot.Proposer(): ballot.Transactions(),
-	}
-
-	roundVote := NewRoundVote(ballot)
-	voted := map[string]*RoundVote{
-		ballot.Proposer(): roundVote,
-	}
-
-	return &RunningRound{
-		Round:        ballot.Round(),
-		Proposer:     proposer,
-		Transactions: transactions,
-		Voted:        voted,
-	}, nil
-}
-
-func (rr *RunningRound) RoundVote(proposer string) (rv *RoundVote, err error) {
-	var found bool
-	rv, found = rr.Voted[proposer]
-	if !found {
-		err = sebakerror.ErrorRoundVoteNotFound
-		return
-	}
-	return
-}
-
-func (rr *RunningRound) IsVoted(ballot Ballot) bool {
-	roundVote, err := rr.RoundVote(ballot.Proposer())
-	if err != nil {
-		return false
-	}
-
-	return roundVote.IsVoted(ballot)
-}
-
-func (rr *RunningRound) Vote(ballot Ballot) {
-	rr.Lock()
-	defer rr.Unlock()
-
-	if _, found := rr.Voted[ballot.Proposer()]; !found {
-		rr.Voted[ballot.Proposer()] = NewRoundVote(ballot)
-	} else {
-		rr.Voted[ballot.Proposer()].Vote(ballot)
-	}
-}
 
 type TransactionPool struct {
 	sebakcommon.SafeLock
@@ -286,13 +124,13 @@ type ISAAC struct {
 	TransactionPool       *TransactionPool
 	RunningRounds         map[ /* Round.Hash() */ string]*RunningRound
 	LatestConfirmedBlock  Block
-	LatestRound           Round
+	LatestRound           round.Round
 }
 
 func NewISAAC(networkID []byte, node *sebaknode.LocalNode, votingThresholdPolicy sebakcommon.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		NetworkID:             networkID,
-		Node:                  node,
+		NetworkID: networkID,
+		Node:      node,
 		VotingThresholdPolicy: votingThresholdPolicy,
 		TransactionPool:       NewTransactionPool(),
 		RunningRounds:         map[string]*RunningRound{},
@@ -301,9 +139,11 @@ func NewISAAC(networkID []byte, node *sebaknode.LocalNode, votingThresholdPolicy
 	return
 }
 
-func (is *ISAAC) CloseConsensus(proposer string, round Round, vh sebakcommon.VotingHole) (err error) {
+func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh sebakcommon.VotingHole) (err error) {
 	is.Lock()
 	defer is.Unlock()
+
+	is.SetLatestRound(round)
 
 	if vh == sebakcommon.VotingNOTYET {
 		err = errors.New("invalid VotingHole, `VotingNOTYET`")
@@ -342,11 +182,11 @@ func (is *ISAAC) SetLatestConsensusedBlock(block Block) {
 	is.LatestConfirmedBlock = block
 }
 
-func (is *ISAAC) SetLatestRound(round Round) {
+func (is *ISAAC) SetLatestRound(round round.Round) {
 	is.LatestRound = round
 }
 
-func (is *ISAAC) IsAvailableRound(round Round) bool {
+func (is *ISAAC) IsAvailableRound(round round.Round) bool {
 	// check current round is from InitRound
 	if is.LatestRound.BlockHash == "" {
 		return true

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -201,7 +201,7 @@ func (is *ISAAC) IsAvailableRound(round round.Round) bool {
 	} else {
 		// TODO if incoming round.BlockHeight is bigger than
 		// LatestConfirmedBlock.Height and this round confirmed successfully,
-		// this node will get into catchup status
+		// this node will get into sync state
 	}
 
 	if round.BlockHeight == is.LatestRound.BlockHeight {

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -143,8 +143,6 @@ func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh sebakcomm
 	is.Lock()
 	defer is.Unlock()
 
-	is.SetLatestRound(round)
-
 	if vh == sebakcommon.VotingNOTYET {
 		err = errors.New("invalid VotingHole, `VotingNOTYET`")
 		return

--- a/lib/isaac_simulation_test.go
+++ b/lib/isaac_simulation_test.go
@@ -12,6 +12,7 @@ import (
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/round"
 )
 
 /*
@@ -47,7 +48,7 @@ func TestIsaacSimulationProposer(t *testing.T) {
 	roundNumber := uint64(0)
 	err = nodeRunner.proposeNewBallot(roundNumber)
 	require.Nil(t, err)
-	round := Round{
+	round := round.Round{
 		Number:      roundNumber,
 		BlockHeight: nodeRunner.Consensus().LatestConfirmedBlock.Height,
 		BlockHash:   nodeRunner.Consensus().LatestConfirmedBlock.Hash,

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -17,6 +17,7 @@ import (
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/round"
 	"boscoin.io/sebak/lib/storage"
 )
 
@@ -410,7 +411,7 @@ func (nr *NodeRunner) InitRound() {
 	}
 
 	nr.consensus.SetLatestConsensusedBlock(latestBlock)
-	nr.consensus.SetLatestRound(Round{})
+	nr.consensus.SetLatestRound(round.Round{})
 
 	ticker := time.NewTicker(time.Millisecond * 5)
 	for _ = range ticker.C {
@@ -510,8 +511,7 @@ func (nr *NodeRunner) readyToProposeNewBallot(roundNumber uint64) {
 }
 
 func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
-	// start new round
-	round := Round{
+	round := round.Round{
 		Number:      roundNumber,
 		BlockHeight: nr.consensus.LatestConfirmedBlock.Height,
 		BlockHash:   nr.consensus.LatestConfirmedBlock.Hash,

--- a/lib/proposer_calculator_test.go
+++ b/lib/proposer_calculator_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//In TestProposerCalculator test, the proposer is always the node itself because of SelfProposerCalculator.
+// In TestProposerCalculator test, the proposer is always the node itself because of SelfProposerCalculator.
 func TestProposerCalculator(t *testing.T) {
 	nodeRunners := createTestNodeRunner(1)
 
@@ -18,7 +18,7 @@ func TestProposerCalculator(t *testing.T) {
 	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(2, 1))
 }
 
-//	All 3 nodes have the same proposer at each round
+// All 3 nodes have the same proposer at each round
 func TestNodesHaveSameProposers(t *testing.T) {
 	numberOfNodes := 3
 

--- a/lib/proposer_calculator_test.go
+++ b/lib/proposer_calculator_test.go
@@ -6,9 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-/*
-In TestProposerCalculator test, the proposer is always the node itself because of SelfProposerCalculator.
-*/
+//In TestProposerCalculator test, the proposer is always the node itself because of SelfProposerCalculator.
 func TestProposerCalculator(t *testing.T) {
 	nodeRunners := createTestNodeRunner(1)
 
@@ -20,9 +18,7 @@ func TestProposerCalculator(t *testing.T) {
 	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(2, 1))
 }
 
-/*
-	All 3 nodes have the same proposer at each round
-*/
+//	All 3 nodes have the same proposer at each round
 func TestNodesHaveSameProposers(t *testing.T) {
 	numberOfNodes := 3
 

--- a/lib/round/round.go
+++ b/lib/round/round.go
@@ -1,4 +1,4 @@
-package sebak
+package round
 
 import (
 	"github.com/btcsuite/btcutil/base58"

--- a/lib/round_vote.go
+++ b/lib/round_vote.go
@@ -1,0 +1,127 @@
+package sebak
+
+import (
+	"boscoin.io/sebak/lib/common"
+)
+
+type RoundVoteResult map[ /* Node.Address() */ string]sebakcommon.VotingHole
+
+type RoundVote struct {
+	SIGN   RoundVoteResult
+	ACCEPT RoundVoteResult
+}
+
+func NewRoundVote(ballot Ballot) (rv *RoundVote) {
+	rv = &RoundVote{
+		SIGN:   RoundVoteResult{},
+		ACCEPT: RoundVoteResult{},
+	}
+
+	rv.Vote(ballot)
+
+	return rv
+}
+
+func (rv *RoundVote) IsVoted(ballot Ballot) bool {
+	result := rv.GetResult(ballot.State())
+
+	_, found := result[ballot.Source()]
+	return found
+}
+
+func (rv *RoundVote) IsVotedByNode(state sebakcommon.BallotState, node string) bool {
+	result := rv.GetResult(state)
+
+	_, found := result[node]
+	return found
+}
+
+func (rv *RoundVote) Vote(ballot Ballot) (isNew bool, err error) {
+	if ballot.IsFromProposer() {
+		return
+	}
+
+	result := rv.GetResult(ballot.State())
+	_, isNew = result[ballot.Source()]
+	result[ballot.Source()] = ballot.Vote()
+
+	return
+}
+
+func (rv *RoundVote) GetResult(state sebakcommon.BallotState) (result RoundVoteResult) {
+	if !state.IsValidForVote() {
+		return
+	}
+
+	switch state {
+	case sebakcommon.BallotStateSIGN:
+		result = rv.SIGN
+	case sebakcommon.BallotStateACCEPT:
+		result = rv.ACCEPT
+	}
+
+	return result
+}
+
+func (rv *RoundVote) CanGetVotingResult(policy sebakcommon.VotingThresholdPolicy, state sebakcommon.BallotState) (RoundVoteResult, sebakcommon.VotingHole, bool) {
+	threshold := policy.Threshold(state)
+	if threshold < 1 {
+		return RoundVoteResult{}, sebakcommon.VotingNOTYET, false
+	}
+
+	result := rv.GetResult(state)
+	if len(result) < int(threshold) {
+		return result, sebakcommon.VotingNOTYET, false
+	}
+
+	var yes, no, expired int
+	for _, votingHole := range result {
+		switch votingHole {
+		case sebakcommon.VotingYES:
+			yes++
+		case sebakcommon.VotingNO:
+			no++
+		case sebakcommon.VotingEXP:
+			expired++
+		}
+	}
+
+	log.Debug(
+		"check threshold in isaac",
+		"threshold", threshold,
+		"yes", yes,
+		"no", no,
+		"expired", expired,
+		"policy", policy,
+		"state", state,
+	)
+
+	if state == sebakcommon.BallotStateSIGN {
+		if yes >= threshold {
+			return result, sebakcommon.VotingYES, true
+		} else if no >= threshold+1 {
+			return result, sebakcommon.VotingNO, true
+		}
+	} else if state == sebakcommon.BallotStateACCEPT {
+		if yes >= threshold {
+			return result, sebakcommon.VotingYES, true
+		} else if no >= threshold {
+			return result, sebakcommon.VotingNO, true
+		}
+	} else {
+		// do nothing
+	}
+
+	// check draw!
+	total := policy.Validators()
+	voted := yes + no + expired
+	if cannotBeOver(total-voted, threshold, yes, no) { // draw
+		return result, sebakcommon.VotingEXP, true
+	}
+
+	return result, sebakcommon.VotingNOTYET, false
+}
+
+func cannotBeOver(remain, threshold, yes, no int) bool {
+	return remain+yes < threshold && remain+no < threshold
+}

--- a/lib/running_round.go
+++ b/lib/running_round.go
@@ -1,0 +1,64 @@
+package sebak
+
+import (
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/round"
+)
+
+type RunningRound struct {
+	sebakcommon.SafeLock
+
+	Round        round.Round
+	Proposer     string                              // LocalNode's `Proposer`
+	Transactions map[ /* Proposer */ string][]string /* Transaction.Hash */
+	Voted        map[ /* Proposer */ string]*RoundVote
+}
+
+func NewRunningRound(proposer string, ballot Ballot) (*RunningRound, error) {
+	transactions := map[string][]string{
+		ballot.Proposer(): ballot.Transactions(),
+	}
+
+	roundVote := NewRoundVote(ballot)
+	voted := map[string]*RoundVote{
+		ballot.Proposer(): roundVote,
+	}
+
+	return &RunningRound{
+		Round:        ballot.Round(),
+		Proposer:     proposer,
+		Transactions: transactions,
+		Voted:        voted,
+	}, nil
+}
+
+func (rr *RunningRound) RoundVote(proposer string) (rv *RoundVote, err error) {
+	var found bool
+	rv, found = rr.Voted[proposer]
+	if !found {
+		err = sebakerror.ErrorRoundVoteNotFound
+		return
+	}
+	return
+}
+
+func (rr *RunningRound) IsVoted(ballot Ballot) bool {
+	roundVote, err := rr.RoundVote(ballot.Proposer())
+	if err != nil {
+		return false
+	}
+
+	return roundVote.IsVoted(ballot)
+}
+
+func (rr *RunningRound) Vote(ballot Ballot) {
+	rr.Lock()
+	defer rr.Unlock()
+
+	if _, found := rr.Voted[ballot.Proposer()]; !found {
+		rr.Voted[ballot.Proposer()] = NewRoundVote(ballot)
+	} else {
+		rr.Voted[ballot.Proposer()].Vote(ballot)
+	}
+}

--- a/lib/test.go
+++ b/lib/test.go
@@ -13,6 +13,7 @@ import (
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/round"
 	"boscoin.io/sebak/lib/storage"
 )
 
@@ -58,7 +59,7 @@ func testMakeNewBlock(transactions []string) Block {
 
 	return NewBlock(
 		kp.Address(),
-		Round{
+		round.Round{
 			BlockHeight: 0,
 			BlockHash:   "",
 		},
@@ -252,7 +253,7 @@ func makeTransactionCreateAccount(kpSource *keypair.Full, target string, amount 
 	return
 }
 
-func GenerateBallot(t *testing.T, proposer *sebaknode.LocalNode, round Round, tx Transaction, ballotState sebakcommon.BallotState, sender *sebaknode.LocalNode) *Ballot {
+func GenerateBallot(t *testing.T, proposer *sebaknode.LocalNode, round round.Round, tx Transaction, ballotState sebakcommon.BallotState, sender *sebaknode.LocalNode) *Ballot {
 	ballot := NewBallot(proposer, round, []string{tx.GetHash()})
 	ballot.SetVote(sebakcommon.BallotStateINIT, sebakcommon.VotingYES)
 	ballot.Sign(proposer.Keypair(), networkID)
@@ -267,7 +268,7 @@ func GenerateBallot(t *testing.T, proposer *sebaknode.LocalNode, round Round, tx
 	return ballot
 }
 
-func GenerateEmptyTxBallot(t *testing.T, proposer *sebaknode.LocalNode, round Round, ballotState sebakcommon.BallotState, sender *sebaknode.LocalNode) *Ballot {
+func GenerateEmptyTxBallot(t *testing.T, proposer *sebaknode.LocalNode, round round.Round, ballotState sebakcommon.BallotState, sender *sebaknode.LocalNode) *Ballot {
 	ballot := NewBallot(proposer, round, []string{})
 	ballot.SetVote(sebakcommon.BallotStateINIT, sebakcommon.VotingYES)
 	ballot.Sign(proposer.Keypair(), networkID)


### PR DESCRIPTION
1. Split `RunningRound` and `RoundVoteResult` file from `isaac.go`
1. modify `Round` package `sebak` to `round`
for readability.