### PR TITLE
Rename sebakcommon package

### DIFF
--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -9,12 +9,12 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/keypair"
 
+	"boscoin.io/sebak/cmd/sebak/common"
+
 	"boscoin.io/sebak/lib"
+	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/storage"
-
-	"boscoin.io/sebak/cmd/sebak/common"
-	"boscoin.io/sebak/lib/block"
 )
 
 const (
@@ -34,7 +34,7 @@ func init() {
 		Run: func(c *cobra.Command, args []string) {
 			flagName, err := MakeGenesisBlock(args[0], flagNetworkID, flagBalance, flagStorageConfigString)
 			if len(flagName) != 0 || err != nil {
-				common.PrintFlagsError(c, flagName, err)
+				cmdcommon.PrintFlagsError(c, flagName, err)
 			}
 
 			fmt.Println("successfully created genesis block")
@@ -87,7 +87,7 @@ func MakeGenesisBlock(addressStr, networkID, balanceStr, storage string) (string
 		balanceStr = initialBalance
 	}
 
-	if balance, err = common.ParseAmountFromString(balanceStr); err != nil {
+	if balance, err = cmdcommon.ParseAmountFromString(balanceStr); err != nil {
 		return "--balance", err
 	}
 

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -23,7 +23,7 @@ const (
 
 var (
 	genesisCmd  *cobra.Command
-	flagBalance string = sebakcommon.GetENVValue("SEBAK_GENESIS_BALANCE", initialBalance)
+	flagBalance string = common.GetENVValue("SEBAK_GENESIS_BALANCE", initialBalance)
 )
 
 func init() {
@@ -70,7 +70,7 @@ func init() {
 //   Note that only one needs be non-`nil` for it to be considered an error.
 //
 func MakeGenesisBlock(addressStr, networkID, balanceStr, storage string) (string, error) {
-	var balance sebakcommon.Amount
+	var balance common.Amount
 	var err error
 	var kp keypair.KP
 	var storageConfig *sebakstorage.Config
@@ -94,7 +94,7 @@ func MakeGenesisBlock(addressStr, networkID, balanceStr, storage string) (string
 	// Use the default value
 	if len(storage) == 0 {
 		// We try to get the env value first, before doing IO which could fail
-		storage = sebakcommon.GetENVValue("SEBAK_STORAGE", "")
+		storage = common.GetENVValue("SEBAK_STORAGE", "")
 		// No env, use the default (current directory)
 		if len(storage) == 0 {
 			if currentDirectory, err := os.Getwd(); err == nil {
@@ -127,7 +127,7 @@ func MakeGenesisBlock(addressStr, networkID, balanceStr, storage string) (string
 	account := block.NewBlockAccount(
 		kp.Address(),
 		balance,
-		sebakcommon.MakeGenesisCheckpoint([]byte(flagNetworkID)),
+		common.MakeGenesisCheckpoint([]byte(flagNetworkID)),
 	)
 	account.Save(st)
 

--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stellar/go/keypair"
 
-	"boscoin.io/sebak/cmd/sebak/common"
+	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 
 	"boscoin.io/sebak/lib"
 	"boscoin.io/sebak/lib/block"

--- a/cmd/sebak/cmd/init.go
+++ b/cmd/sebak/cmd/init.go
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		common.PrintFlagsError(rootCmd, "", err)
+		cmdcommon.PrintFlagsError(rootCmd, "", err)
 	}
 }
 

--- a/cmd/sebak/cmd/init.go
+++ b/cmd/sebak/cmd/init.go
@@ -20,7 +20,7 @@ var rootCmd = &cobra.Command{
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		cmdcommon.PrintFlagsError(rootCmd, "", err)
+		common.PrintFlagsError(rootCmd, "", err)
 	}
 }
 

--- a/cmd/sebak/cmd/key/generate.go
+++ b/cmd/sebak/cmd/key/generate.go
@@ -62,20 +62,20 @@ func init() {
 			input := strings.TrimSpace(strings.Join(args, " "))
 
 			if flagPublicKey && len(input) == 0 {
-				common.PrintFlagsError(c, "--parse", errors.New("--parse needs <secret seed>"))
+				cmdcommon.PrintFlagsError(c, "--parse", errors.New("--parse needs <secret seed>"))
 			}
 
 			kp, err := generateKP(input, flagPublicKey)
 
 			if flagPublicKey && err != nil {
-				common.PrintFlagsError(c, "<input>", fmt.Errorf("failed to parse secret seed: %v", err))
+				cmdcommon.PrintFlagsError(c, "<input>", fmt.Errorf("failed to parse secret seed: %v", err))
 			} else if !flagPublicKey && len(input) > 0 {
 				passphrase = &input
 			}
 
-			encoders := map[string]common.Encode{
-				"json":       common.DefaultEncodes["json"],
-				"prettyjson": common.DefaultEncodes["prettyjson"],
+			encoders := map[string]cmdcommon.Encode{
+				"json":       cmdcommon.DefaultEncodes["json"],
+				"prettyjson": cmdcommon.DefaultEncodes["prettyjson"],
 				"default":    defaultEncode,
 				"oneline":    onelineEncode,
 			}
@@ -92,7 +92,7 @@ func init() {
 					panic(err)
 				}
 			} else {
-				common.PrintFlagsError(c, "format", fmt.Errorf(`"%s" not recognized`, flagFormat))
+				cmdcommon.PrintFlagsError(c, "format", fmt.Errorf(`"%s" not recognized`, flagFormat))
 			}
 
 			t := template.Must(template.New("").Parse(`       Secret Seed: {{ .seed }}

--- a/cmd/sebak/cmd/key/generate.go
+++ b/cmd/sebak/cmd/key/generate.go
@@ -62,20 +62,20 @@ func init() {
 			input := strings.TrimSpace(strings.Join(args, " "))
 
 			if flagPublicKey && len(input) == 0 {
-				cmdcommon.PrintFlagsError(c, "--parse", errors.New("--parse needs <secret seed>"))
+				common.PrintFlagsError(c, "--parse", errors.New("--parse needs <secret seed>"))
 			}
 
 			kp, err := generateKP(input, flagPublicKey)
 
 			if flagPublicKey && err != nil {
-				cmdcommon.PrintFlagsError(c, "<input>", fmt.Errorf("failed to parse secret seed: %v", err))
+				common.PrintFlagsError(c, "<input>", fmt.Errorf("failed to parse secret seed: %v", err))
 			} else if !flagPublicKey && len(input) > 0 {
 				passphrase = &input
 			}
 
-			encoders := map[string]cmdcommon.Encode{
-				"json":       cmdcommon.DefaultEncodes["json"],
-				"prettyjson": cmdcommon.DefaultEncodes["prettyjson"],
+			encoders := map[string]common.Encode{
+				"json":       common.DefaultEncodes["json"],
+				"prettyjson": common.DefaultEncodes["prettyjson"],
 				"default":    defaultEncode,
 				"oneline":    onelineEncode,
 			}
@@ -92,7 +92,7 @@ func init() {
 					panic(err)
 				}
 			} else {
-				cmdcommon.PrintFlagsError(c, "format", fmt.Errorf(`"%s" not recognized`, flagFormat))
+				common.PrintFlagsError(c, "format", fmt.Errorf(`"%s" not recognized`, flagFormat))
 			}
 
 			t := template.Must(template.New("").Parse(`       Secret Seed: {{ .seed }}

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -84,7 +84,7 @@ func init() {
 				var balanceStr string
 				csv := strings.Split(flagGenesis, ",")
 				if len(csv) > 2 {
-					common.PrintFlagsError(nodeCmd, "--genesis",
+					cmdcommon.PrintFlagsError(nodeCmd, "--genesis",
 						errors.New("--genesis expects address[,balance], but more than 2 commas detected"))
 				}
 				if len(csv) == 2 {
@@ -92,7 +92,7 @@ func init() {
 				}
 				flagName, err := MakeGenesisBlock(csv[0], flagNetworkID, balanceStr, flagStorageConfigString)
 				if len(flagName) != 0 || err != nil {
-					common.PrintFlagsError(c, flagName, err)
+					cmdcommon.PrintFlagsError(c, flagName, err)
 				}
 			}
 
@@ -112,10 +112,10 @@ func init() {
 	// storage
 	var currentDirectory string
 	if currentDirectory, err = os.Getwd(); err != nil {
-		common.PrintFlagsError(nodeCmd, "--storage", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 	if currentDirectory, err = filepath.Abs(currentDirectory); err != nil {
-		common.PrintFlagsError(nodeCmd, "--storage", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 	flagStorageConfigString = sebakcommon.GetENVValue("SEBAK_STORAGE", fmt.Sprintf("file://%s/db", currentDirectory))
 
@@ -161,25 +161,25 @@ func parseFlagsNode() {
 	var err error
 
 	if len(flagNetworkID) < 1 {
-		common.PrintFlagsError(nodeCmd, "--network-id", errors.New("--network-id must be given"))
+		cmdcommon.PrintFlagsError(nodeCmd, "--network-id", errors.New("--network-id must be given"))
 	}
 	if len(flagValidators) < 1 {
-		common.PrintFlagsError(nodeCmd, "--validators", errors.New("must be given"))
+		cmdcommon.PrintFlagsError(nodeCmd, "--validators", errors.New("must be given"))
 	}
 	if len(flagKPSecretSeed) < 1 {
-		common.PrintFlagsError(nodeCmd, "--secret-seed", errors.New("must be given"))
+		cmdcommon.PrintFlagsError(nodeCmd, "--secret-seed", errors.New("must be given"))
 	}
 
 	var parsedKP keypair.KP
 	parsedKP, err = keypair.Parse(flagKPSecretSeed)
 	if err != nil {
-		common.PrintFlagsError(nodeCmd, "--secret-seed", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--secret-seed", err)
 	} else {
 		kp = parsedKP.(*keypair.Full)
 	}
 
 	if p, err := sebakcommon.ParseEndpoint(flagEndpointString); err != nil {
-		common.PrintFlagsError(nodeCmd, "--endpoint", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--endpoint", err)
 	} else {
 		nodeEndpoint = p
 		flagEndpointString = nodeEndpoint.String()
@@ -187,10 +187,10 @@ func parseFlagsNode() {
 
 	if strings.ToLower(nodeEndpoint.Scheme) == "https" {
 		if _, err = os.Stat(flagTLSCertFile); os.IsNotExist(err) {
-			common.PrintFlagsError(nodeCmd, "--tls-cert", err)
+			cmdcommon.PrintFlagsError(nodeCmd, "--tls-cert", err)
 		}
 		if _, err = os.Stat(flagTLSKeyFile); os.IsNotExist(err) {
-			common.PrintFlagsError(nodeCmd, "--tls-key", err)
+			cmdcommon.PrintFlagsError(nodeCmd, "--tls-key", err)
 		}
 	}
 
@@ -202,20 +202,20 @@ func parseFlagsNode() {
 	nodeEndpoint.RawQuery = queries.Encode()
 
 	if validators, err = parseFlagValidators(flagValidators); err != nil {
-		common.PrintFlagsError(nodeCmd, "--validators", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--validators", err)
 	}
 
 	for _, n := range validators {
 		if n.Address() == kp.Address() {
-			common.PrintFlagsError(nodeCmd, "--validator", fmt.Errorf("duplicated public address found"))
+			cmdcommon.PrintFlagsError(nodeCmd, "--validator", fmt.Errorf("duplicated public address found"))
 		}
 		if n.Endpoint() == nodeEndpoint {
-			common.PrintFlagsError(nodeCmd, "--validator", fmt.Errorf("duplicated endpoint found"))
+			cmdcommon.PrintFlagsError(nodeCmd, "--validator", fmt.Errorf("duplicated endpoint found"))
 		}
 	}
 
 	if storageConfig, err = sebakstorage.NewConfigFromString(flagStorageConfigString); err != nil {
-		common.PrintFlagsError(nodeCmd, "--storage", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
 	timeoutINIT = getTimeout(flagTimeoutINIT, "--timeout-init")
@@ -224,18 +224,18 @@ func parseFlagsNode() {
 	timeoutALLCONFIRM = getTimeout(flagTimeoutALLCONFIRM, "--timeout-allconfirm")
 
 	if transactionsLimit, err = strconv.ParseUint(flagTransactionsLimit, 10, 64); err != nil {
-		common.PrintFlagsError(nodeCmd, "--transactions-limit", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--transactions-limit", err)
 	}
 
 	var tmpUint64 uint64
 	if tmpUint64, err = strconv.ParseUint(flagThreshold, 10, 64); err != nil {
-		common.PrintFlagsError(nodeCmd, "--threshold", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--threshold", err)
 	} else {
 		threshold = int(tmpUint64)
 	}
 
 	if logLevel, err = logging.LvlFromString(flagLogLevel); err != nil {
-		common.PrintFlagsError(nodeCmd, "--log-level", err)
+		cmdcommon.PrintFlagsError(nodeCmd, "--log-level", err)
 	}
 
 	logHandler := logging.StdoutHandler
@@ -244,7 +244,7 @@ func parseFlagsNode() {
 		flagLogOutput = "<stdout>"
 	} else {
 		if logHandler, err = logging.FileHandler(flagLogOutput, logging.JsonFormat()); err != nil {
-			common.PrintFlagsError(nodeCmd, "--log-output", err)
+			cmdcommon.PrintFlagsError(nodeCmd, "--log-output", err)
 		}
 	}
 
@@ -293,7 +293,7 @@ func parseFlagsNode() {
 func getTimeout(timeoutStr string, errMessage string) time.Duration {
 	var timeoutDuration time.Duration
 	if tmpUint64, err := strconv.ParseUint(flagTimeoutINIT, 10, 64); err != nil {
-		common.PrintFlagsError(nodeCmd, errMessage, err)
+		cmdcommon.PrintFlagsError(nodeCmd, errMessage, err)
 	} else {
 		timeoutDuration = time.Duration(tmpUint64) * time.Second
 	}
@@ -368,7 +368,7 @@ func runNode() error {
 	{
 		cancel := make(chan struct{})
 		g.Add(func() error {
-			return common.Interrupt(cancel)
+			return cmdcommon.Interrupt(cancel)
 		}, func(error) {
 			close(cancel)
 		})

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -32,32 +32,32 @@ const defaultHost string = "0.0.0.0"
 const defaultLogLevel logging.Lvl = logging.LvlInfo
 
 var (
-	flagKPSecretSeed   string = sebakcommon.GetENVValue("SEBAK_SECRET_SEED", "")
-	flagNetworkID      string = sebakcommon.GetENVValue("SEBAK_NETWORK_ID", "")
-	flagLogLevel       string = sebakcommon.GetENVValue("SEBAK_LOG_LEVEL", defaultLogLevel.String())
-	flagLogOutput      string = sebakcommon.GetENVValue("SEBAK_LOG_OUTPUT", "")
-	flagVerbose        bool   = sebakcommon.GetENVValue("SEBAK_VERBOSE", "0") == "1"
-	flagEndpointString string = sebakcommon.GetENVValue(
+	flagKPSecretSeed   string = common.GetENVValue("SEBAK_SECRET_SEED", "")
+	flagNetworkID      string = common.GetENVValue("SEBAK_NETWORK_ID", "")
+	flagLogLevel       string = common.GetENVValue("SEBAK_LOG_LEVEL", defaultLogLevel.String())
+	flagLogOutput      string = common.GetENVValue("SEBAK_LOG_OUTPUT", "")
+	flagVerbose        bool   = common.GetENVValue("SEBAK_VERBOSE", "0") == "1"
+	flagEndpointString string = common.GetENVValue(
 		"SEBAK_ENDPOINT",
 		fmt.Sprintf("%s://%s:%d", defaultNetwork, defaultHost, defaultPort),
 	)
 	flagStorageConfigString string
-	flagTLSCertFile         string = sebakcommon.GetENVValue("SEBAK_TLS_CERT", "sebak.crt")
-	flagTLSKeyFile          string = sebakcommon.GetENVValue("SEBAK_TLS_KEY", "sebak.key")
-	flagValidators          string = sebakcommon.GetENVValue("SEBAK_VALIDATORS", "")
-	flagThreshold           string = sebakcommon.GetENVValue("SEBAK_THRESHOLD", "66")
-	flagTimeoutINIT         string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_INIT", "2")
-	flagTimeoutSIGN         string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_SIGN", "2")
-	flagTimeoutACCEPT       string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_ACCEPT", "2")
-	flagTimeoutALLCONFIRM   string = sebakcommon.GetENVValue("SEBAK_TIMEOUT_ALLCONFIRM", "2")
-	flagTransactionsLimit   string = sebakcommon.GetENVValue("SEBAK_TRANSACTIONS_LIMIT", "1000")
+	flagTLSCertFile         string = common.GetENVValue("SEBAK_TLS_CERT", "sebak.crt")
+	flagTLSKeyFile          string = common.GetENVValue("SEBAK_TLS_KEY", "sebak.key")
+	flagValidators          string = common.GetENVValue("SEBAK_VALIDATORS", "")
+	flagThreshold           string = common.GetENVValue("SEBAK_THRESHOLD", "66")
+	flagTimeoutINIT         string = common.GetENVValue("SEBAK_TIMEOUT_INIT", "2")
+	flagTimeoutSIGN         string = common.GetENVValue("SEBAK_TIMEOUT_SIGN", "2")
+	flagTimeoutACCEPT       string = common.GetENVValue("SEBAK_TIMEOUT_ACCEPT", "2")
+	flagTimeoutALLCONFIRM   string = common.GetENVValue("SEBAK_TIMEOUT_ALLCONFIRM", "2")
+	flagTransactionsLimit   string = common.GetENVValue("SEBAK_TRANSACTIONS_LIMIT", "1000")
 )
 
 var (
 	nodeCmd *cobra.Command
 
 	kp                *keypair.Full
-	nodeEndpoint      *sebakcommon.Endpoint
+	nodeEndpoint      *common.Endpoint
 	storageConfig     *sebakstorage.Config
 	validators        []*node.Validator
 	threshold         int
@@ -117,7 +117,7 @@ func init() {
 	if currentDirectory, err = filepath.Abs(currentDirectory); err != nil {
 		cmdcommon.PrintFlagsError(nodeCmd, "--storage", err)
 	}
-	flagStorageConfigString = sebakcommon.GetENVValue("SEBAK_STORAGE", fmt.Sprintf("file://%s/db", currentDirectory))
+	flagStorageConfigString = common.GetENVValue("SEBAK_STORAGE", fmt.Sprintf("file://%s/db", currentDirectory))
 
 	nodeCmd.Flags().StringVar(&flagGenesis, "genesis", flagGenesis, "performs the 'genesis' command before running node. Syntax: key[,balance]")
 	nodeCmd.Flags().StringVar(&flagKPSecretSeed, "secret-seed", flagKPSecretSeed, "secret seed of this node")
@@ -178,7 +178,7 @@ func parseFlagsNode() {
 		kp = parsedKP.(*keypair.Full)
 	}
 
-	if p, err := sebakcommon.ParseEndpoint(flagEndpointString); err != nil {
+	if p, err := common.ParseEndpoint(flagEndpointString); err != nil {
 		cmdcommon.PrintFlagsError(nodeCmd, "--endpoint", err)
 	} else {
 		nodeEndpoint = p

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -21,7 +21,7 @@ import (
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
 
-	"boscoin.io/sebak/cmd/sebak/common"
+	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 
 	"strconv"
 )

--- a/cmd/sebak/cmd/tls.go
+++ b/cmd/sebak/cmd/tls.go
@@ -38,13 +38,13 @@ func generate() {
 	network.NewKeyGenerator(flagTLSOutputPath, flagTLSCertFile, flagTLSKeyFile)
 
 	if _, err = os.Stat(flagTLSOutputPath); os.IsNotExist(err) {
-		common.PrintFlagsError(tlsCmd, "output", err)
+		cmdcommon.PrintFlagsError(tlsCmd, "output", err)
 	}
 	if _, err = os.Stat(flagTLSOutputPath + "/" + flagTLSCertFile); os.IsNotExist(err) {
-		common.PrintFlagsError(tlsCmd, "cert", err)
+		cmdcommon.PrintFlagsError(tlsCmd, "cert", err)
 	}
 	if _, err = os.Stat(flagTLSOutputPath + "/" + flagTLSKeyFile); os.IsNotExist(err) {
-		common.PrintFlagsError(tlsCmd, "key", err)
+		cmdcommon.PrintFlagsError(tlsCmd, "key", err)
 	}
 
 	log = logging.New("module", "tls")

--- a/cmd/sebak/cmd/tls.go
+++ b/cmd/sebak/cmd/tls.go
@@ -38,13 +38,13 @@ func generate() {
 	network.NewKeyGenerator(flagTLSOutputPath, flagTLSCertFile, flagTLSKeyFile)
 
 	if _, err = os.Stat(flagTLSOutputPath); os.IsNotExist(err) {
-		cmdcommon.PrintFlagsError(tlsCmd, "output", err)
+		common.PrintFlagsError(tlsCmd, "output", err)
 	}
 	if _, err = os.Stat(flagTLSOutputPath + "/" + flagTLSCertFile); os.IsNotExist(err) {
-		cmdcommon.PrintFlagsError(tlsCmd, "cert", err)
+		common.PrintFlagsError(tlsCmd, "cert", err)
 	}
 	if _, err = os.Stat(flagTLSOutputPath + "/" + flagTLSKeyFile); os.IsNotExist(err) {
-		cmdcommon.PrintFlagsError(tlsCmd, "key", err)
+		common.PrintFlagsError(tlsCmd, "key", err)
 	}
 
 	log = logging.New("module", "tls")

--- a/cmd/sebak/cmd/wallet/payment.go
+++ b/cmd/sebak/cmd/wallet/payment.go
@@ -41,30 +41,30 @@ func init() {
 
 			// Receiver's public key
 			if receiver, err = keypair.Parse(args[0]); err != nil {
-				common.PrintFlagsError(c, "<receiver public key>", err)
+				cmdcommon.PrintFlagsError(c, "<receiver public key>", err)
 			} else if _, err = receiver.Sign([]byte("witness")); err == nil {
-				common.PrintFlagsError(c, "<receiver public key>", fmt.Errorf("Provided key is a secret seed, not an address"))
+				cmdcommon.PrintFlagsError(c, "<receiver public key>", fmt.Errorf("Provided key is a secret seed, not an address"))
 			}
 
 			// Amount
-			if amount, err = common.ParseAmountFromString(args[1]); err != nil {
-				common.PrintFlagsError(c, "<amount>", err)
+			if amount, err = cmdcommon.ParseAmountFromString(args[1]); err != nil {
+				cmdcommon.PrintFlagsError(c, "<amount>", err)
 			}
 
 			// Sender's secret seed
 			if sender, err = keypair.Parse(args[2]); err != nil {
-				common.PrintFlagsError(c, "<sender secret seed>", err)
+				cmdcommon.PrintFlagsError(c, "<sender secret seed>", err)
 			} else if _, ok := sender.(*keypair.Full); !ok {
-				common.PrintFlagsError(c, "<sender secret seed>", fmt.Errorf("Provided key is an address, not a secret seed"))
+				cmdcommon.PrintFlagsError(c, "<sender secret seed>", fmt.Errorf("Provided key is an address, not a secret seed"))
 			}
 
 			// Check a network ID was provided
 			if len(flagNetworkID) == 0 {
-				common.PrintFlagsError(c, "--network-id", fmt.Errorf("A --network-id needs to be provided"))
+				cmdcommon.PrintFlagsError(c, "--network-id", fmt.Errorf("A --network-id needs to be provided"))
 			}
 
 			if endpoint, err = sebakcommon.ParseEndpoint(flagEndpoint); err != nil {
-				common.PrintFlagsError(c, "--endpoint", err)
+				cmdcommon.PrintFlagsError(c, "--endpoint", err)
 			}
 
 			// TODO: Validate input transaction (does the sender have enough money?)

--- a/cmd/sebak/cmd/wallet/payment.go
+++ b/cmd/sebak/cmd/wallet/payment.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"boscoin.io/sebak/cmd/sebak/common"
+	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 	"boscoin.io/sebak/lib"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network"

--- a/cmd/sebak/cmd/wallet/payment.go
+++ b/cmd/sebak/cmd/wallet/payment.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	flagNetworkID     string = sebakcommon.GetENVValue("SEBAK_NETWORK_ID", "")
+	flagNetworkID     string = common.GetENVValue("SEBAK_NETWORK_ID", "")
 	PaymentCmd        *cobra.Command
 	flagEndpoint      string
 	flagCreateAccount bool
@@ -33,11 +33,11 @@ func init() {
 		Args:  cobra.ExactArgs(3),
 		Run: func(c *cobra.Command, args []string) {
 			var err error
-			var amount sebakcommon.Amount
-			var newBalance sebakcommon.Amount
+			var amount common.Amount
+			var newBalance common.Amount
 			var sender keypair.KP
 			var receiver keypair.KP
-			var endpoint *sebakcommon.Endpoint
+			var endpoint *common.Endpoint
 
 			// Receiver's public key
 			if receiver, err = keypair.Parse(args[0]); err != nil {
@@ -63,7 +63,7 @@ func init() {
 				cmdcommon.PrintFlagsError(c, "--network-id", fmt.Errorf("A --network-id needs to be provided"))
 			}
 
-			if endpoint, err = sebakcommon.ParseEndpoint(flagEndpoint); err != nil {
+			if endpoint, err = common.ParseEndpoint(flagEndpoint); err != nil {
 				cmdcommon.PrintFlagsError(c, "--endpoint", err)
 			}
 
@@ -72,11 +72,11 @@ func init() {
 			// At the moment this is a rather crude implementation: There is no support for pooling of transaction,
 			// 1 operation == 1 transaction
 			var tx sebak.Transaction
-			var connection *sebakcommon.HTTP2Client
+			var connection *common.HTTP2Client
 			var senderAccount block.BlockAccount
 
 			// Keep-alive ignores timeout/idle timeout
-			if connection, err = sebakcommon.NewHTTP2Client(0, 0, true); err != nil {
+			if connection, err = common.NewHTTP2Client(0, 0, true); err != nil {
 				log.Fatal("Error while creating network client: ", err)
 				os.Exit(1)
 			}
@@ -93,7 +93,7 @@ func init() {
 
 			// Check that account's balance is enough before sending the transaction
 			{
-				newBalance, err = sebakcommon.MustAmountFromString(senderAccount.Balance).Sub(amount)
+				newBalance, err = common.MustAmountFromString(senderAccount.Balance).Sub(amount)
 				if err == nil {
 					newBalance, err = newBalance.Sub(sebak.BaseFee)
 				}
@@ -157,7 +157,7 @@ func init() {
 /// Returns:
 ///   `sebak.Transaction` = The generated `Transaction` creating the account
 ///
-func makeTransactionCreateAccount(kpSource keypair.KP, kpDest keypair.KP, amount sebakcommon.Amount, chkp string) sebak.Transaction {
+func makeTransactionCreateAccount(kpSource keypair.KP, kpDest keypair.KP, amount common.Amount, chkp string) sebak.Transaction {
 	opb := sebak.NewOperationBodyCreateAccount(kpDest.Address(), amount)
 
 	op := sebak.Operation{
@@ -177,7 +177,7 @@ func makeTransactionCreateAccount(kpSource keypair.KP, kpDest keypair.KP, amount
 	tx := sebak.Transaction{
 		T: "transaction",
 		H: sebak.TransactionHeader{
-			Created: sebakcommon.NowISO8601(),
+			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
 		},
 		B: txBody,
@@ -201,7 +201,7 @@ func makeTransactionCreateAccount(kpSource keypair.KP, kpDest keypair.KP, amount
 /// Returns:
 ///  `sebak.Transaction` = The generated `Transaction` to do a payment
 ///
-func makeTransactionPayment(kpSource keypair.KP, kpDest keypair.KP, amount sebakcommon.Amount, chkp string) sebak.Transaction {
+func makeTransactionPayment(kpSource keypair.KP, kpDest keypair.KP, amount common.Amount, chkp string) sebak.Transaction {
 	opb := sebak.NewOperationBodyPayment(kpDest.Address(), amount)
 
 	op := sebak.Operation{
@@ -213,7 +213,7 @@ func makeTransactionPayment(kpSource keypair.KP, kpDest keypair.KP, amount sebak
 
 	txBody := sebak.TransactionBody{
 		Source:     kpSource.Address(),
-		Fee:        sebakcommon.Amount(sebak.BaseFee),
+		Fee:        common.Amount(sebak.BaseFee),
 		Checkpoint: chkp,
 		Operations: []sebak.Operation{op},
 	}
@@ -221,7 +221,7 @@ func makeTransactionPayment(kpSource keypair.KP, kpDest keypair.KP, amount sebak
 	tx := sebak.Transaction{
 		T: "transaction",
 		H: sebak.TransactionHeader{
-			Created: sebakcommon.NowISO8601(),
+			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
 		},
 		B: txBody,

--- a/cmd/sebak/common/encoder.go
+++ b/cmd/sebak/common/encoder.go
@@ -1,4 +1,4 @@
-package cmdcommon
+package common
 
 import (
 	"encoding/json"

--- a/cmd/sebak/common/encoder.go
+++ b/cmd/sebak/common/encoder.go
@@ -1,9 +1,10 @@
-package common
+package cmdcommon
 
 import (
 	"encoding/json"
-	"gopkg.in/yaml.v2"
 	"io"
+
+	"gopkg.in/yaml.v2"
 )
 
 type Encode func(v interface{}, w io.Writer) error

--- a/cmd/sebak/common/interrupt.go
+++ b/cmd/sebak/common/interrupt.go
@@ -1,4 +1,4 @@
-package cmdcommon
+package common
 
 import (
 	"errors"

--- a/cmd/sebak/common/interrupt.go
+++ b/cmd/sebak/common/interrupt.go
@@ -1,4 +1,4 @@
-package common
+package cmdcommon
 
 import (
 	"errors"

--- a/cmd/sebak/common/util.go
+++ b/cmd/sebak/common/util.go
@@ -35,9 +35,9 @@ func PrintFlagsError(cmd *cobra.Command, flagName string, err error) {
 // Returns:
 //   sebak.Amount: the value represented by `input`
 //   error: an `error`, if any happened
-func ParseAmountFromString(input string) (sebakcommon.Amount, error) {
+func ParseAmountFromString(input string) (common.Amount, error) {
 	amountStr := strings.Replace(input, ",", "", -1)
 	amountStr = strings.Replace(amountStr, ".", "", -1)
 	amountStr = strings.Replace(amountStr, "_", "", -1)
-	return sebakcommon.AmountFromString(amountStr)
+	return common.AmountFromString(amountStr)
 }

--- a/cmd/sebak/common/util.go
+++ b/cmd/sebak/common/util.go
@@ -1,4 +1,4 @@
-package common
+package cmdcommon
 
 import (
 	"fmt"

--- a/cmd/sebak/common/util.go
+++ b/cmd/sebak/common/util.go
@@ -1,4 +1,4 @@
-package cmdcommon
+package common
 
 import (
 	"fmt"

--- a/lib/api_account.go
+++ b/lib/api_account.go
@@ -33,7 +33,7 @@ func (api NetworkHandlerAPI) GetAccountHandler(w http.ResponseWriter, r *http.Re
 		var readyChan = make(chan struct{})
 
 		// Trigger event for data already stored in the storage
-		iterateId := sebakcommon.GetUniqueIDFromUUID()
+		iterateId := common.GetUniqueIDFromUUID()
 		go func() {
 			<-readyChan
 			observer.BlockAccountObserver.Trigger(fmt.Sprintf("iterate-%s", iterateId), blk)
@@ -75,7 +75,7 @@ func (api NetworkHandlerAPI) GetAccountTransactionsHandler(w http.ResponseWriter
 	switch r.Header.Get("Accept") {
 	case "text/event-stream":
 		var readyChan = make(chan struct{})
-		iterateId := sebakcommon.GetUniqueIDFromUUID()
+		iterateId := common.GetUniqueIDFromUUID()
 		go func() {
 			<-readyChan
 			count := maxNumberOfExistingData
@@ -114,7 +114,7 @@ func (api NetworkHandlerAPI) GetAccountTransactionsHandler(w http.ResponseWriter
 		}
 		closeFunc()
 
-		s, err = sebakcommon.EncodeJSONValue(btl)
+		s, err = common.EncodeJSONValue(btl)
 
 		if _, err = w.Write(s); err != nil {
 			http.Error(w, "Error reading request body", http.StatusInternalServerError)
@@ -135,7 +135,7 @@ func (api NetworkHandlerAPI) GetAccountOperationsHandler(w http.ResponseWriter, 
 	switch r.Header.Get("Accept") {
 	case "text/event-stream":
 		var readyChan = make(chan struct{})
-		iterateId := sebakcommon.GetUniqueIDFromUUID()
+		iterateId := common.GetUniqueIDFromUUID()
 		go func() {
 			<-readyChan
 			count := maxNumberOfExistingData
@@ -173,7 +173,7 @@ func (api NetworkHandlerAPI) GetAccountOperationsHandler(w http.ResponseWriter, 
 		}
 		closeFunc()
 
-		s, err = sebakcommon.EncodeJSONValue(bol)
+		s, err = common.EncodeJSONValue(bol)
 
 		if _, err = w.Write(s); err != nil {
 			http.Error(w, "Error reading request body", http.StatusInternalServerError)

--- a/lib/api_node_test.go
+++ b/lib/api_node_test.go
@@ -66,7 +66,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, mn *network.HTTP2Net
 	g := network.NewKeyGenerator(dirPath, certPath, keyPath)
 
 	var config network.HTTP2NetworkConfig
-	endpoint, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:%s?NodeName=n1", getPort()))
+	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:%s?NodeName=n1", getPort()))
 	if err != nil {
 		t.Error(err)
 		return
@@ -92,7 +92,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, mn *network.HTTP2Net
 	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
 	// Make the latest block
 	{
-		checkpoint := sebakcommon.MakeGenesisCheckpoint(networkID)
+		checkpoint := common.MakeGenesisCheckpoint(networkID)
 		address := kp.Address()
 		balance := BaseFee.MustAdd(BaseFee)
 		account := block.NewBlockAccount(address, balance, checkpoint)

--- a/lib/api_test.go
+++ b/lib/api_test.go
@@ -54,7 +54,7 @@ func TestGetAccountHandler(t *testing.T) {
 	go func() {
 		// Makes Some Events
 		for n := 1; n < 20; n++ {
-			newBalance := ba.GetBalance().MustAdd(sebakcommon.Amount(n))
+			newBalance := ba.GetBalance().MustAdd(common.Amount(n))
 			ba.Balance = newBalance.String()
 			ba.Save(storage)
 			if n <= 10 {
@@ -65,7 +65,7 @@ func TestGetAccountHandler(t *testing.T) {
 	}()
 
 	// Do stream Request to the Server
-	var n sebakcommon.Amount
+	var n common.Amount
 	for n = 0; n < 10; n++ {
 		<-recv
 		line, err := reader.ReadBytes('\n')
@@ -196,7 +196,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	}()
 
 	// Do stream Request to the Server
-	var n sebakcommon.Amount
+	var n common.Amount
 	for n = 0; n < 10; n++ {
 		<-recv
 		line, err := reader.ReadBytes('\n')
@@ -308,7 +308,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 	}()
 
 	// Do stream Request to the Server
-	var n sebakcommon.Amount
+	var n common.Amount
 	for n = 0; n < 10; n++ {
 		<-recv
 		line, err := reader.ReadBytes('\n')

--- a/lib/api_transaction.go
+++ b/lib/api_transaction.go
@@ -19,7 +19,7 @@ func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *ht
 	switch r.Header.Get("Accept") {
 	case "text/event-stream":
 		var readyChan = make(chan struct{})
-		iterateId := sebakcommon.GetUniqueIDFromUUID()
+		iterateId := common.GetUniqueIDFromUUID()
 		go func() {
 			<-readyChan
 			count := maxNumberOfExistingData
@@ -59,7 +59,7 @@ func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *ht
 		}
 		closeFunc()
 
-		s, err = sebakcommon.EncodeJSONValue(btl)
+		s, err = common.EncodeJSONValue(btl)
 		if _, err = w.Write(s); err != nil {
 			http.Error(w, "Error reading request body", http.StatusInternalServerError)
 			return
@@ -78,7 +78,7 @@ func (api NetworkHandlerAPI) GetTransactionByHashHandler(w http.ResponseWriter, 
 	case "text/event-stream":
 
 		var readyChan = make(chan struct{})
-		iterateId := sebakcommon.GetUniqueIDFromUUID()
+		iterateId := common.GetUniqueIDFromUUID()
 		go func() {
 			<-readyChan
 			var bt BlockTransaction

--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -29,12 +29,12 @@ func NewBallot(localNode *node.LocalNode, round round.Round, transactions []stri
 			Round:        round,
 			Transactions: transactions,
 		},
-		State: sebakcommon.BallotStateINIT,
-		Vote:  sebakcommon.VotingNOTYET,
+		State: common.BallotStateINIT,
+		Vote:  common.VotingNOTYET,
 	}
 
 	if len(transactions) < 1 {
-		body.Vote = sebakcommon.VotingYES
+		body.Vote = common.VotingYES
 	}
 
 	b = &Ballot{
@@ -83,10 +83,10 @@ func (b Ballot) IsWellFormed(networkID []byte) (err error) {
 	}
 
 	var confirmed, proposerConfirmed time.Time
-	if confirmed, err = sebakcommon.ParseISO8601(b.B.Confirmed); err != nil {
+	if confirmed, err = common.ParseISO8601(b.B.Confirmed); err != nil {
 		return
 	}
-	if proposerConfirmed, err = sebakcommon.ParseISO8601(b.ProposerConfirmed()); err != nil {
+	if proposerConfirmed, err = common.ParseISO8601(b.ProposerConfirmed()); err != nil {
 		return
 	}
 
@@ -109,7 +109,7 @@ func (b Ballot) IsWellFormed(networkID []byte) (err error) {
 	return
 }
 
-func (b Ballot) Equal(m sebakcommon.Message) bool {
+func (b Ballot) Equal(m common.Message) bool {
 	return b.H.Hash == m.GetHash()
 }
 
@@ -137,7 +137,7 @@ func (b Ballot) ProposerConfirmed() string {
 	return b.B.Proposed.Confirmed
 }
 
-func (b Ballot) Vote() sebakcommon.VotingHole {
+func (b Ballot) Vote() common.VotingHole {
 	return b.B.Vote
 }
 
@@ -145,7 +145,7 @@ func (b *Ballot) SetSource(source string) {
 	b.B.Source = source
 }
 
-func (b *Ballot) SetVote(state sebakcommon.BallotState, vote sebakcommon.VotingHole) {
+func (b *Ballot) SetVote(state common.BallotState, vote common.VotingHole) {
 	b.B.State = state
 	b.B.Vote = vote
 }
@@ -160,16 +160,16 @@ func (b *Ballot) TransactionsLength() int {
 
 func (b *Ballot) Sign(kp keypair.KP, networkID []byte) {
 	if kp.Address() == b.B.Proposed.Proposer {
-		b.B.Proposed.Confirmed = sebakcommon.NowISO8601()
-		hash := sebakcommon.MustMakeObjectHash(b.B.Proposed)
-		signature, _ := sebakcommon.MakeSignature(kp, networkID, string(hash))
+		b.B.Proposed.Confirmed = common.NowISO8601()
+		hash := common.MustMakeObjectHash(b.B.Proposed)
+		signature, _ := common.MakeSignature(kp, networkID, string(hash))
 		b.H.ProposerSignature = base58.Encode(signature)
 	}
 
-	b.B.Confirmed = sebakcommon.NowISO8601()
+	b.B.Confirmed = common.NowISO8601()
 	b.B.Source = kp.Address()
 	b.H.Hash = b.B.MakeHashString()
-	signature, _ := sebakcommon.MakeSignature(kp, networkID, b.H.Hash)
+	signature, _ := common.MakeSignature(kp, networkID, b.H.Hash)
 	b.H.Signature = base58.Encode(signature)
 
 	return
@@ -181,7 +181,7 @@ func (b Ballot) Verify(networkID []byte) (err error) {
 		return
 	}
 	err = kp.Verify(
-		append(networkID, sebakcommon.MustMakeObjectHash(b.B.Proposed)...),
+		append(networkID, common.MustMakeObjectHash(b.B.Proposed)...),
 		base58.Decode(b.H.ProposerSignature),
 	)
 	if err != nil {
@@ -206,7 +206,7 @@ func (b Ballot) IsFromProposer() bool {
 	return b.B.Source == b.B.Proposed.Proposer
 }
 
-func (b Ballot) State() sebakcommon.BallotState {
+func (b Ballot) State() common.BallotState {
 	return b.B.State
 }
 
@@ -224,16 +224,16 @@ type BallotBodyProposed struct {
 }
 
 type BallotBody struct {
-	Confirmed string                  `json:"confirmed"` // created time, ISO8601
-	Proposed  BallotBodyProposed      `json:"proposed"`
-	Source    string                  `json:"source"`
-	State     sebakcommon.BallotState `json:"state"`
-	Vote      sebakcommon.VotingHole  `json:"vote"`
-	Reason    *errors.Error           `json:"reason"`
+	Confirmed string             `json:"confirmed"` // created time, ISO8601
+	Proposed  BallotBodyProposed `json:"proposed"`
+	Source    string             `json:"source"`
+	State     common.BallotState `json:"state"`
+	Vote      common.VotingHole  `json:"vote"`
+	Reason    *errors.Error      `json:"reason"`
 }
 
 func (rb BallotBody) MakeHash() []byte {
-	return sebakcommon.MustMakeObjectHash(rb)
+	return common.MustMakeObjectHash(rb)
 }
 
 func (rb BallotBody) MakeHashString() string {

--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -229,7 +229,11 @@ type BallotBody struct {
 	Source    string             `json:"source"`
 	State     common.BallotState `json:"state"`
 	Vote      common.VotingHole  `json:"vote"`
+<<<<<<< HEAD
 	Reason    *errors.Error      `json:"reason"`
+=======
+	Reason    *sebakerror.Error  `json:"reason"`
+>>>>>>> gofmt
 }
 
 func (rb BallotBody) MakeHash() []byte {

--- a/lib/ballot.go
+++ b/lib/ballot.go
@@ -229,11 +229,7 @@ type BallotBody struct {
 	Source    string             `json:"source"`
 	State     common.BallotState `json:"state"`
 	Vote      common.VotingHole  `json:"vote"`
-<<<<<<< HEAD
 	Reason    *errors.Error      `json:"reason"`
-=======
-	Reason    *sebakerror.Error  `json:"reason"`
->>>>>>> gofmt
 }
 
 func (rb BallotBody) MakeHash() []byte {

--- a/lib/ballot_test.go
+++ b/lib/ballot_test.go
@@ -64,14 +64,14 @@ func TestBallotHash(t *testing.T) {
 
 func TestBallotBadConfirmedTime(t *testing.T) {
 	kp, _ := keypair.Random()
-	endpoint, _ := sebakcommon.NewEndpointFromString("https://localhost:1000")
+	endpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	node, _ := node.NewLocalNode(kp, endpoint, "")
 
 	round := round.Round{Number: 0, BlockHeight: 0, BlockHash: "", TotalTxs: 0}
 
 	updateBallot := func(ballot *Ballot) {
 		ballot.H.Hash = ballot.B.MakeHashString()
-		signature, _ := sebakcommon.MakeSignature(kp, networkID, ballot.H.Hash)
+		signature, _ := common.MakeSignature(kp, networkID, ballot.H.Hash)
 		ballot.H.Signature = base58.Encode(signature)
 	}
 
@@ -88,7 +88,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 		ballot.Sign(kp, networkID)
 
 		newConfirmed := time.Now().Add(time.Duration(2) * BallotConfirmedTimeAllowDuration)
-		ballot.B.Confirmed = sebakcommon.FormatISO8601(newConfirmed)
+		ballot.B.Confirmed = common.FormatISO8601(newConfirmed)
 		updateBallot(ballot)
 
 		err := ballot.IsWellFormed(networkID)
@@ -100,7 +100,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 		ballot.Sign(kp, networkID)
 
 		newConfirmed := time.Now().Add(time.Duration(-2) * BallotConfirmedTimeAllowDuration)
-		ballot.B.Confirmed = sebakcommon.FormatISO8601(newConfirmed)
+		ballot.B.Confirmed = common.FormatISO8601(newConfirmed)
 		updateBallot(ballot)
 
 		err := ballot.IsWellFormed(networkID)
@@ -112,7 +112,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 		ballot.Sign(kp, networkID)
 
 		newConfirmed := time.Now().Add(time.Duration(2) * BallotConfirmedTimeAllowDuration)
-		ballot.B.Proposed.Confirmed = sebakcommon.FormatISO8601(newConfirmed)
+		ballot.B.Proposed.Confirmed = common.FormatISO8601(newConfirmed)
 		updateBallot(ballot)
 
 		err := ballot.IsWellFormed(networkID)
@@ -124,7 +124,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 		ballot.Sign(kp, networkID)
 
 		newConfirmed := time.Now().Add(time.Duration(-2) * BallotConfirmedTimeAllowDuration)
-		ballot.B.Proposed.Confirmed = sebakcommon.FormatISO8601(newConfirmed)
+		ballot.B.Proposed.Confirmed = common.FormatISO8601(newConfirmed)
 		updateBallot(ballot)
 
 		err := ballot.IsWellFormed(networkID)

--- a/lib/block.go
+++ b/lib/block.go
@@ -44,7 +44,7 @@ func MakeGenesisBlock(st *sebakstorage.LevelDBBackend, account block.BlockAccoun
 	round := round.Round{
 		Number:      0,
 		BlockHeight: 0,
-		BlockHash:   base58.Encode(sebakcommon.MustMakeObjectHash(account)),
+		BlockHash:   base58.Encode(common.MustMakeObjectHash(account)),
 		TotalTxs:    0,
 	}
 	transactions := []string{}
@@ -72,7 +72,7 @@ func NewBlock(proposer string, round round.Round, transactions []string, confirm
 
 	log.Debug("NewBlock created", "PrevTotalTxs", round.TotalTxs, "txs", len(transactions), "TotalTxs", b.Header.TotalTxs)
 
-	b.Hash = base58.Encode(sebakcommon.MustMakeObjectHash(b))
+	b.Hash = base58.Encode(common.MustMakeObjectHash(b))
 
 	return *b
 }
@@ -87,7 +87,7 @@ func NewBlockFromBallot(ballot Ballot) Block {
 }
 
 func getTransactionRoot(txs []string) string {
-	return sebakcommon.MustMakeObjectHashString(txs) // TODO make root
+	return common.MustMakeObjectHashString(txs) // TODO make root
 }
 
 func GetBlockKey(hash string) string {
@@ -102,7 +102,7 @@ func (b Block) NewBlockKeyConfirmed() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockKeyPrefixConfirmed(b.Confirmed),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 

--- a/lib/block/account.go
+++ b/lib/block/account.go
@@ -30,10 +30,10 @@ type BlockAccount struct {
 	Balance    string
 	Checkpoint string
 	CodeHash   []byte
-	RootHash   sebakcommon.Hash
+	RootHash   common.Hash
 }
 
-func NewBlockAccount(address string, balance sebakcommon.Amount, checkpoint string) *BlockAccount {
+func NewBlockAccount(address string, balance common.Amount, checkpoint string) *BlockAccount {
 	return &BlockAccount{
 		Address:    address,
 		Balance:    balance.String(),
@@ -42,7 +42,7 @@ func NewBlockAccount(address string, balance sebakcommon.Amount, checkpoint stri
 }
 
 func (b *BlockAccount) String() string {
-	return string(sebakcommon.MustJSONMarshal(b))
+	return string(common.MustJSONMarshal(b))
 }
 
 func (b *BlockAccount) Save(st *sebakstorage.LevelDBBackend) (err error) {
@@ -59,7 +59,7 @@ func (b *BlockAccount) Save(st *sebakstorage.LevelDBBackend) (err error) {
 	} else {
 		// TODO consider to use, [`Transaction`](https://godoc.org/github.com/syndtr/goleveldb/leveldb#DB.OpenTransaction)
 		err = st.New(key, b)
-		createdKey := GetBlockAccountCreatedKey(sebakcommon.GetUniqueIDFromUUID())
+		createdKey := GetBlockAccountCreatedKey(common.GetUniqueIDFromUUID())
 		err = st.New(createdKey, b.Address)
 	}
 	if err == nil {
@@ -79,11 +79,11 @@ func (b *BlockAccount) Save(st *sebakstorage.LevelDBBackend) (err error) {
 }
 
 func (b *BlockAccount) Serialize() (encoded []byte, err error) {
-	encoded, err = sebakcommon.EncodeJSONValue(b)
+	encoded, err = common.EncodeJSONValue(b)
 	return
 }
 func (b *BlockAccount) Deserialize(encoded []byte) (err error) {
-	return sebakcommon.DecodeJSONValue(encoded, b)
+	return common.DecodeJSONValue(encoded, b)
 }
 
 func GetBlockAccountKey(address string) string {
@@ -145,15 +145,15 @@ func GetBlockAccountsByCreated(st *sebakstorage.LevelDBBackend, reverse bool) (f
 		})
 }
 
-func (b *BlockAccount) GetBalance() sebakcommon.Amount {
-	return sebakcommon.MustAmountFromString(b.Balance)
+func (b *BlockAccount) GetBalance() common.Amount {
+	return common.MustAmountFromString(b.Balance)
 }
 
 // Add fund to an account
 //
 // If the amount would make the account overflow over the full supply of coin,
 // an `error` is returned.
-func (b *BlockAccount) Deposit(fund sebakcommon.Amount, checkpoint string) error {
+func (b *BlockAccount) Deposit(fund common.Amount, checkpoint string) error {
 	if val, err := b.GetBalance().Add(fund); err != nil {
 		return err
 	} else {
@@ -166,7 +166,7 @@ func (b *BlockAccount) Deposit(fund sebakcommon.Amount, checkpoint string) error
 // Remove fund from an account
 //
 // If the amount would make the account go negative, an `error` is returned.
-func (b *BlockAccount) Withdraw(fund sebakcommon.Amount, checkpoint string) error {
+func (b *BlockAccount) Withdraw(fund common.Amount, checkpoint string) error {
 	if val, err := b.GetBalance().Sub(fund); err != nil {
 		return err
 	} else {
@@ -196,7 +196,7 @@ func GetBlockAccountCheckpointKey(address, checkpoint string) string {
 }
 
 func GetBlockAccountCheckpointByAddressKey(address string) string {
-	return fmt.Sprintf("%s%s-%s", BlockAccountCheckpointByAddressPrefix, address, sebakcommon.GetUniqueIDFromUUID())
+	return fmt.Sprintf("%s%s-%s", BlockAccountCheckpointByAddressPrefix, address, common.GetUniqueIDFromUUID())
 }
 
 func GetBlockAccountCheckpointByAddressKeyPrefix(address string) string {
@@ -204,7 +204,7 @@ func GetBlockAccountCheckpointByAddressKeyPrefix(address string) string {
 }
 
 func (b *BlockAccountCheckpoint) String() string {
-	return string(sebakcommon.MustJSONMarshal(b))
+	return string(common.MustJSONMarshal(b))
 }
 
 func (b *BlockAccountCheckpoint) Save(st *sebakstorage.LevelDBBackend) (err error) {

--- a/lib/block/account_test.go
+++ b/lib/block/account_test.go
@@ -31,7 +31,7 @@ func TestSaveExistingBlockAccount(t *testing.T) {
 	b := TestMakeBlockAccount()
 	b.Save(st)
 
-	err := b.Deposit(sebakcommon.Amount(100), "fake-checkpoint")
+	err := b.Deposit(common.Amount(100), "fake-checkpoint")
 	require.Nil(t, err)
 
 	err = b.Save(st)

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -9,7 +9,7 @@ import (
 func TestMakeBlockAccount() *BlockAccount {
 	kp, _ := keypair.Random()
 	address := kp.Address()
-	balance := sebakcommon.Amount(2000)
+	balance := common.Amount(2000)
 	checkpoint := uuid.New().String()
 
 	return NewBlockAccount(address, balance, checkpoint)

--- a/lib/block_operation.go
+++ b/lib/block_operation.go
@@ -34,7 +34,7 @@ type BlockOperation struct {
 	Type   OperationType
 	Source string
 	Target string
-	Amount sebakcommon.Amount
+	Amount common.Amount
 
 	// transaction will be used only for `Save` time.
 	transaction Transaction
@@ -100,7 +100,7 @@ func (bo *BlockOperation) Save(st *sebakstorage.LevelDBBackend) (err error) {
 }
 
 func (bo BlockOperation) Serialize() (encoded []byte, err error) {
-	encoded, err = sebakcommon.EncodeJSONValue(bo)
+	encoded, err = common.EncodeJSONValue(bo)
 	return
 }
 
@@ -136,7 +136,7 @@ func (bo BlockOperation) NewBlockOperationTxHashKey() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockOperationKeyPrefixTxHash(bo.TxHash),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -144,7 +144,7 @@ func (bo BlockOperation) NewBlockOperationSourceKey() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockOperationKeyPrefixSource(bo.Source),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -152,7 +152,7 @@ func (bo BlockOperation) NewBlockOperationTargetKey() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockOperationKeyPrefixTarget(bo.Target),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -160,7 +160,7 @@ func (bo BlockOperation) NewBlockOperationCheckpoint() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockOperationKeyPrefixCheckpoint(bo.transaction.B.Checkpoint),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -170,7 +170,7 @@ func (bo BlockOperation) NewBlockOperationPeersKey() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockOperationKeyPrefixPeers(addresses[0], addresses[1]),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 

--- a/lib/block_operation_test.go
+++ b/lib/block_operation_test.go
@@ -100,7 +100,7 @@ func TestBlockOperationSaveByTransacton(t *testing.T) {
 
 	_, tx := TestMakeTransaction(networkID, 10)
 	block := testMakeNewBlock([]string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, tx, sebakcommon.MustJSONMarshal(tx))
+	bt := NewBlockTransactionFromTransaction(block.Hash, tx, common.MustJSONMarshal(tx))
 	err := bt.Save(st)
 	require.Nil(t, err)
 
@@ -131,14 +131,14 @@ func TestBlockOperationGetSortedByCheckpoint(t *testing.T) {
 
 	_, tx := TestMakeTransaction(networkID, 10)
 	block := testMakeNewBlock([]string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, tx, sebakcommon.MustJSONMarshal(tx))
+	bt := NewBlockTransactionFromTransaction(block.Hash, tx, common.MustJSONMarshal(tx))
 	err := bt.Save(st)
 	require.Nil(t, err)
 
 	{
 		_, txAnother := TestMakeTransaction(networkID, 10)
 		block := testMakeNewBlock([]string{txAnother.GetHash()})
-		btAnother := NewBlockTransactionFromTransaction(block.Hash, txAnother, sebakcommon.MustJSONMarshal(tx))
+		btAnother := NewBlockTransactionFromTransaction(block.Hash, txAnother, common.MustJSONMarshal(tx))
 		err2 := btAnother.Save(st)
 		require.Nil(t, err2)
 	}

--- a/lib/block_transaction.go
+++ b/lib/block_transaction.go
@@ -39,9 +39,9 @@ type BlockTransaction struct {
 	TargetCheckpoint   string
 	Signature          string
 	Source             string
-	Fee                sebakcommon.Amount
+	Fee                common.Amount
 	Operations         []string
-	Amount             sebakcommon.Amount
+	Amount             common.Amount
 
 	Confirmed string
 	Created   string
@@ -84,7 +84,7 @@ func (bt BlockTransaction) NewBlockTransactionKeySource() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockTransactionKeyPrefixSource(bt.Source),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -92,7 +92,7 @@ func (bt BlockTransaction) NewBlockTransactionKeyConfirmed() string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockTransactionKeyPrefixConfirmed(bt.Confirmed),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -100,7 +100,7 @@ func (bt BlockTransaction) NewBlockTransactionKeyByAccount(accountAddress string
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockTransactionKeyPrefixAccount(accountAddress),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -108,7 +108,7 @@ func (bt BlockTransaction) NewBlockTransactionKeyByBlock(hash string) string {
 	return fmt.Sprintf(
 		"%s%s",
 		GetBlockTransactionKeyPrefixBlock(hash),
-		sebakcommon.GetUniqueIDFromUUID(),
+		common.GetUniqueIDFromUUID(),
 	)
 }
 
@@ -127,7 +127,7 @@ func (bt *BlockTransaction) Save(st *sebakstorage.LevelDBBackend) (err error) {
 		return errors.ErrorBlockAlreadyExists
 	}
 
-	bt.Confirmed = sebakcommon.NowISO8601()
+	bt.Confirmed = common.NowISO8601()
 	if err = st.New(GetBlockTransactionKey(bt.Hash), bt); err != nil {
 		return
 	}
@@ -170,12 +170,12 @@ func (bt *BlockTransaction) Save(st *sebakstorage.LevelDBBackend) (err error) {
 }
 
 func (bt BlockTransaction) Serialize() (encoded []byte, err error) {
-	encoded, err = sebakcommon.EncodeJSONValue(bt)
+	encoded, err = common.EncodeJSONValue(bt)
 	return
 }
 
 func (bt BlockTransaction) String() string {
-	encoded, _ := sebakcommon.EncodeJSONValue(bt)
+	encoded, _ := common.EncodeJSONValue(bt)
 	return string(encoded)
 }
 

--- a/lib/block_transaction_history.go
+++ b/lib/block_transaction_history.go
@@ -37,7 +37,7 @@ func NewTransactionHistoryFromTransaction(tx Transaction, message []byte) BlockT
 	return BlockTransactionHistory{
 		Hash:      tx.H.Hash,
 		Source:    tx.B.Source,
-		Confirmed: sebakcommon.NowISO8601(),
+		Confirmed: common.NowISO8601(),
 		Created:   tx.H.Created,
 		Message:   string(message),
 	}
@@ -48,7 +48,7 @@ func GetBlockTransactionHistoryKey(hash string) string {
 }
 
 func (bt BlockTransactionHistory) Serialize() (encoded []byte, err error) {
-	encoded, err = sebakcommon.EncodeJSONValue(bt)
+	encoded, err = common.EncodeJSONValue(bt)
 	return
 }
 func (bt *BlockTransactionHistory) Save(st *sebakstorage.LevelDBBackend) (err error) {
@@ -66,7 +66,7 @@ func (bt *BlockTransactionHistory) Save(st *sebakstorage.LevelDBBackend) (err er
 		return errors.ErrorBlockAlreadyExists
 	}
 
-	bt.Confirmed = sebakcommon.NowISO8601()
+	bt.Confirmed = common.NowISO8601()
 	if err = st.New(GetBlockTransactionHistoryKey(bt.Hash), bt); err != nil {
 		return
 	}

--- a/lib/block_transaction_test.go
+++ b/lib/block_transaction_test.go
@@ -182,7 +182,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 		}
 		closeFunc()
 
-		reverseCreatedOrder := sebakcommon.ReverseStringSlice(createdOrder)
+		reverseCreatedOrder := common.ReverseStringSlice(createdOrder)
 
 		require.Equal(t, len(saved), len(createdOrder))
 		for i, bt := range saved {
@@ -246,7 +246,7 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 		}
 		closeFunc()
 
-		reverseCreatedOrder := sebakcommon.ReverseStringSlice(createdOrder)
+		reverseCreatedOrder := common.ReverseStringSlice(createdOrder)
 
 		require.Equal(t, len(saved), len(createdOrder))
 		for i, bt := range saved {

--- a/lib/common/amount.go
+++ b/lib/common/amount.go
@@ -8,7 +8,7 @@
 //   Those are provided for testing / quick prototyping and should not be in production code.
 // - Invariant `panic`s if the instance it's called on violates its invariant (see Contract programming)
 //
-package sebakcommon
+package common
 
 import (
 	"fmt"

--- a/lib/common/amount_test.go
+++ b/lib/common/amount_test.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"strconv"

--- a/lib/common/ballot_state.go
+++ b/lib/common/ballot_state.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 type BallotState uint
 

--- a/lib/common/checker.go
+++ b/lib/common/checker.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import "fmt"
 

--- a/lib/common/checker_test.go
+++ b/lib/common/checker_test.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"errors"

--- a/lib/common/data.go
+++ b/lib/common/data.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import "encoding/json"
 

--- a/lib/common/data_test.go
+++ b/lib/common/data_test.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"encoding/json"

--- a/lib/common/hash.go
+++ b/lib/common/hash.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"github.com/btcsuite/btcutil/base58"

--- a/lib/common/hash_test.go
+++ b/lib/common/hash_test.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"testing"

--- a/lib/common/http2_client.go
+++ b/lib/common/http2_client.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"bytes"

--- a/lib/common/message.go
+++ b/lib/common/message.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 type Message interface {
 	GetType() string

--- a/lib/common/net.go
+++ b/lib/common/net.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"errors"

--- a/lib/common/time.go
+++ b/lib/common/time.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import "time"
 

--- a/lib/common/time_test.go
+++ b/lib/common/time_test.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"testing"

--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"bytes"

--- a/lib/common/util_benchmark_test.go
+++ b/lib/common/util_benchmark_test.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 import (
 	"math/rand"

--- a/lib/common/voting.go
+++ b/lib/common/voting.go
@@ -1,4 +1,4 @@
-package sebakcommon
+package common
 
 type VotingHole string
 

--- a/lib/constant.go
+++ b/lib/constant.go
@@ -9,7 +9,7 @@ import (
 const (
 	// BaseFee is the default transaction fee, if fee is lower than BaseFee, the
 	// transaction will fail validation.
-	BaseFee sebakcommon.Amount = 10000
+	BaseFee common.Amount = 10000
 
 	// BallotConfirmedTimeAllowDuration is the duration time for ballot from
 	// other nodes. If confirmed time of ballot has too late or ahead by

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -129,8 +129,8 @@ type ISAAC struct {
 
 func NewISAAC(networkID []byte, node *node.LocalNode, votingThresholdPolicy common.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		NetworkID: networkID,
-		Node:      node,
+		NetworkID:             networkID,
+		Node:                  node,
 		VotingThresholdPolicy: votingThresholdPolicy,
 		TransactionPool:       NewTransactionPool(),
 		RunningRounds:         map[string]*RunningRound{},

--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -9,7 +9,7 @@ import (
 )
 
 type TransactionPool struct {
-	sebakcommon.SafeLock
+	common.SafeLock
 
 	Pool    map[ /* Transaction.GetHash() */ string]Transaction
 	Hashes  []string // Transaction.GetHash()
@@ -64,7 +64,7 @@ func (tp *TransactionPool) Remove(hashes ...string) {
 	indices := map[int]int{}
 	var max int
 	for _, hash := range hashes {
-		index, found := sebakcommon.InStringArray(tp.Hashes, hash)
+		index, found := common.InStringArray(tp.Hashes, hash)
 		if !found {
 			continue
 		}
@@ -116,21 +116,21 @@ func (tp *TransactionPool) IsSameSource(source string) (found bool) {
 }
 
 type ISAAC struct {
-	sebakcommon.SafeLock
+	common.SafeLock
 
 	NetworkID             []byte
 	Node                  *node.LocalNode
-	VotingThresholdPolicy sebakcommon.VotingThresholdPolicy
+	VotingThresholdPolicy common.VotingThresholdPolicy
 	TransactionPool       *TransactionPool
 	RunningRounds         map[ /* Round.Hash() */ string]*RunningRound
 	LatestConfirmedBlock  Block
 	LatestRound           round.Round
 }
 
-func NewISAAC(networkID []byte, node *node.LocalNode, votingThresholdPolicy sebakcommon.VotingThresholdPolicy) (is *ISAAC, err error) {
+func NewISAAC(networkID []byte, node *node.LocalNode, votingThresholdPolicy common.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		NetworkID:             networkID,
-		Node:                  node,
+		NetworkID: networkID,
+		Node:      node,
 		VotingThresholdPolicy: votingThresholdPolicy,
 		TransactionPool:       NewTransactionPool(),
 		RunningRounds:         map[string]*RunningRound{},
@@ -139,11 +139,11 @@ func NewISAAC(networkID []byte, node *node.LocalNode, votingThresholdPolicy seba
 	return
 }
 
-func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh sebakcommon.VotingHole) (err error) {
+func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh common.VotingHole) (err error) {
 	is.Lock()
 	defer is.Unlock()
 
-	if vh == sebakcommon.VotingNOTYET {
+	if vh == common.VotingNOTYET {
 		err = errors.New("invalid VotingHole, `VotingNOTYET`")
 		return
 	}
@@ -154,7 +154,7 @@ func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh sebakcomm
 		return
 	}
 
-	if vh == sebakcommon.VotingNO {
+	if vh == common.VotingNO {
 		delete(rr.Transactions, proposer)
 		delete(rr.Voted, proposer)
 

--- a/lib/isaac_simulation_test.go
+++ b/lib/isaac_simulation_test.go
@@ -61,43 +61,43 @@ func TestIsaacSimulationProposer(t *testing.T) {
 	txHashs := rr.Transactions[proposer.Address()]
 	require.Equal(t, tx.GetHash(), txHashs[0])
 
-	ballotSIGN1 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[1].localNode)
+	ballotSIGN1 := GenerateBallot(t, proposer, round, tx, common.BallotStateSIGN, nodeRunners[1].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotSIGN1)
 	require.Nil(t, err)
 
-	ballotSIGN2 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[2].localNode)
+	ballotSIGN2 := GenerateBallot(t, proposer, round, tx, common.BallotStateSIGN, nodeRunners[2].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotSIGN2)
 	require.Nil(t, err)
 
-	ballotSIGN3 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[3].localNode)
+	ballotSIGN3 := GenerateBallot(t, proposer, round, tx, common.BallotStateSIGN, nodeRunners[3].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotSIGN3)
 	require.Nil(t, err)
 
-	ballotSIGN4 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateSIGN, nodeRunners[4].localNode)
+	ballotSIGN4 := GenerateBallot(t, proposer, round, tx, common.BallotStateSIGN, nodeRunners[4].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotSIGN4)
 	require.Nil(t, err)
 
-	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateSIGN)))
+	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(common.BallotStateSIGN)))
 
-	ballotACCEPT1 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[1].localNode)
+	ballotACCEPT1 := GenerateBallot(t, proposer, round, tx, common.BallotStateACCEPT, nodeRunners[1].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotACCEPT1)
 	require.Nil(t, err)
 
-	ballotACCEPT2 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[2].localNode)
+	ballotACCEPT2 := GenerateBallot(t, proposer, round, tx, common.BallotStateACCEPT, nodeRunners[2].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotACCEPT2)
 	require.Nil(t, err)
 
-	ballotACCEPT3 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[3].localNode)
+	ballotACCEPT3 := GenerateBallot(t, proposer, round, tx, common.BallotStateACCEPT, nodeRunners[3].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotACCEPT3)
 	require.Nil(t, err)
 
-	ballotACCEPT4 := GenerateBallot(t, proposer, round, tx, sebakcommon.BallotStateACCEPT, nodeRunners[4].localNode)
+	ballotACCEPT4 := GenerateBallot(t, proposer, round, tx, common.BallotStateACCEPT, nodeRunners[4].localNode)
 	err = ReceiveBallot(t, nodeRunner, ballotACCEPT4)
 
 	_, ok := err.(CheckerStopCloseConsensus)
 	require.True(t, ok)
 
-	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(sebakcommon.BallotStateACCEPT)))
+	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(common.BallotStateACCEPT)))
 
 	block := nodeRunner.Consensus().LatestConfirmedBlock
 	require.Equal(t, proposer.Address(), block.Proposer)

--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -20,8 +20,8 @@ const (
 )
 
 type Network interface {
-	Endpoint() *sebakcommon.Endpoint
-	GetClient(endpoint *sebakcommon.Endpoint) NetworkClient
+	Endpoint() *common.Endpoint
+	GetClient(endpoint *common.Endpoint) NetworkClient
 	AddWatcher(func(Network, net.Conn, http.ConnState))
 	AddHandler(string, http.HandlerFunc) *mux.Route
 
@@ -36,7 +36,7 @@ type Network interface {
 	ReceiveMessage() <-chan Message
 }
 
-func NewNetwork(endpoint *sebakcommon.Endpoint) (n Network, err error) {
+func NewNetwork(endpoint *common.Endpoint) (n Network, err error) {
 	switch endpoint.Scheme {
 	case "memory":
 		n = NewMemoryNetwork()
@@ -53,12 +53,12 @@ func NewNetwork(endpoint *sebakcommon.Endpoint) (n Network, err error) {
 }
 
 type NetworkClient interface {
-	Endpoint() *sebakcommon.Endpoint
+	Endpoint() *common.Endpoint
 
 	Connect(node node.Node) ([]byte, error)
 	GetNodeInfo() ([]byte, error)
-	SendMessage(sebakcommon.Serializable) ([]byte, error)
-	SendBallot(sebakcommon.Serializable) ([]byte, error)
+	SendMessage(common.Serializable) ([]byte, error)
+	SendBallot(common.Serializable) ([]byte, error)
 }
 
 type MessageType string

--- a/lib/network/connection_manager.go
+++ b/lib/network/connection_manager.go
@@ -17,7 +17,7 @@ type ConnectionManager struct {
 
 	localNode *node.LocalNode
 	network   Network
-	policy    sebakcommon.VotingThresholdPolicy
+	policy    common.VotingThresholdPolicy
 
 	validators map[ /* nodd.Address() */ string]*node.Validator
 	clients    map[ /* nodd.Address() */ string]NetworkClient
@@ -29,7 +29,7 @@ type ConnectionManager struct {
 func NewConnectionManager(
 	localNode *node.LocalNode,
 	network Network,
-	policy sebakcommon.VotingThresholdPolicy,
+	policy common.VotingThresholdPolicy,
 	validators map[string]*node.Validator,
 ) *ConnectionManager {
 	return &ConnectionManager{
@@ -164,7 +164,7 @@ func (c *ConnectionManager) ConnectionWatcher(t Network, conn net.Conn, state ht
 	return
 }
 
-func (c *ConnectionManager) Broadcast(message sebakcommon.Message) {
+func (c *ConnectionManager) Broadcast(message common.Message) {
 	for address, connected := range c.connected {
 		if connected {
 			go func(v string) {

--- a/lib/network/generate_key.go
+++ b/lib/network/generate_key.go
@@ -49,7 +49,7 @@ func NewKeyGenerator(dirPath, certPath, keyPath string) *KeyGenerator {
 	p.certPath = fmt.Sprintf("%s/%s", dirPath, certPath)
 	p.keyPath = fmt.Sprintf("%s/%s", dirPath, keyPath)
 
-	if !sebakcommon.IsExists(p.certPath) || !sebakcommon.IsExists(p.keyPath) {
+	if !common.IsExists(p.certPath) || !common.IsExists(p.keyPath) {
 		GenerateKey(p.dirPath, p.certPath, p.keyPath)
 	}
 
@@ -67,13 +67,13 @@ func (g *KeyGenerator) GetKeyPath() string {
 func (g *KeyGenerator) Close() {
 	remove(g.keyPath)
 	remove(g.certPath)
-	if res, _ := sebakcommon.IsEmpty(g.dirPath); res {
+	if res, _ := common.IsEmpty(g.dirPath); res {
 		remove(g.dirPath)
 	}
 }
 
 func GenerateKey(dirPath, certPath, keyPath string) {
-	if sebakcommon.IsNotExists(dirPath) {
+	if common.IsNotExists(dirPath) {
 		os.Mkdir(dirPath, 0755)
 	}
 

--- a/lib/network/generate_key_test.go
+++ b/lib/network/generate_key_test.go
@@ -17,7 +17,7 @@ func TestGenerateKey(t *testing.T) {
 	require.Equal(t, g.GetCertPath(), certPath)
 	require.Equal(t, g.GetKeyPath(), keyPath)
 
-	require.Equal(t, sebakcommon.IsExists(certPath), true)
-	require.Equal(t, sebakcommon.IsExists(keyPath), true)
+	require.Equal(t, common.IsExists(certPath), true)
+	require.Equal(t, common.IsExists(keyPath), true)
 
 }

--- a/lib/network/http2_network.go
+++ b/lib/network/http2_network.go
@@ -109,8 +109,8 @@ func NewHTTP2Network(config HTTP2NetworkConfig) (h2n *HTTP2Network) {
 }
 
 // GetClient creates new keep-alive HTTP2 client
-func (t *HTTP2Network) GetClient(endpoint *sebakcommon.Endpoint) NetworkClient {
-	rawClient, _ := sebakcommon.NewHTTP2Client(defaultTimeout, 0, true)
+func (t *HTTP2Network) GetClient(endpoint *common.Endpoint) NetworkClient {
+	rawClient, _ := common.NewHTTP2Client(defaultTimeout, 0, true)
 
 	client := NewHTTP2NetworkClient(endpoint, rawClient)
 
@@ -121,7 +121,7 @@ func (t *HTTP2Network) GetClient(endpoint *sebakcommon.Endpoint) NetworkClient {
 	return client
 }
 
-func (t *HTTP2Network) Endpoint() *sebakcommon.Endpoint {
+func (t *HTTP2Network) Endpoint() *common.Endpoint {
 	return t.config.Endpoint
 }
 
@@ -183,7 +183,7 @@ func (t *HTTP2Network) Ready() error {
 }
 
 func (t *HTTP2Network) IsReady() bool {
-	client, err := sebakcommon.NewHTTP2Client(50*time.Millisecond, 50*time.Millisecond, false)
+	client, err := common.NewHTTP2Client(50*time.Millisecond, 50*time.Millisecond, false)
 	if err != nil {
 		return false
 	}

--- a/lib/network/http2_network_client.go
+++ b/lib/network/http2_network_client.go
@@ -11,8 +11,8 @@ import (
 )
 
 type HTTP2NetworkClient struct {
-	endpoint       *sebakcommon.Endpoint
-	client         *sebakcommon.HTTP2Client
+	endpoint       *common.Endpoint
+	client         *common.HTTP2Client
 	defaultHeaders http.Header
 }
 
@@ -21,9 +21,9 @@ var (
 	defaultIdleTimeout = 3 * time.Second
 )
 
-func NewHTTP2NetworkClient(endpoint *sebakcommon.Endpoint, client *sebakcommon.HTTP2Client) *HTTP2NetworkClient {
+func NewHTTP2NetworkClient(endpoint *common.Endpoint, client *common.HTTP2Client) *HTTP2NetworkClient {
 	if client == nil {
-		client, _ = sebakcommon.NewHTTP2Client(
+		client, _ = common.NewHTTP2Client(
 			defaultTimeout,
 			defaultIdleTimeout,
 			false,
@@ -33,7 +33,7 @@ func NewHTTP2NetworkClient(endpoint *sebakcommon.Endpoint, client *sebakcommon.H
 	return &HTTP2NetworkClient{endpoint: endpoint, client: client, defaultHeaders: http.Header{}}
 }
 
-func (c *HTTP2NetworkClient) Endpoint() *sebakcommon.Endpoint {
+func (c *HTTP2NetworkClient) Endpoint() *common.Endpoint {
 	return c.endpoint
 }
 
@@ -96,7 +96,7 @@ func (c *HTTP2NetworkClient) Connect(n node.Node) (body []byte, err error) {
 	return
 }
 
-func (c *HTTP2NetworkClient) SendMessage(message sebakcommon.Serializable) (retBody []byte, err error) {
+func (c *HTTP2NetworkClient) SendMessage(message common.Serializable) (retBody []byte, err error) {
 	headers := c.DefaultHeaders()
 	headers.Set("Content-Type", "application/json")
 
@@ -120,7 +120,7 @@ func (c *HTTP2NetworkClient) SendMessage(message sebakcommon.Serializable) (retB
 	return
 }
 
-func (c *HTTP2NetworkClient) SendBallot(message sebakcommon.Serializable) (retBody []byte, err error) {
+func (c *HTTP2NetworkClient) SendBallot(message common.Serializable) (retBody []byte, err error) {
 	headers := c.DefaultHeaders()
 	headers.Set("Content-Type", "application/json")
 

--- a/lib/network/http2_network_config.go
+++ b/lib/network/http2_network_config.go
@@ -12,7 +12,7 @@ import (
 
 type HTTP2NetworkConfig struct {
 	NodeName string
-	Endpoint *sebakcommon.Endpoint
+	Endpoint *common.Endpoint
 	Addr     string
 
 	ReadTimeout,
@@ -26,7 +26,7 @@ type HTTP2NetworkConfig struct {
 	HTTP2LogOutput io.Writer
 }
 
-func NewHTTP2NetworkConfigFromEndpoint(endpoint *sebakcommon.Endpoint) (config HTTP2NetworkConfig, err error) {
+func NewHTTP2NetworkConfigFromEndpoint(endpoint *common.Endpoint) (config HTTP2NetworkConfig, err error) {
 	query := endpoint.Query()
 
 	var NodeName string
@@ -37,7 +37,7 @@ func NewHTTP2NetworkConfigFromEndpoint(endpoint *sebakcommon.Endpoint) (config H
 	var TLSCertFile, TLSKeyFile string
 	var HTTP2LogOutput io.Writer
 
-	if ReadTimeout, err = time.ParseDuration(sebakcommon.GetUrlQuery(query, "ReadTimeout", "0s")); err != nil {
+	if ReadTimeout, err = time.ParseDuration(common.GetUrlQuery(query, "ReadTimeout", "0s")); err != nil {
 		return
 	}
 	if ReadTimeout < 0*time.Second {
@@ -45,7 +45,7 @@ func NewHTTP2NetworkConfigFromEndpoint(endpoint *sebakcommon.Endpoint) (config H
 		return
 	}
 
-	if ReadHeaderTimeout, err = time.ParseDuration(sebakcommon.GetUrlQuery(query, "ReadHeaderTimeout", "0s")); err != nil {
+	if ReadHeaderTimeout, err = time.ParseDuration(common.GetUrlQuery(query, "ReadHeaderTimeout", "0s")); err != nil {
 		return
 	}
 	if ReadHeaderTimeout < 0*time.Second {
@@ -53,7 +53,7 @@ func NewHTTP2NetworkConfigFromEndpoint(endpoint *sebakcommon.Endpoint) (config H
 		return
 	}
 
-	if WriteTimeout, err = time.ParseDuration(sebakcommon.GetUrlQuery(query, "WriteTimeout", "0s")); err != nil {
+	if WriteTimeout, err = time.ParseDuration(common.GetUrlQuery(query, "WriteTimeout", "0s")); err != nil {
 		return
 	}
 	if WriteTimeout < 0*time.Second {
@@ -61,7 +61,7 @@ func NewHTTP2NetworkConfigFromEndpoint(endpoint *sebakcommon.Endpoint) (config H
 		return
 	}
 
-	if IdleTimeout, err = time.ParseDuration(sebakcommon.GetUrlQuery(query, "IdleTimeout", "0s")); err != nil {
+	if IdleTimeout, err = time.ParseDuration(common.GetUrlQuery(query, "IdleTimeout", "0s")); err != nil {
 		return
 	}
 	if IdleTimeout < 0*time.Second {
@@ -114,5 +114,5 @@ func (config HTTP2NetworkConfig) IsHTTPS() bool {
 }
 
 func (config HTTP2NetworkConfig) String() string {
-	return string(sebakcommon.MustJSONMarshal(config))
+	return string(common.MustJSONMarshal(config))
 }

--- a/lib/network/http2_network_config_test.go
+++ b/lib/network/http2_network_config_test.go
@@ -17,7 +17,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		queryValues.Set("TLSCertFile", "faketlscert")
 		queryValues.Set("TLSKeyFile", "faketlskey")
 
-		endpoint := &sebakcommon.Endpoint{
+		endpoint := &common.Endpoint{
 			Scheme:   "https",
 			Host:     fmt.Sprintf("localhost:%s", getPort()),
 			RawQuery: queryValues.Encode(),
@@ -32,7 +32,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		queryValues.Set("NodeName", "showme")
 		queryValues.Set("TLSCertFile", "faketlscert")
 
-		endpoint := &sebakcommon.Endpoint{
+		endpoint := &common.Endpoint{
 			Scheme:   "https",
 			Host:     fmt.Sprintf("localhost:%s", getPort()),
 			RawQuery: queryValues.Encode(),
@@ -47,7 +47,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		queryValues.Set("NodeName", "showme")
 		queryValues.Set("TLSKeyFile", "faketlskey")
 
-		endpoint := &sebakcommon.Endpoint{
+		endpoint := &common.Endpoint{
 			Scheme:   "https",
 			Host:     fmt.Sprintf("localhost:%s", getPort()),
 			RawQuery: queryValues.Encode(),
@@ -63,7 +63,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		queryValues.Set("TLSCertFile", "faketlscert")
 		queryValues.Set("TLSKeyFile", "faketlskey")
 
-		endpoint := &sebakcommon.Endpoint{
+		endpoint := &common.Endpoint{
 			Scheme:   "http",
 			Host:     fmt.Sprintf("localhost:%s", getPort()),
 			RawQuery: queryValues.Encode(),

--- a/lib/network/http2_network_test.go
+++ b/lib/network/http2_network_test.go
@@ -35,7 +35,7 @@ func getPort() string {
 	return testPort
 }
 
-func makeTestHTTP2NetworkForTLS(endpoint *sebakcommon.Endpoint) (network *HTTP2Network, err error) {
+func makeTestHTTP2NetworkForTLS(endpoint *common.Endpoint) (network *HTTP2Network, err error) {
 	var config HTTP2NetworkConfig
 	if config, err = NewHTTP2NetworkConfigFromEndpoint(endpoint); err != nil {
 		return
@@ -86,7 +86,7 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 	queryValues.Set("TLSCertFile", g.GetCertPath())
 	queryValues.Set("TLSKeyFile", g.GetKeyPath())
 
-	endpoint := &sebakcommon.Endpoint{
+	endpoint := &common.Endpoint{
 		Scheme:   "https",
 		Host:     fmt.Sprintf("localhost:%s", getPort()),
 		RawQuery: queryValues.Encode(),
@@ -98,7 +98,7 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 
 	{
 		// with normal HTTP2Client
-		client, err := sebakcommon.NewHTTP2Client(
+		client, err := common.NewHTTP2Client(
 			defaultTimeout,
 			defaultIdleTimeout,
 			false,
@@ -126,7 +126,7 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 // Without TLS configurations, `TLSCertFile`, `TLSKeyFile`, `HTTP2Network`
 // will be `HTTP` server, not `HTTPS`.
 func TestHTTP2NetworkWithoutTLS(t *testing.T) {
-	endpoint, err := sebakcommon.NewEndpointFromString(
+	endpoint, err := common.NewEndpointFromString(
 		fmt.Sprintf("http://localhost:%s?NodeName=showme", getPort()),
 	)
 	require.Nil(t, err)
@@ -137,7 +137,7 @@ func TestHTTP2NetworkWithoutTLS(t *testing.T) {
 
 	{
 		// with normal HTTP2Client
-		client, err := sebakcommon.NewHTTP2Client(
+		client, err := common.NewHTTP2Client(
 			defaultTimeout,
 			defaultIdleTimeout,
 			false,

--- a/lib/network/memory_network.go
+++ b/lib/network/memory_network.go
@@ -24,21 +24,21 @@ func addMemoryNetwork(m *MemoryNetwork) {
 	memoryNetworks[m.Endpoint().String()] = m
 }
 
-func getMemoryNetwork(endpoint *sebakcommon.Endpoint) *MemoryNetwork {
+func getMemoryNetwork(endpoint *common.Endpoint) *MemoryNetwork {
 	n, _ := memoryNetworks[endpoint.String()]
 	return n
 }
 
 type MemoryNetwork struct {
-	localNode  sebakcommon.Serializable
-	endpoint   *sebakcommon.Endpoint
+	localNode  common.Serializable
+	endpoint   *common.Endpoint
 	connWriter chan Message
 	close      chan bool
 
 	receiveChannel chan Message
 }
 
-func (t *MemoryNetwork) GetClient(endpoint *sebakcommon.Endpoint) NetworkClient {
+func (t *MemoryNetwork) GetClient(endpoint *common.Endpoint) NetworkClient {
 	n, ok := memoryNetworks[endpoint.String()]
 	if !ok {
 		return nil
@@ -50,7 +50,7 @@ func (t *MemoryNetwork) GetClient(endpoint *sebakcommon.Endpoint) NetworkClient 
 func (p *MemoryNetwork) AddWatcher(f func(Network, net.Conn, http.ConnState)) {
 	return
 }
-func (p *MemoryNetwork) Endpoint() *sebakcommon.Endpoint {
+func (p *MemoryNetwork) Endpoint() *common.Endpoint {
 	return p.endpoint
 }
 
@@ -110,12 +110,12 @@ func (p *MemoryNetwork) receiveMessage() {
 	}
 }
 
-func (p *MemoryNetwork) SetLocalNode(localNode sebakcommon.Serializable) {
+func (p *MemoryNetwork) SetLocalNode(localNode common.Serializable) {
 	p.localNode = localNode
 }
 
-func CreateNewMemoryEndpoint() *sebakcommon.Endpoint {
-	return &sebakcommon.Endpoint{Scheme: "memory", Host: uuid.New().String()}
+func CreateNewMemoryEndpoint() *common.Endpoint {
+	return &common.Endpoint{Scheme: "memory", Host: uuid.New().String()}
 }
 
 func NewMemoryNetwork() *MemoryNetwork {

--- a/lib/network/memory_network_client.go
+++ b/lib/network/memory_network_client.go
@@ -6,19 +6,19 @@ import (
 )
 
 type MemoryTransportClient struct {
-	endpoint *sebakcommon.Endpoint
+	endpoint *common.Endpoint
 
 	server *MemoryNetwork
 }
 
-func NewMemoryNetworkClient(endpoint *sebakcommon.Endpoint, server *MemoryNetwork) *MemoryTransportClient {
+func NewMemoryNetworkClient(endpoint *common.Endpoint, server *MemoryNetwork) *MemoryTransportClient {
 	return &MemoryTransportClient{
 		endpoint: endpoint,
 		server:   server,
 	}
 }
 
-func (m *MemoryTransportClient) Endpoint() *sebakcommon.Endpoint {
+func (m *MemoryTransportClient) Endpoint() *common.Endpoint {
 	return m.endpoint
 }
 
@@ -32,7 +32,7 @@ func (m *MemoryTransportClient) GetNodeInfo() (b []byte, err error) {
 	return
 }
 
-func (m *MemoryTransportClient) SendMessage(message sebakcommon.Serializable) (body []byte, err error) {
+func (m *MemoryTransportClient) SendMessage(message common.Serializable) (body []byte, err error) {
 	var s []byte
 	if s, err = message.Serialize(); err != nil {
 		return
@@ -42,7 +42,7 @@ func (m *MemoryTransportClient) SendMessage(message sebakcommon.Serializable) (b
 	return
 }
 
-func (m *MemoryTransportClient) SendBallot(message sebakcommon.Serializable) (body []byte, err error) {
+func (m *MemoryTransportClient) SendBallot(message common.Serializable) (body []byte, err error) {
 	var s []byte
 	if s, err = message.Serialize(); err != nil {
 		return

--- a/lib/network/memory_network_test.go
+++ b/lib/network/memory_network_test.go
@@ -34,7 +34,7 @@ func (m DummyMessage) GetType() string {
 	return m.T
 }
 
-func (m DummyMessage) Equal(n sebakcommon.Message) bool {
+func (m DummyMessage) Equal(n common.Message) bool {
 	return m.Hash == n.GetHash()
 }
 
@@ -47,7 +47,7 @@ func (m DummyMessage) Source() string {
 }
 
 func (m *DummyMessage) UpdateHash() {
-	m.Hash = base58.Encode(sebakcommon.MustMakeObjectHash(m.Data))
+	m.Hash = base58.Encode(common.MustMakeObjectHash(m.Data))
 }
 
 func (m DummyMessage) Serialize() ([]byte, error) {

--- a/lib/node/localNode.go
+++ b/lib/node/localNode.go
@@ -25,11 +25,11 @@ type LocalNode struct {
 
 	state      NodeState
 	alias      string
-	endpoint   *sebakcommon.Endpoint
+	endpoint   *common.Endpoint
 	validators map[ /* Node.Address() */ string]*Validator
 }
 
-func NewLocalNode(kp *keypair.Full, endpoint *sebakcommon.Endpoint, alias string) (n *LocalNode, err error) {
+func NewLocalNode(kp *keypair.Full, endpoint *common.Endpoint, alias string) (n *LocalNode, err error) {
 	if len(alias) < 1 {
 		alias = MakeAlias(kp.Address())
 	}
@@ -104,7 +104,7 @@ func (n *LocalNode) SetAlias(s string) {
 	n.alias = s
 }
 
-func (n *LocalNode) Endpoint() *sebakcommon.Endpoint {
+func (n *LocalNode) Endpoint() *common.Endpoint {
 	return n.endpoint
 }
 

--- a/lib/node/node.go
+++ b/lib/node/node.go
@@ -8,7 +8,7 @@ type Node interface {
 	Address() string
 	Alias() string
 	SetAlias(string)
-	Endpoint() *sebakcommon.Endpoint
+	Endpoint() *common.Endpoint
 	Equal(Node) bool
 	DeepEqual(Node) bool
 	Serialize() ([]byte, error)

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNodeStateChange(t *testing.T) {
 	kp, _ := keypair.Random()
-	endpoint, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
+	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
 	node, _ := NewLocalNode(kp, endpoint, "")
@@ -36,7 +36,7 @@ func TestNodeStateChange(t *testing.T) {
 
 func TestNodeMarshalJSON(t *testing.T) {
 	kp, _ := keypair.Random()
-	endpoint, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
+	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
 	marshalNode, _ := NewLocalNode(kp, endpoint, "")
@@ -71,13 +71,13 @@ func TestNodeMarshalJSON(t *testing.T) {
 func TestNodeMarshalJSONWithValidator(t *testing.T) {
 	kp, _ := keypair.Random()
 
-	endpoint, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
+	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
-	endpoint2, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:5001?NodeName=n2"))
+	endpoint2, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5001?NodeName=n2"))
 	require.Equal(t, nil, err)
 
-	endpoint3, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:5002?NodeName=n3"))
+	endpoint3, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5002?NodeName=n3"))
 	require.Equal(t, nil, err)
 
 	kp2, _ := keypair.Random()

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -21,7 +21,7 @@ import (
 type ValidatorFromJSON struct {
 	Alias    string                `json:"alias"`
 	Address  string                `json:"address"`
-	Endpoint *sebakcommon.Endpoint `json:"endpoint"`
+	Endpoint *common.Endpoint `json:"endpoint"`
 	State    NodeState             `json:"state"`
 }
 
@@ -31,7 +31,7 @@ type Validator struct {
 	state    NodeState
 	alias    string
 	address  string
-	endpoint *sebakcommon.Endpoint
+	endpoint *common.Endpoint
 }
 
 func (v *Validator) String() string {
@@ -89,7 +89,7 @@ func (v *Validator) SetAlias(s string) {
 	v.alias = s
 }
 
-func (v *Validator) Endpoint() *sebakcommon.Endpoint {
+func (v *Validator) Endpoint() *common.Endpoint {
 	return v.endpoint
 }
 
@@ -120,7 +120,7 @@ func (v *Validator) Serialize() ([]byte, error) {
 	return json.Marshal(v)
 }
 
-func NewValidator(address string, endpoint *sebakcommon.Endpoint, alias string) (v *Validator, err error) {
+func NewValidator(address string, endpoint *common.Endpoint, alias string) (v *Validator, err error) {
 	if len(alias) < 1 {
 		alias = MakeAlias(address)
 	}
@@ -154,8 +154,8 @@ func NewValidatorFromURI(v string) (validator *Validator, err error) {
 		return
 	}
 
-	var endpoint *sebakcommon.Endpoint
-	endpoint, err = sebakcommon.ParseEndpoint(
+	var endpoint *common.Endpoint
+	endpoint, err = common.ParseEndpoint(
 		fmt.Sprintf("%s://%s%s", parsed.Scheme, parsed.Host, parsed.Path),
 	)
 	if err != nil {

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -19,10 +19,10 @@ import (
 )
 
 type ValidatorFromJSON struct {
-	Alias    string                `json:"alias"`
-	Address  string                `json:"address"`
+	Alias    string           `json:"alias"`
+	Address  string           `json:"address"`
 	Endpoint *common.Endpoint `json:"endpoint"`
-	State    NodeState             `json:"state"`
+	State    NodeState        `json:"state"`
 }
 
 type Validator struct {

--- a/lib/node/validator_test.go
+++ b/lib/node/validator_test.go
@@ -79,7 +79,7 @@ func TestParseValidatorFromURI(t *testing.T) {
 func TestValidatorMarshalJSON(t *testing.T) {
 	kp, _ := keypair.Random()
 
-	endpoint, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
+	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
 	validator, _ := NewValidator(kp.Address(), endpoint, "v1")
@@ -109,7 +109,7 @@ func TestValidatorNewValidatorFromString(t *testing.T) {
 func TestValidatorUnMarshalJSON(t *testing.T) {
 	kp, _ := keypair.Random()
 
-	endpoint, err := sebakcommon.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
+	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
 	validator, _ := NewValidator(kp.Address(), endpoint, "node")

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -21,7 +21,7 @@ import (
 	"boscoin.io/sebak/lib/storage"
 )
 
-var DefaultHandleTransactionCheckerFuncs = []sebakcommon.CheckerFunc{
+var DefaultHandleTransactionCheckerFuncs = []common.CheckerFunc{
 	TransactionUnmarshal,
 	HasTransaction,
 	SaveTransactionHistory,
@@ -31,13 +31,13 @@ var DefaultHandleTransactionCheckerFuncs = []sebakcommon.CheckerFunc{
 	BroadcastTransaction,
 }
 
-var DefaultHandleBaseBallotCheckerFuncs = []sebakcommon.CheckerFunc{
+var DefaultHandleBaseBallotCheckerFuncs = []common.CheckerFunc{
 	BallotUnmarshal,
 	BallotNotFromKnownValidators,
 	BallotAlreadyFinished,
 }
 
-var DefaultHandleINITBallotCheckerFuncs = []sebakcommon.CheckerFunc{
+var DefaultHandleINITBallotCheckerFuncs = []common.CheckerFunc{
 	BallotAlreadyVoted,
 	BallotVote,
 	BallotIsSameProposer,
@@ -45,7 +45,7 @@ var DefaultHandleINITBallotCheckerFuncs = []sebakcommon.CheckerFunc{
 	INITBallotBroadcast,
 }
 
-var DefaultHandleSIGNBallotCheckerFuncs = []sebakcommon.CheckerFunc{
+var DefaultHandleSIGNBallotCheckerFuncs = []common.CheckerFunc{
 	BallotAlreadyVoted,
 	BallotVote,
 	BallotIsSameProposer,
@@ -53,7 +53,7 @@ var DefaultHandleSIGNBallotCheckerFuncs = []sebakcommon.CheckerFunc{
 	SIGNBallotBroadcast,
 }
 
-var DefaultHandleACCEPTBallotCheckerFuncs = []sebakcommon.CheckerFunc{
+var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
 	BallotAlreadyVoted,
 	BallotVote,
 	BallotIsSameProposer,
@@ -68,21 +68,21 @@ type ProposerCalculator interface {
 type NodeRunner struct {
 	networkID          []byte
 	localNode          *node.LocalNode
-	policy             sebakcommon.VotingThresholdPolicy
+	policy             common.VotingThresholdPolicy
 	network            network.Network
 	consensus          *ISAAC
 	connectionManager  *network.ConnectionManager
 	storage            *sebakstorage.LevelDBBackend
 	proposerCalculator ProposerCalculator
 
-	handleTransactionCheckerFuncs  []sebakcommon.CheckerFunc
-	handleBaseBallotCheckerFuncs   []sebakcommon.CheckerFunc
-	handleINITBallotCheckerFuncs   []sebakcommon.CheckerFunc
-	handleSIGNBallotCheckerFuncs   []sebakcommon.CheckerFunc
-	handleACCEPTBallotCheckerFuncs []sebakcommon.CheckerFunc
+	handleTransactionCheckerFuncs  []common.CheckerFunc
+	handleBaseBallotCheckerFuncs   []common.CheckerFunc
+	handleINITBallotCheckerFuncs   []common.CheckerFunc
+	handleSIGNBallotCheckerFuncs   []common.CheckerFunc
+	handleACCEPTBallotCheckerFuncs []common.CheckerFunc
 
-	handleTransactionCheckerDeferFunc sebakcommon.CheckerDeferFunc
-	handleBallotCheckerDeferFunc      sebakcommon.CheckerDeferFunc
+	handleTransactionCheckerDeferFunc common.CheckerDeferFunc
+	handleBallotCheckerDeferFunc      common.CheckerDeferFunc
 
 	log logging.Logger
 
@@ -92,7 +92,7 @@ type NodeRunner struct {
 func NewNodeRunner(
 	networkID string,
 	localNode *node.LocalNode,
-	policy sebakcommon.VotingThresholdPolicy,
+	policy common.VotingThresholdPolicy,
 	n network.Network,
 	consensus *ISAAC,
 	storage *sebakstorage.LevelDBBackend,
@@ -228,7 +228,7 @@ func (nr *NodeRunner) Storage() *sebakstorage.LevelDBBackend {
 	return nr.storage
 }
 
-func (nr *NodeRunner) Policy() sebakcommon.VotingThresholdPolicy {
+func (nr *NodeRunner) Policy() common.VotingThresholdPolicy {
 	return nr.policy
 }
 
@@ -254,37 +254,37 @@ func (nr *NodeRunner) ConnectValidators() {
 }
 
 func (nr *NodeRunner) SetHandleTransactionCheckerFuncs(
-	deferFunc sebakcommon.CheckerDeferFunc,
-	f ...sebakcommon.CheckerFunc,
+	deferFunc common.CheckerDeferFunc,
+	f ...common.CheckerFunc,
 ) {
 	if len(f) > 0 {
 		nr.handleTransactionCheckerFuncs = f
 	}
 
 	if deferFunc == nil {
-		deferFunc = sebakcommon.DefaultDeferFunc
+		deferFunc = common.DefaultDeferFunc
 	}
 
 	nr.handleTransactionCheckerDeferFunc = deferFunc
 }
 
-func (nr *NodeRunner) SetHandleBaseBallotCheckerFuncs(f ...sebakcommon.CheckerFunc) {
+func (nr *NodeRunner) SetHandleBaseBallotCheckerFuncs(f ...common.CheckerFunc) {
 	nr.handleBaseBallotCheckerFuncs = f
 }
 
-func (nr *NodeRunner) SetHandleINITBallotCheckerFuncs(f ...sebakcommon.CheckerFunc) {
+func (nr *NodeRunner) SetHandleINITBallotCheckerFuncs(f ...common.CheckerFunc) {
 	nr.handleINITBallotCheckerFuncs = f
 }
 
-func (nr *NodeRunner) SetHandleSIGNBallotCheckerFuncs(f ...sebakcommon.CheckerFunc) {
+func (nr *NodeRunner) SetHandleSIGNBallotCheckerFuncs(f ...common.CheckerFunc) {
 	nr.handleSIGNBallotCheckerFuncs = f
 }
 
-func (nr *NodeRunner) SetHandleACCEPTBallotCheckerFuncs(f ...sebakcommon.CheckerFunc) {
+func (nr *NodeRunner) SetHandleACCEPTBallotCheckerFuncs(f ...common.CheckerFunc) {
 	nr.handleACCEPTBallotCheckerFuncs = f
 }
 
-func (nr *NodeRunner) SetHandleMessageCheckerDeferFunc(f sebakcommon.CheckerDeferFunc) {
+func (nr *NodeRunner) SetHandleMessageCheckerDeferFunc(f common.CheckerDeferFunc) {
 	nr.handleTransactionCheckerDeferFunc = f
 }
 
@@ -314,7 +314,7 @@ func (nr *NodeRunner) handleMessage() {
 		}
 
 		if err != nil {
-			if _, ok := err.(sebakcommon.CheckerStop); ok {
+			if _, ok := err.(common.CheckerStop); ok {
 				continue
 			}
 			nr.log.Error("failed to handle network.Message", "message", message.Head(50), "error", err)
@@ -326,15 +326,15 @@ func (nr *NodeRunner) handleTransaction(message network.Message) (err error) {
 	nr.log.Debug("got message`", "message", message.Head(50))
 
 	checker := &MessageChecker{
-		DefaultChecker: sebakcommon.DefaultChecker{Funcs: nr.handleTransactionCheckerFuncs},
+		DefaultChecker: common.DefaultChecker{Funcs: nr.handleTransactionCheckerFuncs},
 		NodeRunner:     nr,
 		LocalNode:      nr.localNode,
 		NetworkID:      nr.networkID,
 		Message:        message,
 	}
 
-	if err = sebakcommon.RunChecker(checker, nr.handleTransactionCheckerDeferFunc); err != nil {
-		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
+	if err = common.RunChecker(checker, nr.handleTransactionCheckerDeferFunc); err != nil {
+		if _, ok := err.(common.CheckerErrorStop); !ok {
 			nr.log.Error("failed to handle message from client", "error", err)
 		}
 		return
@@ -347,34 +347,34 @@ func (nr *NodeRunner) handleBallotMessage(message network.Message) (err error) {
 	nr.log.Debug("got ballot", "message", message.Head(50))
 
 	baseChecker := &BallotChecker{
-		DefaultChecker: sebakcommon.DefaultChecker{Funcs: nr.handleBaseBallotCheckerFuncs},
+		DefaultChecker: common.DefaultChecker{Funcs: nr.handleBaseBallotCheckerFuncs},
 		NodeRunner:     nr,
 		LocalNode:      nr.localNode,
 		NetworkID:      nr.networkID,
 		Message:        message,
 		Log:            nr.Log(),
-		VotingHole:     sebakcommon.VotingNOTYET,
+		VotingHole:     common.VotingNOTYET,
 	}
-	err = sebakcommon.RunChecker(baseChecker, nr.handleTransactionCheckerDeferFunc)
+	err = common.RunChecker(baseChecker, nr.handleTransactionCheckerDeferFunc)
 	if err != nil {
-		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
+		if _, ok := err.(common.CheckerErrorStop); !ok {
 			nr.log.Error("failed to handle ballot", "error", err, "state", "base")
 			return
 		}
 	}
 
-	var checkerFuncs []sebakcommon.CheckerFunc
+	var checkerFuncs []common.CheckerFunc
 	switch baseChecker.Ballot.State() {
-	case sebakcommon.BallotStateINIT:
+	case common.BallotStateINIT:
 		checkerFuncs = DefaultHandleINITBallotCheckerFuncs
-	case sebakcommon.BallotStateSIGN:
+	case common.BallotStateSIGN:
 		checkerFuncs = DefaultHandleSIGNBallotCheckerFuncs
-	case sebakcommon.BallotStateACCEPT:
+	case common.BallotStateACCEPT:
 		checkerFuncs = DefaultHandleACCEPTBallotCheckerFuncs
 	}
 
 	checker := &BallotChecker{
-		DefaultChecker: sebakcommon.DefaultChecker{Funcs: checkerFuncs},
+		DefaultChecker: common.DefaultChecker{Funcs: checkerFuncs},
 		NodeRunner:     nr,
 		LocalNode:      nr.localNode,
 		NetworkID:      nr.networkID,
@@ -385,9 +385,9 @@ func (nr *NodeRunner) handleBallotMessage(message network.Message) (err error) {
 		RoundVote:      baseChecker.RoundVote,
 		Log:            baseChecker.Log,
 	}
-	err = sebakcommon.RunChecker(checker, nr.handleTransactionCheckerDeferFunc)
+	err = common.RunChecker(checker, nr.handleTransactionCheckerDeferFunc)
 	if err != nil {
-		if stopped, ok := err.(sebakcommon.CheckerStop); ok {
+		if stopped, ok := err.(common.CheckerStop); ok {
 			nr.log.Debug(
 				"stopped to handle ballot",
 				"state", baseChecker.Ballot.State(),
@@ -422,7 +422,7 @@ func (nr *NodeRunner) InitRound() {
 		}
 
 		for address, _ := range nr.localNode.GetValidators() {
-			if _, found := sebakcommon.InStringArray(connected, address); !found {
+			if _, found := common.InStringArray(connected, address); !found {
 				notFound = true
 				break
 			}
@@ -520,17 +520,17 @@ func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
 	nr.log.Debug("new round proposed", "round", round, "transactions", availableTransactions)
 
 	transactionsChecker := &BallotTransactionChecker{
-		DefaultChecker: sebakcommon.DefaultChecker{Funcs: handleBallotTransactionCheckerFuncs},
+		DefaultChecker: common.DefaultChecker{Funcs: handleBallotTransactionCheckerFuncs},
 		NodeRunner:     nr,
 		LocalNode:      nr.localNode,
 		NetworkID:      nr.networkID,
 		Transactions:   availableTransactions,
 		CheckAll:       true,
-		VotingHole:     sebakcommon.VotingNOTYET,
+		VotingHole:     common.VotingNOTYET,
 	}
 
-	if err := sebakcommon.RunChecker(transactionsChecker, sebakcommon.DefaultDeferFunc); err != nil {
-		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
+	if err := common.RunChecker(transactionsChecker, common.DefaultDeferFunc); err != nil {
+		if _, ok := err.(common.CheckerErrorStop); !ok {
 			nr.log.Error("error occurred in BallotTransactionChecker", "error", err)
 		}
 	}
@@ -539,7 +539,7 @@ func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
 	nr.Consensus().TransactionPool.Remove(transactionsChecker.InvalidTransactions()...)
 
 	ballot := NewBallot(nr.localNode, round, transactionsChecker.ValidTransactions)
-	ballot.SetVote(sebakcommon.BallotStateINIT, sebakcommon.VotingYES)
+	ballot.SetVote(common.BallotStateINIT, common.VotingYES)
 	ballot.Sign(nr.localNode.Keypair(), nr.networkID)
 
 	nr.log.Debug("new ballot created", "ballot", ballot)

--- a/lib/node_runner_ballot_transaction_checker.go
+++ b/lib/node_runner_ballot_transaction_checker.go
@@ -7,14 +7,14 @@ import (
 )
 
 type BallotTransactionChecker struct {
-	sebakcommon.DefaultChecker
+	common.DefaultChecker
 
 	NodeRunner *NodeRunner
 	LocalNode  node.Node
 	NetworkID  []byte
 
 	Transactions         []string
-	VotingHole           sebakcommon.VotingHole
+	VotingHole           common.VotingHole
 	ValidTransactions    []string
 	validTransactionsMap map[string]bool
 	CheckAll             bool
@@ -45,7 +45,7 @@ func (checker *BallotTransactionChecker) setValidTransactions(hashes []string) {
 
 // TransactionsIsNew checks the incoming transaction is
 // already stored or not.
-func IsNew(c sebakcommon.Checker, args ...interface{}) (err error) {
+func IsNew(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
 
 	var validTransactions []string
@@ -70,7 +70,7 @@ func IsNew(c sebakcommon.Checker, args ...interface{}) (err error) {
 
 // GetMissingTransaction will get the missing
 // tranactions, that is, not in `TransactionPool` from proposer.
-func GetMissingTransaction(c sebakcommon.Checker, args ...interface{}) (err error) {
+func GetMissingTransaction(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
 
 	var validTransactions []string
@@ -90,14 +90,14 @@ func GetMissingTransaction(c sebakcommon.Checker, args ...interface{}) (err erro
 
 // BallotTransactionsSourceCheck checks there are transactions which has same
 // source in the `Transactions`.
-func BallotTransactionsSameSource(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotTransactionsSameSource(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
 
 	var validTransactions []string
 	sources := map[string]bool{}
 	for _, hash := range checker.ValidTransactions {
 		tx, _ := checker.NodeRunner.Consensus().TransactionPool.Get(hash)
-		if found := sebakcommon.InStringMap(sources, tx.B.Source); found {
+		if found := common.InStringMap(sources, tx.B.Source); found {
 			if !checker.CheckAll {
 				err = errors.ErrorTransactionSameSource
 				return
@@ -115,7 +115,7 @@ func BallotTransactionsSameSource(c sebakcommon.Checker, args ...interface{}) (e
 }
 
 // BallotTransactionsSourceCheck calls `Transaction.Validate()`.
-func BallotTransactionsSourceCheck(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotTransactionsSourceCheck(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
 
 	var validTransactions []string

--- a/lib/node_runner_checker.go
+++ b/lib/node_runner_checker.go
@@ -24,12 +24,12 @@ func (c CheckerStopCloseConsensus) Error() string {
 	return c.message
 }
 
-func (c CheckerStopCloseConsensus) Checker() sebakcommon.Checker {
+func (c CheckerStopCloseConsensus) Checker() common.Checker {
 	return c.checker
 }
 
 type NodeRunnerHandleMessageChecker struct {
-	sebakcommon.DefaultChecker
+	common.DefaultChecker
 
 	NodeRunner *NodeRunner
 	LocalNode  *node.LocalNode
@@ -41,7 +41,7 @@ type NodeRunnerHandleMessageChecker struct {
 
 // CheckNodeRunnerHandleMessageTransactionUnmarshal makes `Transaction` from
 // incoming `network.Message`.
-func CheckNodeRunnerHandleMessageTransactionUnmarshal(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckNodeRunnerHandleMessageTransactionUnmarshal(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*NodeRunnerHandleMessageChecker)
 
 	var tx Transaction
@@ -61,7 +61,7 @@ func CheckNodeRunnerHandleMessageTransactionUnmarshal(c sebakcommon.Checker, arg
 
 // CheckNodeRunnerHandleMessageHasTransactionAlready checks transaction is in
 // `TransactionPool`.
-func CheckNodeRunnerHandleMessageHasTransactionAlready(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckNodeRunnerHandleMessageHasTransactionAlready(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*NodeRunnerHandleMessageChecker)
 
 	is := checker.NodeRunner.Consensus()
@@ -75,7 +75,7 @@ func CheckNodeRunnerHandleMessageHasTransactionAlready(c sebakcommon.Checker, ar
 
 // CheckNodeRunnerHandleMessageHistory checks transaction is in
 // `BlockTransactionHistory`, which has the received transaction recently.
-func CheckNodeRunnerHandleMessageHistory(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckNodeRunnerHandleMessageHistory(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*NodeRunnerHandleMessageChecker)
 
 	var found bool
@@ -97,7 +97,7 @@ func CheckNodeRunnerHandleMessageHistory(c sebakcommon.Checker, args ...interfac
 
 // CheckNodeRunnerHandleMessagePushIntoTransactionPool add the incoming
 // transactions into `TransactionPool`.
-func CheckNodeRunnerHandleMessagePushIntoTransactionPool(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckNodeRunnerHandleMessagePushIntoTransactionPool(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*NodeRunnerHandleMessageChecker)
 
 	tx := checker.Transaction
@@ -111,7 +111,7 @@ func CheckNodeRunnerHandleMessagePushIntoTransactionPool(c sebakcommon.Checker, 
 
 // CheckNodeRunnerHandleMessageTransactionBroadcast broadcasts the incoming
 // transaction to the other nodes.
-func CheckNodeRunnerHandleMessageTransactionBroadcast(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckNodeRunnerHandleMessageTransactionBroadcast(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*NodeRunnerHandleMessageChecker)
 
 	checker.NodeRunner.Log().Debug("transaction will be broadcasted", "transaction", checker.Transaction.GetHash())
@@ -123,7 +123,7 @@ func CheckNodeRunnerHandleMessageTransactionBroadcast(c sebakcommon.Checker, arg
 }
 
 type BallotChecker struct {
-	sebakcommon.DefaultChecker
+	common.DefaultChecker
 
 	NodeRunner         *NodeRunner
 	LocalNode          *node.LocalNode
@@ -131,17 +131,17 @@ type BallotChecker struct {
 	Message            network.Message
 	IsNew              bool
 	Ballot             Ballot
-	VotingHole         sebakcommon.VotingHole
+	VotingHole         common.VotingHole
 	RoundVote          *RoundVote
 	Result             RoundVoteResult
 	VotingFinished     bool
-	FinishedVotingHole sebakcommon.VotingHole
+	FinishedVotingHole common.VotingHole
 
 	Log logging.Logger
 }
 
 // BallotUnmarshal makes `Ballot` from network.Message.
-func BallotUnmarshal(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
 	var ballot Ballot
@@ -162,7 +162,7 @@ func BallotUnmarshal(c sebakcommon.Checker, args ...interface{}) (err error) {
 
 // BallotNotFromKnownValidators checks the incoming ballot
 // is from the known validators.
-func BallotNotFromKnownValidators(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotNotFromKnownValidators(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 	if checker.LocalNode.HasValidators(checker.Ballot.Source()) {
 		return
@@ -179,7 +179,7 @@ func BallotNotFromKnownValidators(c sebakcommon.Checker, args ...interface{}) (e
 
 // BallotAlreadyFinished checks the incoming ballot in
 // valid round.
-func BallotAlreadyFinished(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotAlreadyFinished(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
 	round := checker.Ballot.Round()
@@ -193,7 +193,7 @@ func BallotAlreadyFinished(c sebakcommon.Checker, args ...interface{}) (err erro
 }
 
 // BallotAlreadyVoted checks the node of ballot voted.
-func BallotAlreadyVoted(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotAlreadyVoted(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 	rr := checker.NodeRunner.Consensus().RunningRounds
 
@@ -214,7 +214,7 @@ func BallotAlreadyVoted(c sebakcommon.Checker, args ...interface{}) (err error) 
 // BallotVote vote by incoming ballot; if the ballot is new
 // and the round of ballot is not yet registered, this will make new
 // `RunningRound`.
-func BallotVote(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotVote(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
 	roundHash := checker.Ballot.Round().Hash()
@@ -257,10 +257,10 @@ func BallotVote(c sebakcommon.Checker, args ...interface{}) (err error) {
 
 // BallotIsSameProposer checks the incoming ballot has the
 // same proposer with the current `RunningRound`.
-func BallotIsSameProposer(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotIsSameProposer(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
-	if checker.VotingHole != sebakcommon.VotingNOTYET {
+	if checker.VotingHole != common.VotingNOTYET {
 		return
 	}
 
@@ -277,7 +277,7 @@ func BallotIsSameProposer(c sebakcommon.Checker, args ...interface{}) (err error
 	}
 
 	if runningRound.Proposer != checker.Ballot.Proposer() {
-		checker.VotingHole = sebakcommon.VotingNO
+		checker.VotingHole = common.VotingNO
 		checker.Log.Debug(
 			"ballot has different proposer",
 			"proposer", runningRound.Proposer,
@@ -290,7 +290,7 @@ func BallotIsSameProposer(c sebakcommon.Checker, args ...interface{}) (err error
 }
 
 // BallotCheckResult checks the voting result.
-func BallotCheckResult(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BallotCheckResult(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
 	if !checker.Ballot.State().IsValidForVote() {
@@ -313,7 +313,7 @@ func BallotCheckResult(c sebakcommon.Checker, args ...interface{}) (err error) {
 	return
 }
 
-var handleBallotTransactionCheckerFuncs = []sebakcommon.CheckerFunc{
+var handleBallotTransactionCheckerFuncs = []common.CheckerFunc{
 	IsNew,
 	GetMissingTransaction,
 	BallotTransactionsSameSource,
@@ -322,7 +322,7 @@ var handleBallotTransactionCheckerFuncs = []sebakcommon.CheckerFunc{
 
 // INITBallotValidateTransactions validates the
 // transactions of newly added ballot.
-func INITBallotValidateTransactions(c sebakcommon.Checker, args ...interface{}) (err error) {
+func INITBallotValidateTransactions(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
 	if !checker.IsNew || checker.VotingFinished {
@@ -334,28 +334,28 @@ func INITBallotValidateTransactions(c sebakcommon.Checker, args ...interface{}) 
 		return
 	}
 
-	if checker.VotingHole != sebakcommon.VotingNOTYET {
+	if checker.VotingHole != common.VotingNOTYET {
 		return
 	}
 
 	if checker.Ballot.TransactionsLength() < 1 {
-		checker.VotingHole = sebakcommon.VotingYES
+		checker.VotingHole = common.VotingYES
 		return
 	}
 
 	transactionsChecker := &BallotTransactionChecker{
-		DefaultChecker: sebakcommon.DefaultChecker{Funcs: handleBallotTransactionCheckerFuncs},
+		DefaultChecker: common.DefaultChecker{Funcs: handleBallotTransactionCheckerFuncs},
 		NodeRunner:     checker.NodeRunner,
 		LocalNode:      checker.LocalNode,
 		NetworkID:      checker.NetworkID,
 		Transactions:   checker.Ballot.Transactions(),
-		VotingHole:     sebakcommon.VotingNOTYET,
+		VotingHole:     common.VotingNOTYET,
 	}
 
-	err = sebakcommon.RunChecker(transactionsChecker, sebakcommon.DefaultDeferFunc)
+	err = common.RunChecker(transactionsChecker, common.DefaultDeferFunc)
 	if err != nil {
-		if _, ok := err.(sebakcommon.CheckerErrorStop); !ok {
-			checker.VotingHole = sebakcommon.VotingNO
+		if _, ok := err.(common.CheckerErrorStop); !ok {
+			checker.VotingHole = common.VotingNO
 			checker.Log.Debug("failed to handle transactions of ballot", "error", err)
 			err = nil
 			return
@@ -363,10 +363,10 @@ func INITBallotValidateTransactions(c sebakcommon.Checker, args ...interface{}) 
 		err = nil
 	}
 
-	if transactionsChecker.VotingHole == sebakcommon.VotingNO {
-		checker.VotingHole = sebakcommon.VotingNO
+	if transactionsChecker.VotingHole == common.VotingNO {
+		checker.VotingHole = common.VotingNO
 	} else {
-		checker.VotingHole = sebakcommon.VotingYES
+		checker.VotingHole = common.VotingYES
 	}
 
 	return
@@ -374,7 +374,7 @@ func INITBallotValidateTransactions(c sebakcommon.Checker, args ...interface{}) 
 
 // INITBallotBroadcast will broadcast the validated INIT
 // ballot.
-func INITBallotBroadcast(c sebakcommon.Checker, args ...interface{}) (err error) {
+func INITBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 	if !checker.IsNew {
 		return
@@ -382,7 +382,7 @@ func INITBallotBroadcast(c sebakcommon.Checker, args ...interface{}) (err error)
 
 	newBallot := checker.Ballot
 	newBallot.SetSource(checker.LocalNode.Address())
-	newBallot.SetVote(sebakcommon.BallotStateSIGN, checker.VotingHole)
+	newBallot.SetVote(common.BallotStateSIGN, checker.VotingHole)
 	newBallot.Sign(checker.LocalNode.Keypair(), checker.NetworkID)
 
 	rr := checker.NodeRunner.Consensus().RunningRounds
@@ -403,7 +403,7 @@ func INITBallotBroadcast(c sebakcommon.Checker, args ...interface{}) (err error)
 
 // SIGNBallotBroadcast will broadcast the confirmed SIGN
 // ballot.
-func SIGNBallotBroadcast(c sebakcommon.Checker, args ...interface{}) (err error) {
+func SIGNBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 	if !checker.VotingFinished {
 		return
@@ -411,7 +411,7 @@ func SIGNBallotBroadcast(c sebakcommon.Checker, args ...interface{}) (err error)
 
 	newBallot := checker.Ballot
 	newBallot.SetSource(checker.LocalNode.Address())
-	newBallot.SetVote(sebakcommon.BallotStateACCEPT, checker.FinishedVotingHole)
+	newBallot.SetVote(common.BallotStateACCEPT, checker.FinishedVotingHole)
 	newBallot.Sign(checker.LocalNode.Keypair(), checker.NetworkID)
 
 	rr := checker.NodeRunner.Consensus().RunningRounds
@@ -431,15 +431,15 @@ func SIGNBallotBroadcast(c sebakcommon.Checker, args ...interface{}) (err error)
 
 // ACCEPTBallotStore will store the confirmed ballot to
 // `Block`.
-func ACCEPTBallotStore(c sebakcommon.Checker, args ...interface{}) (err error) {
+func ACCEPTBallotStore(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
 	if !checker.VotingFinished {
 		return
 	}
 
-	willStore := checker.FinishedVotingHole == sebakcommon.VotingYES
-	if checker.FinishedVotingHole == sebakcommon.VotingYES {
+	willStore := checker.FinishedVotingHole == common.VotingYES
+	if checker.FinishedVotingHole == common.VotingYES {
 		var block Block
 		block, err = FinishBallot(
 			checker.NodeRunner.Storage(),

--- a/lib/node_runner_checker_test.go
+++ b/lib/node_runner_checker_test.go
@@ -18,7 +18,7 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 
 	rootAccount, _ := block.GetBlockAccount(nodeRunner.Storage(), rootKP.Address())
 
-	TestMakeBlockAccount := func(balance sebakcommon.Amount) (account *block.BlockAccount, kp *keypair.Full) {
+	TestMakeBlockAccount := func(balance common.Amount) (account *block.BlockAccount, kp *keypair.Full) {
 		kp, _ = keypair.Random()
 		account = block.NewBlockAccount(kp.Address(), balance, TestGenerateNewCheckpoint())
 
@@ -29,22 +29,22 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 		messageData, _ := tx.Serialize()
 
 		checker := &MessageChecker{
-			DefaultChecker: sebakcommon.DefaultChecker{Funcs: DefaultHandleTransactionCheckerFuncs},
+			DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleTransactionCheckerFuncs},
 			NodeRunner:     nodeRunner,
 			LocalNode:      nodeRunner.Node(),
 			NetworkID:      networkID,
 			Message:        network.Message{Type: "message", Data: messageData},
 		}
 
-		if err := sebakcommon.RunChecker(checker, nil); err != nil {
-			if _, ok := err.(sebakcommon.CheckerErrorStop); !ok && expectedError != nil {
+		if err := common.RunChecker(checker, nil); err != nil {
+			if _, ok := err.(common.CheckerErrorStop); !ok && expectedError != nil {
 				require.Error(t, err, expectedError)
 			}
 		}
 	}
 
 	{ // valid transaction
-		targetAccount, targetKP := TestMakeBlockAccount(sebakcommon.Amount(10000000000000) /* 100,00000 BOS */)
+		targetAccount, targetKP := TestMakeBlockAccount(common.Amount(10000000000000) /* 100,00000 BOS */)
 		targetAccount.Save(nodeRunner.Storage())
 
 		tx := TestMakeTransactionWithKeypair(networkID, 1, rootKP, targetKP)
@@ -57,7 +57,7 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 	}
 
 	{ // invalid transaction: same source already in TransactionPool
-		targetAccount, targetKP := TestMakeBlockAccount(sebakcommon.Amount(10000000000000))
+		targetAccount, targetKP := TestMakeBlockAccount(common.Amount(10000000000000))
 		targetAccount.Save(nodeRunner.Storage())
 
 		tx := TestMakeTransactionWithKeypair(networkID, 1, rootKP, targetKP)
@@ -74,8 +74,8 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 	}
 
 	{ // invalid transaction: source account does not exists
-		_, sourceKP := TestMakeBlockAccount(sebakcommon.Amount(10000000000000))
-		targetAccount, targetKP := TestMakeBlockAccount(sebakcommon.Amount(10000000000000))
+		_, sourceKP := TestMakeBlockAccount(common.Amount(10000000000000))
+		targetAccount, targetKP := TestMakeBlockAccount(common.Amount(10000000000000))
 		targetAccount.Save(nodeRunner.Storage())
 
 		tx := TestMakeTransactionWithKeypair(networkID, 1, sourceKP, targetKP)
@@ -90,8 +90,8 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 	}
 
 	{ // invalid transaction: target account does not exists
-		sourceAccount, sourceKP := TestMakeBlockAccount(sebakcommon.Amount(10000000000000))
-		_, targetKP := TestMakeBlockAccount(sebakcommon.Amount(10000000000000))
+		sourceAccount, sourceKP := TestMakeBlockAccount(common.Amount(10000000000000))
+		_, targetKP := TestMakeBlockAccount(common.Amount(10000000000000))
 		sourceAccount.Save(nodeRunner.Storage())
 
 		tx := TestMakeTransactionWithKeypair(networkID, 1, sourceKP, targetKP)

--- a/lib/node_runner_configuration.go
+++ b/lib/node_runner_configuration.go
@@ -32,13 +32,13 @@ func NewNodeRunnerConfiguration() *NodeRunnerConfiguration {
 	return &p
 }
 
-func (n *NodeRunnerConfiguration) GetTimeout(ballotState sebakcommon.BallotState) time.Duration {
+func (n *NodeRunnerConfiguration) GetTimeout(ballotState common.BallotState) time.Duration {
 	switch ballotState {
-	case sebakcommon.BallotStateINIT:
+	case common.BallotStateINIT:
 		return n.TimeoutINIT
-	case sebakcommon.BallotStateSIGN:
+	case common.BallotStateSIGN:
 		return n.TimeoutSIGN
-	case sebakcommon.BallotStateACCEPT:
+	case common.BallotStateACCEPT:
 		return n.TimeoutACCEPT
 	default:
 		return 0

--- a/lib/node_runner_memory_network_test.go
+++ b/lib/node_runner_memory_network_test.go
@@ -21,7 +21,7 @@ func makeTransaction(kp *keypair.Full) (tx Transaction) {
 	tx = Transaction{
 		T: "transaction",
 		H: TransactionHeader{
-			Created: sebakcommon.NowISO8601(),
+			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
 		},
 		B: txBody,
@@ -31,7 +31,7 @@ func makeTransaction(kp *keypair.Full) (tx Transaction) {
 	return
 }
 
-func makeTransactionPayment(kpSource *keypair.Full, target string, amount sebakcommon.Amount) (tx Transaction) {
+func makeTransactionPayment(kpSource *keypair.Full, target string, amount common.Amount) (tx Transaction) {
 	opb := NewOperationBodyPayment(target, amount)
 
 	op := Operation{
@@ -51,7 +51,7 @@ func makeTransactionPayment(kpSource *keypair.Full, target string, amount sebakc
 	tx = Transaction{
 		T: "transaction",
 		H: TransactionHeader{
-			Created: sebakcommon.NowISO8601(),
+			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
 		},
 		B: txBody,

--- a/lib/node_runner_message_checker.go
+++ b/lib/node_runner_message_checker.go
@@ -20,7 +20,7 @@ import (
 )
 
 type MessageChecker struct {
-	sebakcommon.DefaultChecker
+	common.DefaultChecker
 
 	NodeRunner *NodeRunner
 	LocalNode  *node.LocalNode
@@ -32,7 +32,7 @@ type MessageChecker struct {
 
 // TransactionUnmarshal makes `Transaction` from
 // incoming `network.Message`.
-func TransactionUnmarshal(c sebakcommon.Checker, args ...interface{}) (err error) {
+func TransactionUnmarshal(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*MessageChecker)
 
 	var tx Transaction
@@ -52,7 +52,7 @@ func TransactionUnmarshal(c sebakcommon.Checker, args ...interface{}) (err error
 
 // HasTransaction checks transaction is in
 // `TransactionPool`.
-func HasTransaction(c sebakcommon.Checker, args ...interface{}) (err error) {
+func HasTransaction(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*MessageChecker)
 
 	consensus := checker.NodeRunner.Consensus()
@@ -66,7 +66,7 @@ func HasTransaction(c sebakcommon.Checker, args ...interface{}) (err error) {
 
 // SaveTransactionHistory checks transaction is in
 // `BlockTransactionHistory`, which has the received transaction recently.
-func SaveTransactionHistory(c sebakcommon.Checker, args ...interface{}) (err error) {
+func SaveTransactionHistory(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*MessageChecker)
 
 	var found bool
@@ -88,7 +88,7 @@ func SaveTransactionHistory(c sebakcommon.Checker, args ...interface{}) (err err
 
 // SameSource checks there are transactions which has same source in the
 // `TransactionPool`.
-func MessageHasSameSource(c sebakcommon.Checker, args ...interface{}) (err error) {
+func MessageHasSameSource(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*MessageChecker)
 
 	if checker.NodeRunner.Consensus().TransactionPool.IsSameSource(checker.Transaction.Source()) {
@@ -100,7 +100,7 @@ func MessageHasSameSource(c sebakcommon.Checker, args ...interface{}) (err error
 }
 
 // MessageValidate validates.
-func MessageValidate(c sebakcommon.Checker, args ...interface{}) (err error) {
+func MessageValidate(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*MessageChecker)
 
 	if err = checker.Transaction.Validate(checker.NodeRunner.Storage()); err != nil {
@@ -112,7 +112,7 @@ func MessageValidate(c sebakcommon.Checker, args ...interface{}) (err error) {
 
 // PushIntoTransactionPool add the incoming
 // transactions into `TransactionPool`.
-func PushIntoTransactionPool(c sebakcommon.Checker, args ...interface{}) (err error) {
+func PushIntoTransactionPool(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*MessageChecker)
 
 	tx := checker.Transaction
@@ -126,7 +126,7 @@ func PushIntoTransactionPool(c sebakcommon.Checker, args ...interface{}) (err er
 
 // BroadcastTransaction broadcasts the incoming
 // transaction to the other nodes.
-func BroadcastTransaction(c sebakcommon.Checker, args ...interface{}) (err error) {
+func BroadcastTransaction(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*MessageChecker)
 
 	checker.NodeRunner.Log().Debug("transaction from client will be broadcasted", "transaction", checker.Transaction.GetHash())

--- a/lib/node_runner_message_checker_test.go
+++ b/lib/node_runner_message_checker_test.go
@@ -22,7 +22,7 @@ func TestMessageChecker(t *testing.T) {
 	validMessage := network.Message{Type: "message", Data: b}
 	nodeRunner, localNode := MakeNodeRunner()
 	checker := &MessageChecker{
-		DefaultChecker: sebakcommon.DefaultChecker{},
+		DefaultChecker: common.DefaultChecker{},
 		NodeRunner:     nodeRunner,
 		LocalNode:      localNode,
 		NetworkID:      networkID,
@@ -57,16 +57,16 @@ func TestMessageChecker(t *testing.T) {
 	err = PushIntoTransactionPool(checker)
 	require.Nil(t, err)
 
-	var CheckerFuncs = []sebakcommon.CheckerFunc{
+	var CheckerFuncs = []common.CheckerFunc{
 		TransactionUnmarshal,
 		HasTransaction,
 		SaveTransactionHistory,
 		PushIntoTransactionPool,
 	}
 
-	checker.DefaultChecker = sebakcommon.DefaultChecker{Funcs: CheckerFuncs}
+	checker.DefaultChecker = common.DefaultChecker{Funcs: CheckerFuncs}
 
-	err = sebakcommon.RunChecker(checker, sebakcommon.DefaultDeferFunc)
+	err = common.RunChecker(checker, common.DefaultDeferFunc)
 	require.Equal(t, err, errors.ErrorNewButKnownMessage)
 }
 

--- a/lib/node_runner_test.go
+++ b/lib/node_runner_test.go
@@ -49,7 +49,7 @@ func createTestNodeRunner(n int) []*NodeRunner {
 		}
 	}
 
-	checkpoint := sebakcommon.MakeGenesisCheckpoint(networkID)
+	checkpoint := common.MakeGenesisCheckpoint(networkID)
 	address := kp.Address()
 	balance := BaseFee.MustAdd(1)
 	account = block.NewBlockAccount(address, balance, checkpoint)
@@ -116,13 +116,13 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 	var ports []int
 	for i := 0; i < n; i++ {
 		kp, _ := keypair.Random()
-		port := sebakcommon.GetFreePort(ports...)
+		port := common.GetFreePort(ports...)
 		if port < 1 {
 			panic("failed to find free port")
 		}
 		ports = append(ports, port)
 
-		endpoint, _ := sebakcommon.NewEndpointFromString(
+		endpoint, _ := common.NewEndpointFromString(
 			fmt.Sprintf(
 				"http://localhost:%d?NodeName=%s&HTTP2LogOutput=%s",
 				port,
@@ -147,7 +147,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 	genesisAccount := block.NewBlockAccount(
 		rootKP.Address(),
 		10000000000000,
-		sebakcommon.MakeGenesisCheckpoint(networkID),
+		common.MakeGenesisCheckpoint(networkID),
 	)
 	for _, node := range nodes {
 		vth, _ := NewDefaultVotingThresholdPolicy(66, 66)
@@ -235,7 +235,7 @@ func TestNodeRunnerCreateAccount(t *testing.T) {
 
 	client := nr0.Network().GetClient(nr0.Node().Endpoint())
 
-	initialBalance := sebakcommon.Amount(1)
+	initialBalance := common.Amount(1)
 	tx := makeTransactionCreateAccount(kp, kpNewAccount.Address(), initialBalance)
 	tx.B.Checkpoint = account.Checkpoint
 	tx.Sign(kp, networkID)
@@ -269,8 +269,8 @@ func TestNodeRunnerSaveBlock(t *testing.T) {
 	}
 	var wg sync.WaitGroup
 	wg.Add(numberOfNodes)
-	checkerDeferFunc := func(n int, checker sebakcommon.Checker, err error) {
-		if _, ok := err.(sebakcommon.CheckerStop); !ok {
+	checkerDeferFunc := func(n int, checker common.Checker, err error) {
+		if _, ok := err.(common.CheckerStop); !ok {
 			return
 		}
 		wg.Done()

--- a/lib/operation.go
+++ b/lib/operation.go
@@ -24,7 +24,7 @@ type Operation struct {
 }
 
 func (o Operation) MakeHash() []byte {
-	return sebakcommon.MustMakeObjectHash(o)
+	return common.MustMakeObjectHash(o)
 }
 
 func (o Operation) MakeHashString() string {
@@ -81,15 +81,15 @@ func NewOperationFromInterface(oj OperationFromJSON) (op Operation, err error) {
 	body := oj.B.(map[string]interface{})
 	switch op.H.Type {
 	case OperationCreateAccount:
-		var amount sebakcommon.Amount
-		amount, err = sebakcommon.AmountFromString(fmt.Sprintf("%v", body["amount"]))
+		var amount common.Amount
+		amount, err = common.AmountFromString(fmt.Sprintf("%v", body["amount"]))
 		if err != nil {
 			return
 		}
 		op.B = NewOperationBodyCreateAccount(body["target"].(string), amount)
 	case OperationPayment:
-		var amount sebakcommon.Amount
-		amount, err = sebakcommon.AmountFromString(fmt.Sprintf("%v", body["amount"]))
+		var amount common.Amount
+		amount, err = common.AmountFromString(fmt.Sprintf("%v", body["amount"]))
 		if err != nil {
 			return
 		}
@@ -135,7 +135,7 @@ type OperationBody interface {
 	Validate(*sebakstorage.LevelDBBackend) error
 	IsWellFormed([]byte) error
 	TargetAddress() string
-	GetAmount() sebakcommon.Amount
+	GetAmount() common.Amount
 }
 
 // FinishOperation do finish the task after consensus by the type of each operation.

--- a/lib/operation_create_account.go
+++ b/lib/operation_create_account.go
@@ -13,10 +13,10 @@ import (
 
 type OperationBodyCreateAccount struct {
 	Target string             `json:"target"`
-	Amount sebakcommon.Amount `json:"amount"`
+	Amount common.Amount `json:"amount"`
 }
 
-func NewOperationBodyCreateAccount(target string, amount sebakcommon.Amount) OperationBodyCreateAccount {
+func NewOperationBodyCreateAccount(target string, amount common.Amount) OperationBodyCreateAccount {
 	return OperationBodyCreateAccount{
 		Target: target,
 		Amount: amount,
@@ -50,7 +50,7 @@ func (o OperationBodyCreateAccount) TargetAddress() string {
 	return o.Target
 }
 
-func (o OperationBodyCreateAccount) GetAmount() sebakcommon.Amount {
+func (o OperationBodyCreateAccount) GetAmount() common.Amount {
 	return o.Amount
 }
 

--- a/lib/operation_create_account.go
+++ b/lib/operation_create_account.go
@@ -12,7 +12,7 @@ import (
 )
 
 type OperationBodyCreateAccount struct {
-	Target string             `json:"target"`
+	Target string        `json:"target"`
 	Amount common.Amount `json:"amount"`
 }
 

--- a/lib/operation_payment.go
+++ b/lib/operation_payment.go
@@ -13,7 +13,7 @@ import (
 )
 
 type OperationBodyPayment struct {
-	Target string             `json:"target"`
+	Target string        `json:"target"`
 	Amount common.Amount `json:"amount"`
 }
 

--- a/lib/operation_payment.go
+++ b/lib/operation_payment.go
@@ -14,10 +14,10 @@ import (
 
 type OperationBodyPayment struct {
 	Target string             `json:"target"`
-	Amount sebakcommon.Amount `json:"amount"`
+	Amount common.Amount `json:"amount"`
 }
 
-func NewOperationBodyPayment(target string, amount sebakcommon.Amount) OperationBodyPayment {
+func NewOperationBodyPayment(target string, amount common.Amount) OperationBodyPayment {
 	return OperationBodyPayment{
 		Target: target,
 		Amount: amount,
@@ -56,7 +56,7 @@ func (o OperationBodyPayment) TargetAddress() string {
 	return o.Target
 }
 
-func (o OperationBodyPayment) GetAmount() sebakcommon.Amount {
+func (o OperationBodyPayment) GetAmount() common.Amount {
 	return o.Amount
 }
 
@@ -70,9 +70,9 @@ func FinishOperationPayment(st *sebakstorage.LevelDBBackend, tx Transaction, op 
 		err = errors.ErrorBlockAccountDoesNotExists
 		return
 	}
-	current, err := sebakcommon.ParseCheckpoint(baTarget.Checkpoint)
-	next, err := sebakcommon.ParseCheckpoint(tx.NextTargetCheckpoint())
-	newCheckPoint := sebakcommon.MakeCheckpoint(current[0], next[1])
+	current, err := common.ParseCheckpoint(baTarget.Checkpoint)
+	next, err := common.ParseCheckpoint(tx.NextTargetCheckpoint())
+	newCheckPoint := common.MakeCheckpoint(current[0], next[1])
 
 	if err = baTarget.Deposit(op.B.GetAmount(), newCheckPoint); err != nil {
 		return

--- a/lib/operation_test.go
+++ b/lib/operation_test.go
@@ -14,7 +14,7 @@ func TestMakeHashOfOperationBodyPayment(t *testing.T) {
 
 	opb := OperationBodyPayment{
 		Target: kp.Address(),
-		Amount: sebakcommon.Amount(100),
+		Amount: common.Amount(100),
 	}
 	op := Operation{
 		H: OperationHeader{Type: OperationPayment},

--- a/lib/round/round.go
+++ b/lib/round/round.go
@@ -14,7 +14,7 @@ type Round struct {
 }
 
 func (r Round) Hash() string {
-	return base58.Encode(sebakcommon.MustMakeObjectHash(r))
+	return base58.Encode(common.MustMakeObjectHash(r))
 }
 
 func (r Round) IsSame(a Round) bool {

--- a/lib/round_vote.go
+++ b/lib/round_vote.go
@@ -4,7 +4,7 @@ import (
 	"boscoin.io/sebak/lib/common"
 )
 
-type RoundVoteResult map[ /* Node.Address() */ string]sebakcommon.VotingHole
+type RoundVoteResult map[ /* Node.Address() */ string]common.VotingHole
 
 type RoundVote struct {
 	SIGN   RoundVoteResult
@@ -29,7 +29,7 @@ func (rv *RoundVote) IsVoted(ballot Ballot) bool {
 	return found
 }
 
-func (rv *RoundVote) IsVotedByNode(state sebakcommon.BallotState, node string) bool {
+func (rv *RoundVote) IsVotedByNode(state common.BallotState, node string) bool {
 	result := rv.GetResult(state)
 
 	_, found := result[node]
@@ -48,40 +48,40 @@ func (rv *RoundVote) Vote(ballot Ballot) (isNew bool, err error) {
 	return
 }
 
-func (rv *RoundVote) GetResult(state sebakcommon.BallotState) (result RoundVoteResult) {
+func (rv *RoundVote) GetResult(state common.BallotState) (result RoundVoteResult) {
 	if !state.IsValidForVote() {
 		return
 	}
 
 	switch state {
-	case sebakcommon.BallotStateSIGN:
+	case common.BallotStateSIGN:
 		result = rv.SIGN
-	case sebakcommon.BallotStateACCEPT:
+	case common.BallotStateACCEPT:
 		result = rv.ACCEPT
 	}
 
 	return result
 }
 
-func (rv *RoundVote) CanGetVotingResult(policy sebakcommon.VotingThresholdPolicy, state sebakcommon.BallotState) (RoundVoteResult, sebakcommon.VotingHole, bool) {
+func (rv *RoundVote) CanGetVotingResult(policy common.VotingThresholdPolicy, state common.BallotState) (RoundVoteResult, common.VotingHole, bool) {
 	threshold := policy.Threshold(state)
 	if threshold < 1 {
-		return RoundVoteResult{}, sebakcommon.VotingNOTYET, false
+		return RoundVoteResult{}, common.VotingNOTYET, false
 	}
 
 	result := rv.GetResult(state)
 	if len(result) < int(threshold) {
-		return result, sebakcommon.VotingNOTYET, false
+		return result, common.VotingNOTYET, false
 	}
 
 	var yes, no, expired int
 	for _, votingHole := range result {
 		switch votingHole {
-		case sebakcommon.VotingYES:
+		case common.VotingYES:
 			yes++
-		case sebakcommon.VotingNO:
+		case common.VotingNO:
 			no++
-		case sebakcommon.VotingEXP:
+		case common.VotingEXP:
 			expired++
 		}
 	}
@@ -96,17 +96,17 @@ func (rv *RoundVote) CanGetVotingResult(policy sebakcommon.VotingThresholdPolicy
 		"state", state,
 	)
 
-	if state == sebakcommon.BallotStateSIGN {
+	if state == common.BallotStateSIGN {
 		if yes >= threshold {
-			return result, sebakcommon.VotingYES, true
+			return result, common.VotingYES, true
 		} else if no >= threshold+1 {
-			return result, sebakcommon.VotingNO, true
+			return result, common.VotingNO, true
 		}
-	} else if state == sebakcommon.BallotStateACCEPT {
+	} else if state == common.BallotStateACCEPT {
 		if yes >= threshold {
-			return result, sebakcommon.VotingYES, true
+			return result, common.VotingYES, true
 		} else if no >= threshold {
-			return result, sebakcommon.VotingNO, true
+			return result, common.VotingNO, true
 		}
 	} else {
 		// do nothing
@@ -116,10 +116,10 @@ func (rv *RoundVote) CanGetVotingResult(policy sebakcommon.VotingThresholdPolicy
 	total := policy.Validators()
 	voted := yes + no + expired
 	if cannotBeOver(total-voted, threshold, yes, no) { // draw
-		return result, sebakcommon.VotingEXP, true
+		return result, common.VotingEXP, true
 	}
 
-	return result, sebakcommon.VotingNOTYET, false
+	return result, common.VotingNOTYET, false
 }
 
 func cannotBeOver(remain, threshold, yes, no int) bool {

--- a/lib/running_round.go
+++ b/lib/running_round.go
@@ -7,7 +7,7 @@ import (
 )
 
 type RunningRound struct {
-	sebakcommon.SafeLock
+	common.SafeLock
 
 	Round        round.Round
 	Proposer     string                              // LocalNode's `Proposer`

--- a/lib/statedb/state_object.go
+++ b/lib/statedb/state_object.go
@@ -9,11 +9,11 @@ import (
 	"fmt"
 )
 
-type Storage map[sebakcommon.Hash]sebakcommon.Hash
+type Storage map[common.Hash]common.Hash
 
 type Code []byte
 
-var emptyCodeHash = sebakcommon.MakeHash([]byte{})
+var emptyCodeHash = common.MakeHash([]byte{})
 
 type stateObject struct {
 	address     string
@@ -82,26 +82,26 @@ func (so *stateObject) Checkpoint() string {
 	return so.data.Checkpoint
 }
 
-func (so *stateObject) GetState(key sebakcommon.Hash) sebakcommon.Hash {
+func (so *stateObject) GetState(key common.Hash) common.Hash {
 	value, exists := so.cachedStorage[key]
 	if exists {
 		return value
 	}
 	enc, err := so.storageTrie.TryGet(key[:])
 	if err != nil {
-		return sebakcommon.Hash{}
+		return common.Hash{}
 	}
 	if len(enc) > 0 {
 		value.SetBytes(enc)
 	}
-	if (value != sebakcommon.Hash{}) {
+	if (value != common.Hash{}) {
 		so.cachedStorage[key] = value
 	}
 	return value
 }
 
 /* SETTERS */
-func (so *stateObject) SetState(key, value sebakcommon.Hash) {
+func (so *stateObject) SetState(key, value common.Hash) {
 	so.cachedStorage[key] = value
 	so.dirtyStorage[key] = value
 
@@ -112,8 +112,8 @@ func (so *stateObject) SetState(key, value sebakcommon.Hash) {
 
 }
 
-func (so *stateObject) AddBalance(amount sebakcommon.Amount) (err error) {
-	val := sebakcommon.MustAmountFromString(so.Balance())
+func (so *stateObject) AddBalance(amount common.Amount) (err error) {
+	val := common.MustAmountFromString(so.Balance())
 	val, err = val.Add(amount)
 	so.data.Balance = val.String()
 	if so.onDirty != nil {
@@ -123,14 +123,14 @@ func (so *stateObject) AddBalance(amount sebakcommon.Amount) (err error) {
 	return
 }
 
-func (so *stateObject) AddBalanceWithCheckpoint(amount sebakcommon.Amount, checkpoint string) (err error) {
+func (so *stateObject) AddBalanceWithCheckpoint(amount common.Amount, checkpoint string) (err error) {
 	so.data.Checkpoint = checkpoint
 	so.AddBalance(amount)
 	return
 }
 
-func (so *stateObject) SubBalance(amount sebakcommon.Amount) (err error) {
-	val := sebakcommon.MustAmountFromString(so.Balance())
+func (so *stateObject) SubBalance(amount common.Amount) (err error) {
+	val := common.MustAmountFromString(so.Balance())
 	val, err = val.Sub(amount)
 	so.data.Balance = val.String()
 	if so.onDirty != nil {
@@ -140,7 +140,7 @@ func (so *stateObject) SubBalance(amount sebakcommon.Amount) (err error) {
 	return
 }
 
-func (so *stateObject) SubBalanceWithCheckpoint(amount sebakcommon.Amount, checkpoint string) (err error) {
+func (so *stateObject) SubBalanceWithCheckpoint(amount common.Amount, checkpoint string) (err error) {
 	so.data.Checkpoint = checkpoint
 	so.SubBalance(amount)
 	return
@@ -168,23 +168,23 @@ func (so *stateObject) SetCode(codeHash, code []byte) {
 func (so *stateObject) updateTrie() {
 	for key, value := range so.dirtyStorage {
 		delete(so.dirtyStorage, key)
-		if (value == sebakcommon.Hash{}) {
+		if (value == common.Hash{}) {
 			continue
 		}
 		so.storageTrie.TryUpdate(key[:], value[:])
 	}
 }
 
-func (so *stateObject) CommitTrie() (root sebakcommon.Hash, err error) {
+func (so *stateObject) CommitTrie() (root common.Hash, err error) {
 	so.updateTrie()
 	root, err = so.storageTrie.Commit(nil)
 	if err == nil {
-		so.data.RootHash = sebakcommon.Hash(root)
+		so.data.RootHash = common.Hash(root)
 	}
 	return
 }
 
-func (so *stateObject) CommitDB(root sebakcommon.Hash) (err error) {
+func (so *stateObject) CommitDB(root common.Hash) (err error) {
 	if err = so.Save(); err != nil {
 		return
 	}
@@ -209,7 +209,7 @@ func (so *stateObject) Save() (err error) {
 	} else {
 		// TODO consider to use, [`Transaction`](https://godoc.org/github.com/syndtr/goleveldb/leveldb#DB.OpenTransaction)
 		err = st.New(key, so.data)
-		createdKey := block.GetBlockAccountCreatedKey(sebakcommon.GetUniqueIDFromUUID())
+		createdKey := block.GetBlockAccountCreatedKey(common.GetUniqueIDFromUUID())
 		err = st.New(createdKey, so.Address())
 	}
 	if err == nil {
@@ -231,8 +231,8 @@ func (so *stateObject) Save() (err error) {
 /*
 func (so *stateObject) GetValue(key string, value interface{}) (err error) {
 	encKey, err := trie.EncodeToBytes(key)
-	hashedKey := sebakcommon.MakeHash(encKey)
-	hashedVal := so.GetState(sebakcommon.BytesToHash(hashedKey))
+	hashedKey := common.MakeHash(encKey)
+	hashedVal := so.GetState(common.BytesToHash(hashedKey))
 	encVal, err := so.db.Get(hashedVal[:])
 	err = trie.DecodeBytes(encVal, value)
 	return
@@ -246,13 +246,13 @@ func (so *stateObject) SetValue(key string, value interface{}) (err error) {
 	if err != nil {
 		return
 	}
-	hashedKey := sebakcommon.MakeHash(encKey)
-	hashedVal := sebakcommon.MakeHash(encVal)
+	hashedKey := common.MakeHash(encKey)
+	hashedVal := common.MakeHash(encVal)
 	err = so.db.Put(hashedVal[:], encVal)
 	if err != nil {
 		return
 	}
-	so.SetState(sebakcommon.BytesToHash(hashedKey), sebakcommon.BytesToHash(hashedVal))
+	so.SetState(common.BytesToHash(hashedKey), common.BytesToHash(hashedVal))
 	return
 }
 */

--- a/lib/statedb/statedb.go
+++ b/lib/statedb/statedb.go
@@ -16,7 +16,7 @@ type StateDB struct {
 	stateObjectsCommitDirty map[string]struct{}
 }
 
-func New(root sebakcommon.Hash, db *trie.EthDatabase) *StateDB {
+func New(root common.Hash, db *trie.EthDatabase) *StateDB {
 	return &StateDB{
 		db:                      db,
 		trie:                    trie.NewTrie(root, db),
@@ -68,20 +68,20 @@ func (stateDB *StateDB) GetCode(addr string) []byte {
 	return nil
 }
 
-func (stateDB *StateDB) GetCodeHash(addr string) sebakcommon.Hash {
+func (stateDB *StateDB) GetCodeHash(addr string) common.Hash {
 	stateObject := stateDB.getStateObject(addr)
 	if stateObject == nil {
-		return sebakcommon.Hash{}
+		return common.Hash{}
 	}
-	return sebakcommon.BytesToHash(stateObject.CodeHash())
+	return common.BytesToHash(stateObject.CodeHash())
 }
 
-func (stateDB *StateDB) GetState(a string, b sebakcommon.Hash) sebakcommon.Hash {
+func (stateDB *StateDB) GetState(a string, b common.Hash) common.Hash {
 	stateObject := stateDB.getStateObject(a)
 	if stateObject != nil {
 		return stateObject.GetState(b)
 	}
-	return sebakcommon.Hash{}
+	return common.Hash{}
 }
 
 func (stateDB *StateDB) CreateAccount(addr string) {
@@ -95,28 +95,28 @@ func (stateDB *StateDB) SetCheckpoint(addr string, checkpoint string) {
 	}
 }
 
-func (stateDB *StateDB) AddBalance(addr string, amount sebakcommon.Amount) {
+func (stateDB *StateDB) AddBalance(addr string, amount common.Amount) {
 	stateObject := stateDB.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.AddBalance(amount)
 	}
 }
 
-func (stateDB *StateDB) AddBalanceWithCheckpoint(addr string, amount sebakcommon.Amount, checkpoint string) {
+func (stateDB *StateDB) AddBalanceWithCheckpoint(addr string, amount common.Amount, checkpoint string) {
 	stateObject := stateDB.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.AddBalanceWithCheckpoint(amount, checkpoint)
 	}
 }
 
-func (stateDB *StateDB) SubBalance(addr string, amount sebakcommon.Amount) {
+func (stateDB *StateDB) SubBalance(addr string, amount common.Amount) {
 	stateObject := stateDB.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SubBalance(amount)
 	}
 }
 
-func (stateDB *StateDB) SubBalanceWithCheckpoint(addr string, amount sebakcommon.Amount, checkpoint string) {
+func (stateDB *StateDB) SubBalanceWithCheckpoint(addr string, amount common.Amount, checkpoint string) {
 	stateObject := stateDB.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SubBalanceWithCheckpoint(amount, checkpoint)
@@ -126,11 +126,11 @@ func (stateDB *StateDB) SubBalanceWithCheckpoint(addr string, amount sebakcommon
 func (stateDB *StateDB) SetCode(addr string, code []byte) {
 	stateObject := stateDB.GetOrNewStateObject(addr)
 	if stateObject != nil {
-		stateObject.SetCode(sebakcommon.MakeHash(code), code)
+		stateObject.SetCode(common.MakeHash(code), code)
 	}
 }
 
-func (stateDB *StateDB) SetState(addr string, key, value sebakcommon.Hash) {
+func (stateDB *StateDB) SetState(addr string, key, value common.Hash) {
 	stateObject := stateDB.GetOrNewStateObject(addr)
 	if stateObject != nil {
 		stateObject.SetState(key, value)
@@ -179,12 +179,12 @@ func (stateDB *StateDB) updateStateObject(stateObject *stateObject) {
 
 }
 
-func (stateDB *StateDB) CommitTrie() (root sebakcommon.Hash, err error) {
+func (stateDB *StateDB) CommitTrie() (root common.Hash, err error) {
 
 	for addr, stateObject := range stateDB.stateObjects {
 		if _, isDirty := stateDB.stateObjectsDirty[addr]; isDirty {
 			if _, err = stateObject.CommitTrie(); err != nil {
-				return sebakcommon.Hash{}, err
+				return common.Hash{}, err
 			}
 			stateDB.updateStateObject(stateObject)
 			delete(stateDB.stateObjectsDirty, addr)
@@ -195,7 +195,7 @@ func (stateDB *StateDB) CommitTrie() (root sebakcommon.Hash, err error) {
 	return
 }
 
-func (stateDB *StateDB) CommitDB(root sebakcommon.Hash) (err error) {
+func (stateDB *StateDB) CommitDB(root common.Hash) (err error) {
 	for addr, stateObject := range stateDB.stateObjects {
 		if _, isDirty := stateDB.stateObjectsCommitDirty[addr]; isDirty {
 			if err = stateObject.CommitDB(stateObject.data.RootHash); err != nil {

--- a/lib/statedb/statedb_test.go
+++ b/lib/statedb/statedb_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 func TestStateDB(t *testing.T) {
-	var Root = sebakcommon.Hash{}
+	var Root = common.Hash{}
 	st, _ := sebakstorage.NewTestMemoryLevelDBBackend()
 
-	var keyHash = sebakcommon.BytesToHash(sebakcommon.MakeHash([]byte("key")))
-	var valueHash = sebakcommon.BytesToHash(sebakcommon.MakeHash([]byte("value")))
+	var keyHash = common.BytesToHash(common.MakeHash([]byte("key")))
+	var valueHash = common.BytesToHash(common.MakeHash([]byte("value")))
 
 	var err error
 

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -126,11 +126,11 @@ func (st *LevelDBBackend) Get(k string, i interface{}) (err error) {
 
 func (st *LevelDBBackend) New(k string, v interface{}) (err error) {
 	var encoded []byte
-	serializable, ok := v.(sebakcommon.Serializable)
+	serializable, ok := v.(common.Serializable)
 	if ok {
 		encoded, err = serializable.Serialize()
 	} else {
-		encoded, err = sebakcommon.EncodeJSONValue(v)
+		encoded, err = common.EncodeJSONValue(v)
 	}
 	if err != nil {
 		return
@@ -168,7 +168,7 @@ func (st *LevelDBBackend) News(vs ...Item) (err error) {
 	batch := new(leveldb.Batch)
 	for _, v := range vs {
 		var encoded []byte
-		if encoded, err = sebakcommon.EncodeJSONValue(v); err != nil {
+		if encoded, err = common.EncodeJSONValue(v); err != nil {
 			return
 		}
 
@@ -182,7 +182,7 @@ func (st *LevelDBBackend) News(vs ...Item) (err error) {
 
 func (st *LevelDBBackend) Set(k string, v interface{}) (err error) {
 	var encoded []byte
-	if encoded, err = sebakcommon.EncodeJSONValue(v); err != nil {
+	if encoded, err = common.EncodeJSONValue(v); err != nil {
 		return
 	}
 
@@ -201,11 +201,11 @@ func (st *LevelDBBackend) Set(k string, v interface{}) (err error) {
 
 func (st *LevelDBBackend) put(k string, v interface{}) (err error) {
 	var encoded []byte
-	serializable, ok := v.(sebakcommon.Serializable)
+	serializable, ok := v.(common.Serializable)
 	if ok {
 		encoded, err = serializable.Serialize()
 	} else {
-		encoded, err = sebakcommon.EncodeJSONValue(v)
+		encoded, err = common.EncodeJSONValue(v)
 	}
 	if err != nil {
 		return
@@ -233,7 +233,7 @@ func (st *LevelDBBackend) Sets(vs ...Item) (err error) {
 	batch := new(leveldb.Batch)
 	for _, v := range vs {
 		var encoded []byte
-		if encoded, err = sebakcommon.EncodeJSONValue(v); err != nil {
+		if encoded, err = common.EncodeJSONValue(v); err != nil {
 			return
 		}
 

--- a/lib/storage/leveldb_test.go
+++ b/lib/storage/leveldb_test.go
@@ -362,7 +362,7 @@ func TestLevelDBIteratorReverseOrder(t *testing.T) {
 }
 
 func TestLevelDBBackendTransactionNew(t *testing.T) {
-	dbpath := fmt.Sprintf("/tmp/%s", sebakcommon.GetUniqueIDFromUUID())
+	dbpath := fmt.Sprintf("/tmp/%s", common.GetUniqueIDFromUUID())
 	defer os.RemoveAll(dbpath)
 
 	st, _ := NewTestFileLevelDBBackend(dbpath)
@@ -370,7 +370,7 @@ func TestLevelDBBackendTransactionNew(t *testing.T) {
 
 	ts, _ := st.OpenTransaction()
 
-	key0 := sebakcommon.GetUniqueIDFromUUID()
+	key0 := common.GetUniqueIDFromUUID()
 	value0 := "findme"
 	if err := ts.New(key0, value0); err != nil {
 		t.Error(err)
@@ -403,7 +403,7 @@ func TestLevelDBBackendTransactionNew(t *testing.T) {
 }
 
 func TestLevelDBBackendTransactionDiscard(t *testing.T) {
-	dbpath := fmt.Sprintf("/tmp/%s", sebakcommon.GetUniqueIDFromUUID())
+	dbpath := fmt.Sprintf("/tmp/%s", common.GetUniqueIDFromUUID())
 	defer os.RemoveAll(dbpath)
 
 	st, _ := NewTestFileLevelDBBackend(dbpath)
@@ -411,7 +411,7 @@ func TestLevelDBBackendTransactionDiscard(t *testing.T) {
 
 	ts, _ := st.OpenTransaction()
 
-	key0 := sebakcommon.GetUniqueIDFromUUID()
+	key0 := common.GetUniqueIDFromUUID()
 	value0 := "findme"
 	if err := ts.New(key0, value0); err != nil {
 		t.Error(err)

--- a/lib/storage/statedb.go
+++ b/lib/storage/statedb.go
@@ -90,11 +90,11 @@ func (s *StateDB) MakeHash() ([]byte, error) {
 		} else if err != nil {
 			return nil, err
 		}
-		h := sebakcommon.MakeHash(bs)
+		h := common.MakeHash(bs)
 		hashes = append(hashes, h)
 	}
 
-	h, err := sebakcommon.MakeObjectHash(hashes)
+	h, err := common.MakeObjectHash(hashes)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -47,7 +47,7 @@ func NewConfigFromString(s string) (e *Config, err error) {
 		return
 	}
 
-	if _, found := sebakcommon.InStringArray(SupportedStorageType, u.Scheme); !found {
+	if _, found := common.InStringArray(SupportedStorageType, u.Scheme); !found {
 		err = errors.New("unsupported storage type")
 		return
 	}

--- a/lib/test.go
+++ b/lib/test.go
@@ -43,7 +43,7 @@ func createNetMemoryNetwork() (*network.MemoryNetwork, *node.LocalNode) {
 func MakeNodeRunner() (*NodeRunner, *node.LocalNode) {
 	kp, _ := keypair.Random()
 
-	nodeEndpoint := &sebakcommon.Endpoint{Scheme: "https", Host: "https://locahost:5000"}
+	nodeEndpoint := &common.Endpoint{Scheme: "https", Host: "https://locahost:5000"}
 	localNode, _ := node.NewLocalNode(kp, nodeEndpoint, "")
 
 	vth, _ := NewDefaultVotingThresholdPolicy(66, 66)
@@ -64,7 +64,7 @@ func testMakeNewBlock(transactions []string) Block {
 			BlockHash:   "",
 		},
 		transactions,
-		sebakcommon.NowISO8601(),
+		common.NowISO8601(),
 	)
 }
 
@@ -101,7 +101,7 @@ func TestMakeOperationBodyPayment(amount int, addressList ...string) OperationBo
 
 	return OperationBodyPayment{
 		Target: address,
-		Amount: sebakcommon.Amount(amount),
+		Amount: common.Amount(amount),
 	}
 }
 
@@ -136,7 +136,7 @@ func TestMakeTransaction(networkID []byte, n int) (kp *keypair.Full, tx Transact
 	tx = Transaction{
 		T: "transaction",
 		H: TransactionHeader{
-			Created: sebakcommon.NowISO8601(),
+			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
 		},
 		B: txBody,
@@ -208,7 +208,7 @@ func (c *SelfProposerThenNotProposer) Calculate(nr *NodeRunner, blockHeight uint
 }
 
 func GetTransaction(t *testing.T) (tx Transaction, txByte []byte) {
-	initialBalance := sebakcommon.Amount(1)
+	initialBalance := common.Amount(1)
 	kpNewAccount, _ := keypair.Random()
 
 	tx = makeTransactionCreateAccount(kp, kpNewAccount.Address(), initialBalance)
@@ -223,8 +223,8 @@ func GetTransaction(t *testing.T) (tx Transaction, txByte []byte) {
 	return
 }
 
-func makeTransactionCreateAccount(kpSource *keypair.Full, target string, amount sebakcommon.Amount) (tx Transaction) {
-	opb := NewOperationBodyCreateAccount(target, sebakcommon.Amount(amount))
+func makeTransactionCreateAccount(kpSource *keypair.Full, target string, amount common.Amount) (tx Transaction) {
+	opb := NewOperationBodyCreateAccount(target, common.Amount(amount))
 
 	op := Operation{
 		H: OperationHeader{
@@ -243,7 +243,7 @@ func makeTransactionCreateAccount(kpSource *keypair.Full, target string, amount 
 	tx = Transaction{
 		T: "transaction",
 		H: TransactionHeader{
-			Created: sebakcommon.NowISO8601(),
+			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
 		},
 		B: txBody,
@@ -253,13 +253,13 @@ func makeTransactionCreateAccount(kpSource *keypair.Full, target string, amount 
 	return
 }
 
-func GenerateBallot(t *testing.T, proposer *node.LocalNode, round round.Round, tx Transaction, ballotState sebakcommon.BallotState, sender *node.LocalNode) *Ballot {
+func GenerateBallot(t *testing.T, proposer *node.LocalNode, round round.Round, tx Transaction, ballotState common.BallotState, sender *node.LocalNode) *Ballot {
 	ballot := NewBallot(proposer, round, []string{tx.GetHash()})
-	ballot.SetVote(sebakcommon.BallotStateINIT, sebakcommon.VotingYES)
+	ballot.SetVote(common.BallotStateINIT, common.VotingYES)
 	ballot.Sign(proposer.Keypair(), networkID)
 
 	ballot.SetSource(sender.Address())
-	ballot.SetVote(ballotState, sebakcommon.VotingYES)
+	ballot.SetVote(ballotState, common.VotingYES)
 	ballot.Sign(sender.Keypair(), networkID)
 
 	err := ballot.IsWellFormed(networkID)
@@ -268,13 +268,13 @@ func GenerateBallot(t *testing.T, proposer *node.LocalNode, round round.Round, t
 	return ballot
 }
 
-func GenerateEmptyTxBallot(t *testing.T, proposer *node.LocalNode, round round.Round, ballotState sebakcommon.BallotState, sender *node.LocalNode) *Ballot {
+func GenerateEmptyTxBallot(t *testing.T, proposer *node.LocalNode, round round.Round, ballotState common.BallotState, sender *node.LocalNode) *Ballot {
 	ballot := NewBallot(proposer, round, []string{})
-	ballot.SetVote(sebakcommon.BallotStateINIT, sebakcommon.VotingYES)
+	ballot.SetVote(common.BallotStateINIT, common.VotingYES)
 	ballot.Sign(proposer.Keypair(), networkID)
 
 	ballot.SetSource(sender.Address())
-	ballot.SetVote(ballotState, sebakcommon.VotingYES)
+	ballot.SetVote(ballotState, common.VotingYES)
 	ballot.Sign(sender.Keypair(), networkID)
 
 	err := ballot.IsWellFormed(networkID)

--- a/lib/transaction_checker.go
+++ b/lib/transaction_checker.go
@@ -11,13 +11,13 @@ import (
 )
 
 type TransactionChecker struct {
-	sebakcommon.DefaultChecker
+	common.DefaultChecker
 
 	NetworkID   []byte
 	Transaction Transaction
 }
 
-func CheckTransactionSource(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckTransactionSource(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*TransactionChecker)
 	if _, err = keypair.Parse(checker.Transaction.B.Source); err != nil {
 		err = errors.ErrorBadPublicAddress
@@ -27,9 +27,9 @@ func CheckTransactionSource(c sebakcommon.Checker, args ...interface{}) (err err
 	return
 }
 
-func CheckTransactionCheckpoint(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckTransactionCheckpoint(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*TransactionChecker)
-	if _, err = sebakcommon.ParseCheckpoint(checker.Transaction.B.Checkpoint); err != nil {
+	if _, err = common.ParseCheckpoint(checker.Transaction.B.Checkpoint); err != nil {
 		err = errors.ErrorTransactionInvalidCheckpoint
 		return
 	}
@@ -37,7 +37,7 @@ func CheckTransactionCheckpoint(c sebakcommon.Checker, args ...interface{}) (err
 	return
 }
 
-func CheckTransactionBaseFee(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckTransactionBaseFee(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*TransactionChecker)
 	if checker.Transaction.B.Fee < BaseFee {
 		err = errors.ErrorInvalidFee
@@ -47,7 +47,7 @@ func CheckTransactionBaseFee(c sebakcommon.Checker, args ...interface{}) (err er
 	return
 }
 
-func CheckTransactionOperation(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckTransactionOperation(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*TransactionChecker)
 
 	if len(checker.Transaction.B.Operations) < 1 {
@@ -67,7 +67,7 @@ func CheckTransactionOperation(c sebakcommon.Checker, args ...interface{}) (err 
 		// if there are multiple operations which has same 'Type' and same
 		// 'TargetAddress()', this transaction will be invalid.
 		u := fmt.Sprintf("%s-%s", op.H.Type, op.B.TargetAddress())
-		if _, found := sebakcommon.InStringArray(hashes, u); found {
+		if _, found := common.InStringArray(hashes, u); found {
 			err = errors.ErrorDuplicatedOperation
 			return
 		}
@@ -78,7 +78,7 @@ func CheckTransactionOperation(c sebakcommon.Checker, args ...interface{}) (err 
 	return
 }
 
-func CheckTransactionVerifySignature(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckTransactionVerifySignature(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*TransactionChecker)
 
 	var kp keypair.KP
@@ -95,7 +95,7 @@ func CheckTransactionVerifySignature(c sebakcommon.Checker, args ...interface{})
 	return
 }
 
-func CheckTransactionHashMatch(c sebakcommon.Checker, args ...interface{}) (err error) {
+func CheckTransactionHashMatch(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*TransactionChecker)
 	if checker.Transaction.H.Hash != checker.Transaction.B.MakeHashString() {
 		err = errors.ErrorHashDoesNotMatch

--- a/lib/transaction_test.go
+++ b/lib/transaction_test.go
@@ -51,7 +51,7 @@ func TestIsWellFormedTransactionWithLowerFee(t *testing.T) {
 	err = tx.IsWellFormed(networkID)
 	require.NotNil(t, err, "Transaction shouidn't pass Fee checks")
 
-	tx.B.Fee = sebakcommon.Amount(0)
+	tx.B.Fee = common.Amount(0)
 	tx.H.Hash = tx.B.MakeHashString()
 	tx.Sign(kp, networkID)
 	err = tx.IsWellFormed(networkID)

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1,7 +1,7 @@
 package trie
 
 import (
-	"boscoin.io/sebak/lib/common"
+	sebakcommon "boscoin.io/sebak/lib/common"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/trie"
 )

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1,7 +1,7 @@
 package trie
 
 import (
-	gocommon "github.com/ethereum/go-ethereum/common"
+	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/trie"
 
 	"boscoin.io/sebak/lib/common"
@@ -14,7 +14,7 @@ type Trie struct {
 
 func NewTrie(root common.Hash, db *EthDatabase) *Trie {
 	triedb := trie.NewDatabase(db)
-	tr, err := trie.New(gocommon.Hash(root), triedb)
+	tr, err := trie.New(ethcommon.Hash(root), triedb)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/trie/trie.go
+++ b/lib/trie/trie.go
@@ -1,9 +1,10 @@
 package trie
 
 import (
-	sebakcommon "boscoin.io/sebak/lib/common"
-	"github.com/ethereum/go-ethereum/common"
+	gocommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/trie"
+
+	"boscoin.io/sebak/lib/common"
 )
 
 type Trie struct {
@@ -11,9 +12,9 @@ type Trie struct {
 	DB *trie.Database
 }
 
-func NewTrie(root sebakcommon.Hash, db *EthDatabase) *Trie {
+func NewTrie(root common.Hash, db *EthDatabase) *Trie {
 	triedb := trie.NewDatabase(db)
-	tr, err := trie.New(common.Hash(root), triedb)
+	tr, err := trie.New(gocommon.Hash(root), triedb)
 	if err != nil {
 		panic(err)
 	}
@@ -23,6 +24,6 @@ func NewTrie(root sebakcommon.Hash, db *EthDatabase) *Trie {
 	}
 }
 
-func (t *Trie) CommitDB(root sebakcommon.Hash) (err error) {
+func (t *Trie) CommitDB(root common.Hash) (err error) {
 	return t.DB.Commit(root, false)
 }

--- a/lib/voting_policy.go
+++ b/lib/voting_policy.go
@@ -16,7 +16,7 @@ type ISAACVotingThresholdPolicy struct {
 }
 
 func (vt *ISAACVotingThresholdPolicy) String() string {
-	o := sebakcommon.MustJSONMarshal(map[string]interface{}{
+	o := common.MustJSONMarshal(map[string]interface{}{
 		"sign":       vt.sign,
 		"accept":     vt.accept,
 		"validators": vt.validators,
@@ -53,12 +53,12 @@ func (vt *ISAACVotingThresholdPolicy) SetConnected(n int) error {
 	return nil
 }
 
-func (vt *ISAACVotingThresholdPolicy) Threshold(state sebakcommon.BallotState) int {
+func (vt *ISAACVotingThresholdPolicy) Threshold(state common.BallotState) int {
 	var t int
 	switch state {
-	case sebakcommon.BallotStateSIGN:
+	case common.BallotStateSIGN:
 		t = vt.sign
-	case sebakcommon.BallotStateACCEPT:
+	case common.BallotStateACCEPT:
 		t = vt.accept
 	}
 
@@ -66,7 +66,7 @@ func (vt *ISAACVotingThresholdPolicy) Threshold(state sebakcommon.BallotState) i
 	threshold := int(math.Ceil(v))
 
 	// in SIGN state, proposer assumes to say VotingYES
-	if state == sebakcommon.BallotStateSIGN {
+	if state == common.BallotStateSIGN {
 		threshold = threshold - 1
 	}
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->
Fixes #289 

### Solution
1. Alias common in cmd to cmdcommon when both using
1. Rename sebakcommon to common
