### PR TITLE
Rename package `sebakstorage` to `storage

### DIFF
--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -61,7 +61,7 @@ func init() {
 //                If not provided, `flagBalance`, which is the value set in the env
 //                when called from another module, will be used
 //   storageConfigUri = URI to include storage path("file://path")
-//       			    If not provided, a default value will be used
+//                      If not provided, a default value will be used
 //
 // Returns:
 //   If an error happened, returns a tuple of (string, error).

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -32,7 +32,7 @@ func init() {
 		Short: "initialize new network",
 		Args:  cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {
-			flagName, err := MakeGenesisBlock(args[0], flagNetworkID, flagBalance, flagStorageConfiging)
+			flagName, err := MakeGenesisBlock(args[0], flagNetworkID, flagBalance, flagStorageConfigString)
 			if len(flagName) != 0 || err != nil {
 				cmdcommon.PrintFlagsError(c, flagName, err)
 			}
@@ -42,7 +42,7 @@ func init() {
 	}
 
 	genesisCmd.Flags().StringVar(&flagBalance, "balance", flagBalance, "initial balance of genesis block")
-	genesisCmd.Flags().StringVar(&flagStorageConfiging, "storage", flagStorageConfiging, "storage uri")
+	genesisCmd.Flags().StringVar(&flagStorageConfigString, "storage", flagStorageConfigString, "storage uri")
 	genesisCmd.Flags().StringVar(&flagNetworkID, "network-id", flagNetworkID, "network id")
 
 	rootCmd.AddCommand(genesisCmd)
@@ -60,7 +60,7 @@ func init() {
 //   balanceStr = Amount of coins to put in the account
 //                If not provided, `flagBalance`, which is the value set in the env
 //                when called from another module, will be used
-//   storageConfig = URI to include storage path("file://path")
+//   storageConfigUri = URI to include storage path("file://path")
 //       			 If not provided, a default value will be used
 //
 // Returns:
@@ -69,7 +69,7 @@ func init() {
 //   and error is the more detailed error.
 //   Note that only one needs be non-`nil` for it to be considered an error.
 //
-func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfig string) (string, error) {
+func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfigUri string) (string, error) {
 	var balance common.Amount
 	var err error
 	var kp keypair.KP
@@ -91,25 +91,25 @@ func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfig string) (
 	}
 
 	// Use the default value
-	if len(storageConfig) == 0 {
+	if len(storageConfigUri) == 0 {
 		// We try to get the env value first, before doing IO which could fail
-		storageConfig = common.GetENVValue("SEBAK_STORAGE", "")
+		storageConfigUri = common.GetENVValue("SEBAK_STORAGE", "")
 		// No env, use the default (current directory)
-		if len(storageConfig) == 0 {
+		if len(storageConfigUri) == 0 {
 			if currentDirectory, err := os.Getwd(); err == nil {
 				if currentDirectory, err = filepath.Abs(currentDirectory); err == nil {
-					storageConfig = fmt.Sprintf("file://%s/db", currentDirectory)
+					storageConfigUri = fmt.Sprintf("file://%s/db", currentDirectory)
 				}
 			}
 			// If any of the previous condition failed
-			if len(storageConfig) == 0 {
+			if len(storageConfigUri) == 0 {
 				return "--storage", err
 			}
 		}
 	}
 
 	var storageConfig *storage.Config
-	if storageConfig, err = storage.NewConfigFromString(storageConfig); err != nil {
+	if storageConfig, err = storage.NewConfigFromString(storageConfigUri); err != nil {
 		return "--storage", err
 	}
 

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -69,11 +69,10 @@ func init() {
 //   and error is the more detailed error.
 //   Note that only one needs be non-`nil` for it to be considered an error.
 //
-func MakeGenesisBlock(addressStr, networkID, balanceStr, storage string) (string, error) {
+func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfigStr string) (string, error) {
 	var balance common.Amount
 	var err error
 	var kp keypair.KP
-	var storageConfig *sebakstorage.Config
 
 	if kp, err = keypair.Parse(addressStr); err != nil {
 		return "<address>", err
@@ -92,28 +91,29 @@ func MakeGenesisBlock(addressStr, networkID, balanceStr, storage string) (string
 	}
 
 	// Use the default value
-	if len(storage) == 0 {
+	if len(storageConfigStr) == 0 {
 		// We try to get the env value first, before doing IO which could fail
-		storage = common.GetENVValue("SEBAK_STORAGE", "")
+		storageConfigStr = common.GetENVValue("SEBAK_STORAGE", "")
 		// No env, use the default (current directory)
-		if len(storage) == 0 {
+		if len(storageConfigStr) == 0 {
 			if currentDirectory, err := os.Getwd(); err == nil {
 				if currentDirectory, err = filepath.Abs(currentDirectory); err == nil {
-					storage = fmt.Sprintf("file://%s/db", currentDirectory)
+					storageConfigStr = fmt.Sprintf("file://%s/db", currentDirectory)
 				}
 			}
 			// If any of the previous condition failed
-			if len(storage) == 0 {
+			if len(storageConfigStr) == 0 {
 				return "--storage", err
 			}
 		}
 	}
 
-	if storageConfig, err = sebakstorage.NewConfigFromString(storage); err != nil {
+	var storageConfig *storage.Config
+	if storageConfig, err = storage.NewConfigFromString(storageConfigStr); err != nil {
 		return "--storage", err
 	}
 
-	st, err := sebakstorage.NewStorage(storageConfig)
+	st, err := storage.NewStorage(storageConfig)
 	if err != nil {
 		return "--storage", fmt.Errorf("failed to initialize storage: %v", err)
 	}

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -60,8 +60,8 @@ func init() {
 //   balanceStr = Amount of coins to put in the account
 //                If not provided, `flagBalance`, which is the value set in the env
 //                when called from another module, will be used
-//   storageConfigUri = URI to include storage path("file://path")
-//                      If not provided, a default value will be used
+//   storageUri = URI to include storage path("file://path")
+//                If not provided, a default value will be used
 //
 // Returns:
 //   If an error happened, returns a tuple of (string, error).
@@ -69,7 +69,7 @@ func init() {
 //   and error is the more detailed error.
 //   Note that only one needs be non-`nil` for it to be considered an error.
 //
-func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfigUri string) (string, error) {
+func MakeGenesisBlock(addressStr, networkID, balanceStr, storageUri string) (string, error) {
 	var balance common.Amount
 	var err error
 	var kp keypair.KP
@@ -91,25 +91,25 @@ func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfigUri string
 	}
 
 	// Use the default value
-	if len(storageConfigUri) == 0 {
+	if len(storageUri) == 0 {
 		// We try to get the env value first, before doing IO which could fail
-		storageConfigUri = common.GetENVValue("SEBAK_STORAGE", "")
+		storageUri = common.GetENVValue("SEBAK_STORAGE", "")
 		// No env, use the default (current directory)
-		if len(storageConfigUri) == 0 {
+		if len(storageUri) == 0 {
 			if currentDirectory, err := os.Getwd(); err == nil {
 				if currentDirectory, err = filepath.Abs(currentDirectory); err == nil {
-					storageConfigUri = fmt.Sprintf("file://%s/db", currentDirectory)
+					storageUri = fmt.Sprintf("file://%s/db", currentDirectory)
 				}
 			}
 			// If any of the previous condition failed
-			if len(storageConfigUri) == 0 {
+			if len(storageUri) == 0 {
 				return "--storage", err
 			}
 		}
 	}
 
 	var storageConfig *storage.Config
-	if storageConfig, err = storage.NewConfigFromString(storageConfigUri); err != nil {
+	if storageConfig, err = storage.NewConfigFromString(storageUri); err != nil {
 		return "--storage", err
 	}
 

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -57,11 +57,11 @@ func init() {
 // Params:
 //   address   = public address of the account owning the genesis block
 //   networkID = `--network-id` argument, used for the block's checkpoint
-//   balance   = Amount of coins to put in the account
-//               If not provided, `flagBalance`, which is the value set in the env
-//               when called from another module, will be used
-//   balance   = Amount of coins to put in the account
-//               If not provided, a default value will be used
+//   balanceStr = Amount of coins to put in the account
+//                If not provided, `flagBalance`, which is the value set in the env
+//                when called from another module, will be used
+//   storageConfigStr = Formatted string to include storage path("file://path")
+//       				If not provided, a default value will be used
 //
 // Returns:
 //   If an error happened, returns a tuple of (string, error).

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -32,7 +32,7 @@ func init() {
 		Short: "initialize new network",
 		Args:  cobra.ExactArgs(1),
 		Run: func(c *cobra.Command, args []string) {
-			flagName, err := MakeGenesisBlock(args[0], flagNetworkID, flagBalance, flagStorageConfigString)
+			flagName, err := MakeGenesisBlock(args[0], flagNetworkID, flagBalance, flagStorageConfiging)
 			if len(flagName) != 0 || err != nil {
 				cmdcommon.PrintFlagsError(c, flagName, err)
 			}
@@ -42,7 +42,7 @@ func init() {
 	}
 
 	genesisCmd.Flags().StringVar(&flagBalance, "balance", flagBalance, "initial balance of genesis block")
-	genesisCmd.Flags().StringVar(&flagStorageConfigString, "storage", flagStorageConfigString, "storage uri")
+	genesisCmd.Flags().StringVar(&flagStorageConfiging, "storage", flagStorageConfiging, "storage uri")
 	genesisCmd.Flags().StringVar(&flagNetworkID, "network-id", flagNetworkID, "network id")
 
 	rootCmd.AddCommand(genesisCmd)
@@ -60,8 +60,8 @@ func init() {
 //   balanceStr = Amount of coins to put in the account
 //                If not provided, `flagBalance`, which is the value set in the env
 //                when called from another module, will be used
-//   storageConfigStr = Formatted string to include storage path("file://path")
-//       				If not provided, a default value will be used
+//   storageConfig = URI to include storage path("file://path")
+//       			 If not provided, a default value will be used
 //
 // Returns:
 //   If an error happened, returns a tuple of (string, error).
@@ -69,7 +69,7 @@ func init() {
 //   and error is the more detailed error.
 //   Note that only one needs be non-`nil` for it to be considered an error.
 //
-func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfigStr string) (string, error) {
+func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfig string) (string, error) {
 	var balance common.Amount
 	var err error
 	var kp keypair.KP
@@ -91,25 +91,25 @@ func MakeGenesisBlock(addressStr, networkID, balanceStr, storageConfigStr string
 	}
 
 	// Use the default value
-	if len(storageConfigStr) == 0 {
+	if len(storageConfig) == 0 {
 		// We try to get the env value first, before doing IO which could fail
-		storageConfigStr = common.GetENVValue("SEBAK_STORAGE", "")
+		storageConfig = common.GetENVValue("SEBAK_STORAGE", "")
 		// No env, use the default (current directory)
-		if len(storageConfigStr) == 0 {
+		if len(storageConfig) == 0 {
 			if currentDirectory, err := os.Getwd(); err == nil {
 				if currentDirectory, err = filepath.Abs(currentDirectory); err == nil {
-					storageConfigStr = fmt.Sprintf("file://%s/db", currentDirectory)
+					storageConfig = fmt.Sprintf("file://%s/db", currentDirectory)
 				}
 			}
 			// If any of the previous condition failed
-			if len(storageConfigStr) == 0 {
+			if len(storageConfig) == 0 {
 				return "--storage", err
 			}
 		}
 	}
 
 	var storageConfig *storage.Config
-	if storageConfig, err = storage.NewConfigFromString(storageConfigStr); err != nil {
+	if storageConfig, err = storage.NewConfigFromString(storageConfig); err != nil {
 		return "--storage", err
 	}
 

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -61,7 +61,7 @@ func init() {
 //                If not provided, `flagBalance`, which is the value set in the env
 //                when called from another module, will be used
 //   storageConfigUri = URI to include storage path("file://path")
-//       			 If not provided, a default value will be used
+//       			    If not provided, a default value will be used
 //
 // Returns:
 //   If an error happened, returns a tuple of (string, error).

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -58,7 +58,7 @@ var (
 
 	kp                *keypair.Full
 	nodeEndpoint      *common.Endpoint
-	storageConfig     *sebakstorage.Config
+	storageConfig     *storage.Config
 	validators        []*node.Validator
 	threshold         int
 	timeoutINIT       time.Duration
@@ -214,7 +214,7 @@ func parseFlagsNode() {
 		}
 	}
 
-	if storageConfig, err = sebakstorage.NewConfigFromString(flagStorageConfigString); err != nil {
+	if storageConfig, err = storage.NewConfigFromString(flagStorageConfigString); err != nil {
 		cmdcommon.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
@@ -331,7 +331,7 @@ func runNode() error {
 		return err
 	}
 
-	st, err := sebakstorage.NewStorage(storageConfig)
+	st, err := storage.NewStorage(storageConfig)
 	if err != nil {
 		log.Crit("failed to initialize storage", "error", err)
 		return err

--- a/lib/api.go
+++ b/lib/api.go
@@ -30,7 +30,7 @@ type NetworkHandlerNode struct {
 type NetworkHandlerAPI struct {
 	localNode *node.LocalNode
 	network   network.Network
-	storage   *sebakstorage.LevelDBBackend
+	storage   *storage.LevelDBBackend
 }
 
 // Implement `Server Sent Event`

--- a/lib/api/resource_test.go
+++ b/lib/api/resource_test.go
@@ -1,17 +1,18 @@
 package api
 
 import (
+	"encoding/json"
+	"strings"
+	"testing"
+
 	"boscoin.io/sebak/lib"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/storage"
-	"encoding/json"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
 )
 
 func TestAPIResourceAccount(t *testing.T) {
-	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
+	storage, err := storage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
 

--- a/lib/api_node_test.go
+++ b/lib/api_node_test.go
@@ -89,7 +89,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, mn *network.HTTP2Net
 
 	p, _ := NewDefaultVotingThresholdPolicy(30, 30)
 	is, _ := NewISAAC(networkID, localNode, p)
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 	// Make the latest block
 	{
 		checkpoint := common.MakeGenesisCheckpoint(networkID)

--- a/lib/api_test.go
+++ b/lib/api_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestGetAccountHandler(t *testing.T) {
 	// Setting Server
-	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
+	storage, err := storage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
 
@@ -97,7 +97,7 @@ func TestGetAccountHandler(t *testing.T) {
 // Test that getting an inexisting account returns an error
 func TestGetNonExistentAccountHandler(t *testing.T) {
 	// Setting Server
-	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
+	storage, err := storage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
 
@@ -128,7 +128,7 @@ func TestGetNonExistentAccountHandler(t *testing.T) {
 func TestGetAccountTransactionsHandler(t *testing.T) {
 	var err error
 
-	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
+	storage, err := storage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
 
@@ -232,7 +232,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 }
 
 func TestGetAccountOperationsHandler(t *testing.T) {
-	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
+	storage, err := storage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
 
@@ -344,7 +344,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 }
 
 func TestGetTransactionByHashHandler(t *testing.T) {
-	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
+	storage, err := storage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
 
@@ -406,7 +406,7 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 }
 
 func TestGetTransactionsHandler(t *testing.T) {
-	storage, err := sebakstorage.NewTestMemoryLevelDBBackend()
+	storage, err := storage.NewTestMemoryLevelDBBackend()
 	require.Nil(t, err)
 	defer storage.Close()
 

--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -240,8 +240,8 @@ func (rb BallotBody) MakeHashString() string {
 	return base58.Encode(rb.MakeHash())
 }
 
-func FinishBallot(st *sebakstorage.LevelDBBackend, ballot Ballot, transactionPool *TransactionPool) (blk Block, err error) {
-	var ts *sebakstorage.LevelDBBackend
+func FinishBallot(st *storage.LevelDBBackend, ballot Ballot, transactionPool *TransactionPool) (blk Block, err error) {
+	var ts *storage.LevelDBBackend
 	if ts, err = st.OpenTransaction(); err != nil {
 		return
 	}

--- a/lib/block.go
+++ b/lib/block.go
@@ -39,7 +39,7 @@ func (bck Block) String() string {
 	return string(encoded)
 }
 
-func MakeGenesisBlock(st *sebakstorage.LevelDBBackend, account block.BlockAccount) Block {
+func MakeGenesisBlock(st *storage.LevelDBBackend, account block.BlockAccount) Block {
 	proposer := "" // null proposer
 	round := round.Round{
 		Number:      0,
@@ -106,7 +106,7 @@ func (b Block) NewBlockKeyConfirmed() string {
 	)
 }
 
-func (b Block) Save(st *sebakstorage.LevelDBBackend) (err error) {
+func (b Block) Save(st *storage.LevelDBBackend) (err error) {
 	key := GetBlockKey(b.Hash)
 
 	var exists bool
@@ -128,14 +128,14 @@ func (b Block) Save(st *sebakstorage.LevelDBBackend) (err error) {
 	return
 }
 
-func GetBlock(st *sebakstorage.LevelDBBackend, hash string) (bt Block, err error) {
+func GetBlock(st *storage.LevelDBBackend, hash string) (bt Block, err error) {
 	err = st.Get(GetBlockKey(hash), &bt)
 	return
 }
 
 func LoadBlocksInsideIterator(
-	st *sebakstorage.LevelDBBackend,
-	iterFunc func() (sebakstorage.IterItem, bool),
+	st *storage.LevelDBBackend,
+	iterFunc func() (storage.IterItem, bool),
 	closeFunc func(),
 ) (
 	func() (Block, bool),
@@ -162,7 +162,7 @@ func LoadBlocksInsideIterator(
 		})
 }
 
-func GetBlocksByConfirmed(st *sebakstorage.LevelDBBackend, reverse bool) (
+func GetBlocksByConfirmed(st *storage.LevelDBBackend, reverse bool) (
 	func() (Block, bool),
 	func(),
 ) {
@@ -171,7 +171,7 @@ func GetBlocksByConfirmed(st *sebakstorage.LevelDBBackend, reverse bool) (
 	return LoadBlocksInsideIterator(st, iterFunc, closeFunc)
 }
 
-func GetLatestBlock(st *sebakstorage.LevelDBBackend) (b Block, err error) {
+func GetLatestBlock(st *storage.LevelDBBackend) (b Block, err error) {
 	// get latest blocks
 	iterFunc, closeFunc := GetBlocksByConfirmed(st, true)
 	b, _ = iterFunc()

--- a/lib/block/account.go
+++ b/lib/block/account.go
@@ -45,7 +45,7 @@ func (b *BlockAccount) String() string {
 	return string(common.MustJSONMarshal(b))
 }
 
-func (b *BlockAccount) Save(st *sebakstorage.LevelDBBackend) (err error) {
+func (b *BlockAccount) Save(st *storage.LevelDBBackend) (err error) {
 	key := GetBlockAccountKey(b.Address)
 
 	var exists bool
@@ -94,11 +94,11 @@ func GetBlockAccountCreatedKey(created string) string {
 	return fmt.Sprintf("%s%s", BlockAccountPrefixCreated, created)
 }
 
-func ExistBlockAccount(st *sebakstorage.LevelDBBackend, address string) (exists bool, err error) {
+func ExistBlockAccount(st *storage.LevelDBBackend, address string) (exists bool, err error) {
 	return st.Has(GetBlockAccountKey(address))
 }
 
-func GetBlockAccount(st *sebakstorage.LevelDBBackend, address string) (b *BlockAccount, err error) {
+func GetBlockAccount(st *storage.LevelDBBackend, address string) (b *BlockAccount, err error) {
 	if err = st.Get(GetBlockAccountKey(address), &b); err != nil {
 		return
 	}
@@ -106,7 +106,7 @@ func GetBlockAccount(st *sebakstorage.LevelDBBackend, address string) (b *BlockA
 	return
 }
 
-func GetBlockAccountAddressesByCreated(st *sebakstorage.LevelDBBackend, reverse bool) (func() (string, bool), func()) {
+func GetBlockAccountAddressesByCreated(st *storage.LevelDBBackend, reverse bool) (func() (string, bool), func()) {
 	iterFunc, closeFunc := st.GetIterator(BlockAccountPrefixCreated, reverse)
 
 	return (func() (string, bool) {
@@ -123,7 +123,7 @@ func GetBlockAccountAddressesByCreated(st *sebakstorage.LevelDBBackend, reverse 
 		})
 }
 
-func GetBlockAccountsByCreated(st *sebakstorage.LevelDBBackend, reverse bool) (func() (*BlockAccount, bool), func()) {
+func GetBlockAccountsByCreated(st *storage.LevelDBBackend, reverse bool) (func() (*BlockAccount, bool), func()) {
 	iterFunc, closeFunc := GetBlockAccountAddressesByCreated(st, reverse)
 
 	return (func() (*BlockAccount, bool) {
@@ -207,7 +207,7 @@ func (b *BlockAccountCheckpoint) String() string {
 	return string(common.MustJSONMarshal(b))
 }
 
-func (b *BlockAccountCheckpoint) Save(st *sebakstorage.LevelDBBackend) (err error) {
+func (b *BlockAccountCheckpoint) Save(st *storage.LevelDBBackend) (err error) {
 	key := GetBlockAccountCheckpointKey(b.Address, b.Checkpoint)
 
 	var exists bool
@@ -231,7 +231,7 @@ func (b *BlockAccountCheckpoint) Save(st *sebakstorage.LevelDBBackend) (err erro
 	return
 }
 
-func GetBlockAccountCheckpoint(st *sebakstorage.LevelDBBackend, address, checkpoint string) (b BlockAccountCheckpoint, err error) {
+func GetBlockAccountCheckpoint(st *storage.LevelDBBackend, address, checkpoint string) (b BlockAccountCheckpoint, err error) {
 	if err = st.Get(GetBlockAccountCheckpointKey(address, checkpoint), &b); err != nil {
 		return
 	}
@@ -239,7 +239,7 @@ func GetBlockAccountCheckpoint(st *sebakstorage.LevelDBBackend, address, checkpo
 	return
 }
 
-func GetBlockAccountCheckpointByAddress(st *sebakstorage.LevelDBBackend, address string, reverse bool) (func() (BlockAccountCheckpoint, bool), func()) {
+func GetBlockAccountCheckpointByAddress(st *storage.LevelDBBackend, address string, reverse bool) (func() (BlockAccountCheckpoint, bool), func()) {
 	prefix := GetBlockAccountCheckpointByAddressKeyPrefix(address)
 	iterFunc, closeFunc := st.GetIterator(prefix, reverse)
 

--- a/lib/block/account_test.go
+++ b/lib/block/account_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestSaveNewBlockAccount(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	b := TestMakeBlockAccount()
 	err := b.Save(st)
@@ -26,7 +26,7 @@ func TestSaveNewBlockAccount(t *testing.T) {
 }
 
 func TestSaveExistingBlockAccount(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	b := TestMakeBlockAccount()
 	b.Save(st)
@@ -42,7 +42,7 @@ func TestSaveExistingBlockAccount(t *testing.T) {
 }
 
 func TestSortMultipleBlockAccount(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	var createdOrder []string
 	for i := 0; i < 50; i++ {
@@ -70,7 +70,7 @@ func TestSortMultipleBlockAccount(t *testing.T) {
 }
 
 func TestGetSortedBlockAccounts(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	var createdOrder []string
 	for i := 0; i < 50; i++ {
@@ -98,7 +98,7 @@ func TestGetSortedBlockAccounts(t *testing.T) {
 }
 
 func TestBlockAccountSaveBlockAccountCheckpoints(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	b := TestMakeBlockAccount()
 	b.Save(st)
@@ -143,7 +143,7 @@ func TestBlockAccountObserver(t *testing.T) {
 	observer.BlockAccountObserver.On(fmt.Sprintf("address-%s", b.Address), ObserverFunc)
 	defer observer.BlockAccountObserver.Off(fmt.Sprintf("address-%s", b.Address), ObserverFunc)
 
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	b.Save(st)
 

--- a/lib/block_operation.go
+++ b/lib/block_operation.go
@@ -59,7 +59,7 @@ func NewBlockOperationFromOperation(op Operation, tx Transaction) BlockOperation
 	}
 }
 
-func (bo *BlockOperation) Save(st *sebakstorage.LevelDBBackend) (err error) {
+func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 	if bo.isSaved {
 		return errors.ErrorAlreadySaved
 	}
@@ -175,11 +175,11 @@ func (bo BlockOperation) NewBlockOperationPeersKey() string {
 	)
 }
 
-func ExistBlockOperation(st *sebakstorage.LevelDBBackend, hash string) (bool, error) {
+func ExistBlockOperation(st *storage.LevelDBBackend, hash string) (bool, error) {
 	return st.Has(GetBlockOperationKey(hash))
 }
 
-func GetBlockOperation(st *sebakstorage.LevelDBBackend, hash string) (bo BlockOperation, err error) {
+func GetBlockOperation(st *storage.LevelDBBackend, hash string) (bo BlockOperation, err error) {
 	if err = st.Get(GetBlockOperationKey(hash), &bo); err != nil {
 		return
 	}
@@ -189,8 +189,8 @@ func GetBlockOperation(st *sebakstorage.LevelDBBackend, hash string) (bo BlockOp
 }
 
 func LoadBlockOperationsInsideIterator(
-	st *sebakstorage.LevelDBBackend,
-	iterFunc func() (sebakstorage.IterItem, bool),
+	st *storage.LevelDBBackend,
+	iterFunc func() (storage.IterItem, bool),
 	closeFunc func(),
 ) (
 	func() (BlockOperation, bool),
@@ -217,7 +217,7 @@ func LoadBlockOperationsInsideIterator(
 		})
 }
 
-func GetBlockOperationsByTxHash(st *sebakstorage.LevelDBBackend, txHash string, reverse bool) (
+func GetBlockOperationsByTxHash(st *storage.LevelDBBackend, txHash string, reverse bool) (
 	func() (BlockOperation, bool),
 	func(),
 ) {
@@ -226,7 +226,7 @@ func GetBlockOperationsByTxHash(st *sebakstorage.LevelDBBackend, txHash string, 
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
 
-func GetBlockOperationsBySource(st *sebakstorage.LevelDBBackend, source string, reverse bool) (
+func GetBlockOperationsBySource(st *storage.LevelDBBackend, source string, reverse bool) (
 	func() (BlockOperation, bool),
 	func(),
 ) {
@@ -235,7 +235,7 @@ func GetBlockOperationsBySource(st *sebakstorage.LevelDBBackend, source string, 
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
 
-func GetBlockOperationsByTarget(st *sebakstorage.LevelDBBackend, target string, reverse bool) (
+func GetBlockOperationsByTarget(st *storage.LevelDBBackend, target string, reverse bool) (
 	func() (BlockOperation, bool),
 	func(),
 ) {
@@ -244,7 +244,7 @@ func GetBlockOperationsByTarget(st *sebakstorage.LevelDBBackend, target string, 
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
 
-func GetBlockOperationsByCheckpoint(st *sebakstorage.LevelDBBackend, checkpoint string, reverse bool) (
+func GetBlockOperationsByCheckpoint(st *storage.LevelDBBackend, checkpoint string, reverse bool) (
 	func() (BlockOperation, bool),
 	func(),
 ) {

--- a/lib/block_operation_test.go
+++ b/lib/block_operation_test.go
@@ -24,7 +24,7 @@ func TestNewBlockOperationFromOperation(t *testing.T) {
 }
 
 func TestBlockOperationSaveAndGet(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	bos := TestMakeNewBlockOperation(networkID, 1)
 	if err := bos[0].Save(st); err != nil {
@@ -44,7 +44,7 @@ func TestBlockOperationSaveAndGet(t *testing.T) {
 }
 
 func TestBlockOperationSaveExisting(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	bos := TestMakeNewBlockOperation(networkID, 1)
 	bo := bos[0]
@@ -60,7 +60,7 @@ func TestBlockOperationSaveExisting(t *testing.T) {
 }
 
 func TestGetSortedBlockOperationsByTxHash(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	// create 30 `BlockOperation`
 	var txHashes []string
@@ -96,7 +96,7 @@ func TestGetSortedBlockOperationsByTxHash(t *testing.T) {
 }
 
 func TestBlockOperationSaveByTransacton(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	_, tx := TestMakeTransaction(networkID, 10)
 	block := testMakeNewBlock([]string{tx.GetHash()})
@@ -127,7 +127,7 @@ func TestBlockOperationSaveByTransacton(t *testing.T) {
 }
 
 func TestBlockOperationGetSortedByCheckpoint(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	_, tx := TestMakeTransaction(networkID, 10)
 	block := testMakeNewBlock([]string{tx.GetHash()})

--- a/lib/block_transaction.go
+++ b/lib/block_transaction.go
@@ -112,7 +112,7 @@ func (bt BlockTransaction) NewBlockTransactionKeyByBlock(hash string) string {
 	)
 }
 
-func (bt *BlockTransaction) Save(st *sebakstorage.LevelDBBackend) (err error) {
+func (bt *BlockTransaction) Save(st *storage.LevelDBBackend) (err error) {
 	if bt.isSaved {
 		return errors.ErrorAlreadySaved
 	}
@@ -205,7 +205,7 @@ func GetBlockTransactionKey(hash string) string {
 	return fmt.Sprintf("%s%s", BlockTransactionPrefixHash, hash)
 }
 
-func GetBlockTransaction(st *sebakstorage.LevelDBBackend, hash string) (bt BlockTransaction, err error) {
+func GetBlockTransaction(st *storage.LevelDBBackend, hash string) (bt BlockTransaction, err error) {
 	if err = st.Get(GetBlockTransactionKey(hash), &bt); err != nil {
 		return
 	}
@@ -214,13 +214,13 @@ func GetBlockTransaction(st *sebakstorage.LevelDBBackend, hash string) (bt Block
 	return
 }
 
-func ExistBlockTransaction(st *sebakstorage.LevelDBBackend, hash string) (bool, error) {
+func ExistBlockTransaction(st *storage.LevelDBBackend, hash string) (bool, error) {
 	return st.Has(GetBlockTransactionKey(hash))
 }
 
 func LoadBlockTransactionsInsideIterator(
-	st *sebakstorage.LevelDBBackend,
-	iterFunc func() (sebakstorage.IterItem, bool),
+	st *storage.LevelDBBackend,
+	iterFunc func() (storage.IterItem, bool),
 	closeFunc func(),
 ) (
 	func() (BlockTransaction, bool),
@@ -247,7 +247,7 @@ func LoadBlockTransactionsInsideIterator(
 		})
 }
 
-func GetBlockTransactionByCheckpoint(st *sebakstorage.LevelDBBackend, checkpoint string) (bt BlockTransaction, err error) {
+func GetBlockTransactionByCheckpoint(st *storage.LevelDBBackend, checkpoint string) (bt BlockTransaction, err error) {
 	var hash string
 	if err = st.Get(GetBlockTransactionKeyCheckpoint(checkpoint), &hash); err != nil {
 		return
@@ -257,7 +257,7 @@ func GetBlockTransactionByCheckpoint(st *sebakstorage.LevelDBBackend, checkpoint
 	return
 }
 
-func GetBlockTransactionsBySource(st *sebakstorage.LevelDBBackend, source string, reverse bool) (
+func GetBlockTransactionsBySource(st *storage.LevelDBBackend, source string, reverse bool) (
 	func() (BlockTransaction, bool),
 	func(),
 ) {
@@ -266,7 +266,7 @@ func GetBlockTransactionsBySource(st *sebakstorage.LevelDBBackend, source string
 	return LoadBlockTransactionsInsideIterator(st, iterFunc, closeFunc)
 }
 
-func GetBlockTransactionsByConfirmed(st *sebakstorage.LevelDBBackend, reverse bool) (
+func GetBlockTransactionsByConfirmed(st *storage.LevelDBBackend, reverse bool) (
 	func() (BlockTransaction, bool),
 	func(),
 ) {
@@ -275,7 +275,7 @@ func GetBlockTransactionsByConfirmed(st *sebakstorage.LevelDBBackend, reverse bo
 	return LoadBlockTransactionsInsideIterator(st, iterFunc, closeFunc)
 }
 
-func GetBlockTransactionsByAccount(st *sebakstorage.LevelDBBackend, accountAddress string, reverse bool) (
+func GetBlockTransactionsByAccount(st *storage.LevelDBBackend, accountAddress string, reverse bool) (
 	func() (BlockTransaction, bool),
 	func(),
 ) {
@@ -283,7 +283,7 @@ func GetBlockTransactionsByAccount(st *sebakstorage.LevelDBBackend, accountAddre
 	return LoadBlockTransactionsInsideIterator(st, iterFunc, closeFunc)
 }
 
-func GetBlockTransactionsByBlock(st *sebakstorage.LevelDBBackend, hash string, reverse bool) (
+func GetBlockTransactionsByBlock(st *storage.LevelDBBackend, hash string, reverse bool) (
 	func() (BlockTransaction, bool),
 	func(),
 ) {

--- a/lib/block_transaction_history.go
+++ b/lib/block_transaction_history.go
@@ -51,7 +51,7 @@ func (bt BlockTransactionHistory) Serialize() (encoded []byte, err error) {
 	encoded, err = common.EncodeJSONValue(bt)
 	return
 }
-func (bt *BlockTransactionHistory) Save(st *sebakstorage.LevelDBBackend) (err error) {
+func (bt *BlockTransactionHistory) Save(st *storage.LevelDBBackend) (err error) {
 	if bt.isSaved {
 		return errors.ErrorAlreadySaved
 	}
@@ -76,7 +76,7 @@ func (bt *BlockTransactionHistory) Save(st *sebakstorage.LevelDBBackend) (err er
 	return nil
 }
 
-func GetBlockTransactionHistory(st *sebakstorage.LevelDBBackend, hash string) (bt BlockTransactionHistory, err error) {
+func GetBlockTransactionHistory(st *storage.LevelDBBackend, hash string) (bt BlockTransactionHistory, err error) {
 	if err = st.Get(GetBlockTransactionHistoryKey(hash), &bt); err != nil {
 		return
 	}
@@ -85,7 +85,7 @@ func GetBlockTransactionHistory(st *sebakstorage.LevelDBBackend, hash string) (b
 	return
 }
 
-func ExistsBlockTransactionHistory(st *sebakstorage.LevelDBBackend, hash string) (bool, error) {
+func ExistsBlockTransactionHistory(st *storage.LevelDBBackend, hash string) (bool, error) {
 	return st.Has(GetBlockTransactionHistoryKey(hash))
 }
 

--- a/lib/block_transaction_test.go
+++ b/lib/block_transaction_test.go
@@ -36,7 +36,7 @@ func TestNewBlockTransaction(t *testing.T) {
 }
 
 func TestBlockTransactionSaveAndGet(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	bt := TestMakeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
@@ -56,7 +56,7 @@ func TestBlockTransactionSaveAndGet(t *testing.T) {
 }
 
 func TestBlockTransactionSaveExisting(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	bt := TestMakeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
@@ -73,7 +73,7 @@ func TestBlockTransactionSaveExisting(t *testing.T) {
 
 /*
 func TestGetSortedBlockTransactionsByCheckpoint(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	// create 30 `BlockOperation`
 	var createdOrder []string
@@ -109,7 +109,7 @@ func TestGetSortedBlockTransactionsByCheckpoint(t *testing.T) {
 func TestMultipleBlockTransactionSource(t *testing.T) {
 	kp, _ := keypair.Random()
 	kpAnother, _ := keypair.Random()
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	numTxs := 10
 
@@ -193,7 +193,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 
 func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 	kp, _ := keypair.Random()
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	numTxs := 10
 
@@ -256,7 +256,7 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 }
 
 func TestBlockTransactionMultipleSave(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	bt := TestMakeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
@@ -271,7 +271,7 @@ func TestBlockTransactionMultipleSave(t *testing.T) {
 }
 
 func TestBlockTransactionGetByCheckpoint(t *testing.T) {
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	bt := TestMakeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
@@ -293,7 +293,7 @@ func TestBlockTransactionGetByCheckpoint(t *testing.T) {
 func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	kp, _ := keypair.Random()
 	kpAnother, _ := keypair.Random()
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	numTxs := 5
 
@@ -372,7 +372,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 
 func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	kp, _ := keypair.Random()
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	numTxs := 5
 

--- a/lib/common/message.go
+++ b/lib/common/message.go
@@ -8,5 +8,5 @@ type Message interface {
 	IsWellFormed([]byte) error
 	Equal(Message) bool
 	Source() string
-	// Validate(sebakstorage.LevelDBBackend) error
+	// Validate(storage.LevelDBBackend) error
 }

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -129,8 +129,8 @@ type ISAAC struct {
 
 func NewISAAC(networkID []byte, node *node.LocalNode, votingThresholdPolicy common.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		NetworkID: networkID,
-		Node:      node,
+		NetworkID:             networkID,
+		Node:                  node,
 		VotingThresholdPolicy: votingThresholdPolicy,
 		TransactionPool:       NewTransactionPool(),
 		RunningRounds:         map[string]*RunningRound{},

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -129,8 +129,8 @@ type ISAAC struct {
 
 func NewISAAC(networkID []byte, node *node.LocalNode, votingThresholdPolicy common.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		NetworkID:             networkID,
-		Node:                  node,
+		NetworkID: networkID,
+		Node:      node,
 		VotingThresholdPolicy: votingThresholdPolicy,
 		TransactionPool:       NewTransactionPool(),
 		RunningRounds:         map[string]*RunningRound{},

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -72,7 +72,7 @@ type NodeRunner struct {
 	network            network.Network
 	consensus          *ISAAC
 	connectionManager  *network.ConnectionManager
-	storage            *sebakstorage.LevelDBBackend
+	storage            *storage.LevelDBBackend
 	proposerCalculator ProposerCalculator
 
 	handleTransactionCheckerFuncs  []common.CheckerFunc
@@ -95,7 +95,7 @@ func NewNodeRunner(
 	policy common.VotingThresholdPolicy,
 	n network.Network,
 	consensus *ISAAC,
-	storage *sebakstorage.LevelDBBackend,
+	storage *storage.LevelDBBackend,
 ) (nr *NodeRunner, err error) {
 	nr = &NodeRunner{
 		networkID: []byte(networkID),
@@ -224,7 +224,7 @@ func (nr *NodeRunner) ConnectionManager() *network.ConnectionManager {
 	return nr.connectionManager
 }
 
-func (nr *NodeRunner) Storage() *sebakstorage.LevelDBBackend {
+func (nr *NodeRunner) Storage() *storage.LevelDBBackend {
 	return nr.storage
 }
 

--- a/lib/node_runner_checker_test.go
+++ b/lib/node_runner_checker_test.go
@@ -9,6 +9,7 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/network"
 )
 
 func TestOnlyValidTransactionInTransactionPool(t *testing.T) {

--- a/lib/node_runner_checker_test.go
+++ b/lib/node_runner_checker_test.go
@@ -9,7 +9,6 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
-	"boscoin.io/sebak/lib/network"
 )
 
 func TestOnlyValidTransactionInTransactionPool(t *testing.T) {

--- a/lib/node_runner_message_checker_test.go
+++ b/lib/node_runner_message_checker_test.go
@@ -7,7 +7,6 @@ import (
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
-	"boscoin.io/sebak/lib/network"
 )
 
 func TestMessageChecker(t *testing.T) {

--- a/lib/node_runner_message_checker_test.go
+++ b/lib/node_runner_message_checker_test.go
@@ -7,6 +7,7 @@ import (
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/network"
 )
 
 func TestMessageChecker(t *testing.T) {

--- a/lib/node_runner_test.go
+++ b/lib/node_runner_test.go
@@ -9,6 +9,7 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
 

--- a/lib/node_runner_test.go
+++ b/lib/node_runner_test.go
@@ -58,7 +58,7 @@ func createTestNodeRunner(n int) []*NodeRunner {
 		v := nodes[i]
 		p, _ := NewDefaultVotingThresholdPolicy(66, 66)
 		is, _ := NewISAAC(networkID, v, p)
-		st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+		st, _ := storage.NewTestMemoryLevelDBBackend()
 
 		account.Save(st)
 		genesisBlock = MakeGenesisBlock(st, *account)
@@ -152,7 +152,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 	for _, node := range nodes {
 		vth, _ := NewDefaultVotingThresholdPolicy(66, 66)
 		is, _ := NewISAAC(networkID, node, vth)
-		st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+		st, _ := storage.NewTestMemoryLevelDBBackend()
 		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node.Endpoint())
 		network := network.NewHTTP2Network(networkConfig)
 		nodeRunner, _ := NewNodeRunner(string(networkID), node, vth, network, is, st)

--- a/lib/node_runner_test.go
+++ b/lib/node_runner_test.go
@@ -9,7 +9,6 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
 

--- a/lib/operation.go
+++ b/lib/operation.go
@@ -39,7 +39,7 @@ func (o Operation) IsWellFormed(networkID []byte) (err error) {
 	return
 }
 
-func (o Operation) Validate(st *sebakstorage.LevelDBBackend) (err error) {
+func (o Operation) Validate(st *storage.LevelDBBackend) (err error) {
 	if err = o.B.Validate(st); err != nil {
 		return
 	}
@@ -132,14 +132,14 @@ type OperationHeader struct {
 }
 
 type OperationBody interface {
-	Validate(*sebakstorage.LevelDBBackend) error
+	Validate(*storage.LevelDBBackend) error
 	IsWellFormed([]byte) error
 	TargetAddress() string
 	GetAmount() common.Amount
 }
 
 // FinishOperation do finish the task after consensus by the type of each operation.
-func FinishOperation(st *sebakstorage.LevelDBBackend, tx Transaction, op Operation) (err error) {
+func FinishOperation(st *storage.LevelDBBackend, tx Transaction, op Operation) (err error) {
 	switch op.H.Type {
 	case OperationCreateAccount:
 		return FinishOperationCreateAccount(st, tx, op)

--- a/lib/operation_create_account.go
+++ b/lib/operation_create_account.go
@@ -36,7 +36,7 @@ func (o OperationBodyCreateAccount) IsWellFormed([]byte) (err error) {
 	return
 }
 
-func (o OperationBodyCreateAccount) Validate(st *sebakstorage.LevelDBBackend) (err error) {
+func (o OperationBodyCreateAccount) Validate(st *storage.LevelDBBackend) (err error) {
 	var exists bool
 	if exists, err = block.ExistBlockAccount(st, o.Target); err == nil && exists {
 		err = errors.ErrorBlockAccountAlreadyExists
@@ -54,7 +54,7 @@ func (o OperationBodyCreateAccount) GetAmount() common.Amount {
 	return o.Amount
 }
 
-func FinishOperationCreateAccount(st *sebakstorage.LevelDBBackend, tx Transaction, op Operation) (err error) {
+func FinishOperationCreateAccount(st *storage.LevelDBBackend, tx Transaction, op Operation) (err error) {
 	var baSource, baTarget *block.BlockAccount
 	if baSource, err = block.GetBlockAccount(st, tx.B.Source); err != nil {
 		err = errors.ErrorBlockAccountDoesNotExists

--- a/lib/operation_payment.go
+++ b/lib/operation_payment.go
@@ -42,7 +42,7 @@ func (o OperationBodyPayment) IsWellFormed([]byte) (err error) {
 	return
 }
 
-func (o OperationBodyPayment) Validate(st *sebakstorage.LevelDBBackend) (err error) {
+func (o OperationBodyPayment) Validate(st *storage.LevelDBBackend) (err error) {
 	var exists bool
 	if exists, err = block.ExistBlockAccount(st, o.Target); err == nil && !exists {
 		err = errors.ErrorBlockAccountDoesNotExists
@@ -60,7 +60,7 @@ func (o OperationBodyPayment) GetAmount() common.Amount {
 	return o.Amount
 }
 
-func FinishOperationPayment(st *sebakstorage.LevelDBBackend, tx Transaction, op Operation) (err error) {
+func FinishOperationPayment(st *storage.LevelDBBackend, tx Transaction, op Operation) (err error) {
 	var baSource, baTarget *block.BlockAccount
 	if baSource, err = block.GetBlockAccount(st, tx.B.Source); err != nil {
 		err = errors.ErrorBlockAccountDoesNotExists

--- a/lib/statedb/statedb_test.go
+++ b/lib/statedb/statedb_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestStateDB(t *testing.T) {
 	var Root = common.Hash{}
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 
 	var keyHash = common.BytesToHash(common.MakeHash([]byte("key")))
 	var valueHash = common.BytesToHash(common.MakeHash([]byte("value")))

--- a/lib/storage/dbbackend.go
+++ b/lib/storage/dbbackend.go
@@ -1,4 +1,4 @@
-package sebakstorage
+package storage
 
 type DBBackend interface {
 	Has(string) (bool, error)

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -1,4 +1,4 @@
-package sebakstorage
+package storage
 
 import (
 	"encoding/json"

--- a/lib/storage/leveldb_test.go
+++ b/lib/storage/leveldb_test.go
@@ -1,4 +1,4 @@
-package sebakstorage
+package storage
 
 import (
 	"fmt"

--- a/lib/storage/statedb.go
+++ b/lib/storage/statedb.go
@@ -1,4 +1,4 @@
-package sebakstorage
+package storage
 
 import (
 	"sort"

--- a/lib/storage/statedb_test.go
+++ b/lib/storage/statedb_test.go
@@ -1,4 +1,4 @@
-package sebakstorage
+package storage
 
 import (
 	"testing"

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -1,4 +1,4 @@
-package sebakstorage
+package storage
 
 import (
 	"errors"

--- a/lib/storage/test.go
+++ b/lib/storage/test.go
@@ -1,4 +1,4 @@
-package sebakstorage
+package storage
 
 import (
 	"fmt"

--- a/lib/test.go
+++ b/lib/test.go
@@ -48,7 +48,7 @@ func MakeNodeRunner() (*NodeRunner, *node.LocalNode) {
 
 	vth, _ := NewDefaultVotingThresholdPolicy(66, 66)
 	is, _ := NewISAAC(networkID, localNode, vth)
-	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
 	network, _ := createNetMemoryNetwork()
 	nodeRunner, _ := NewNodeRunner(string(networkID), localNode, vth, network, is, st)
 	return nodeRunner, localNode

--- a/lib/transaction.go
+++ b/lib/transaction.go
@@ -114,7 +114,7 @@ func (tx Transaction) IsWellFormed(networkID []byte) (err error) {
 // * checkpoint is valid
 // * source has enough balance to pay
 // * and it's `Operations`
-func (tx Transaction) Validate(st *sebakstorage.LevelDBBackend) (err error) {
+func (tx Transaction) Validate(st *storage.LevelDBBackend) (err error) {
 	// check, source exists
 	var ba *block.BlockAccount
 	if ba, err = block.GetBlockAccount(st, tx.B.Source); err != nil {

--- a/lib/trie/database.go
+++ b/lib/trie/database.go
@@ -8,11 +8,11 @@ import (
 )
 
 type EthDatabase struct {
-	ldbBackend *sebakstorage.LevelDBBackend
+	ldbBackend *storage.LevelDBBackend
 	quitLock   sync.Mutex // Mutex protecting the quit channel access
 }
 
-func NewEthDatabase(ldb *sebakstorage.LevelDBBackend) *EthDatabase {
+func NewEthDatabase(ldb *storage.LevelDBBackend) *EthDatabase {
 	return &EthDatabase{
 		ldbBackend: ldb,
 	}
@@ -48,12 +48,12 @@ func (db *EthDatabase) NewBatch() ethdb.Batch {
 	return &ldbBatch{db: db.ldbBackend, b: new(leveldb.Batch)}
 }
 
-func (db *EthDatabase) BackEnd() *sebakstorage.LevelDBBackend {
+func (db *EthDatabase) BackEnd() *storage.LevelDBBackend {
 	return db.ldbBackend
 }
 
 type ldbBatch struct {
-	db   *sebakstorage.LevelDBBackend
+	db   *storage.LevelDBBackend
 	b    *leveldb.Batch
 	size int
 }


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->
Subset of #289

### Solution
1. Just rename sebakstorage to storage
1. Rename storage parameter in genesis.go:MakeGenesisBlock() method