### PR TITLE
Using eventstream with APIHandlers

### DIFF
--- a/lib/api.go
+++ b/lib/api.go
@@ -13,6 +13,13 @@ import (
 
 const maxNumberOfExistingData = 10
 
+// API Endpoint patterns
+const (
+	GetAccountTransactionsHandlerPattern = "/account/{address}/transactions"
+	GetAccountHandlerPattern             = "/account/{address}"
+	GetAccountOperationsHandlerPattern   = "/account/{address}/operations"
+)
+
 type NetworkHandlerNode struct {
 	localNode *node.LocalNode
 	network   network.Network

--- a/lib/api.go
+++ b/lib/api.go
@@ -18,6 +18,8 @@ const (
 	GetAccountTransactionsHandlerPattern = "/account/{address}/transactions"
 	GetAccountHandlerPattern             = "/account/{address}"
 	GetAccountOperationsHandlerPattern   = "/account/{address}/operations"
+	GetTransactionsHandlerPattern        = "/transactions"
+	GetTransactionByHashHandlerPattern   = "/transactions/{txid}"
 )
 
 type NetworkHandlerNode struct {

--- a/lib/api_account.go
+++ b/lib/api_account.go
@@ -66,7 +66,10 @@ func (api NetworkHandlerAPI) GetAccountTransactionsHandler(w http.ResponseWriter
 	if httputils.IsEventStream(r) {
 		event := fmt.Sprintf("source-%s", address)
 		es := NewDefaultEventStream(w, r)
-		es.Render(readFunc(maxNumberOfExistingData))
+		txs := readFunc(maxNumberOfExistingData)
+		for _, tx := range txs {
+			es.Render(tx)
+		}
 		es.Run(observer.BlockTransactionObserver, event)
 		return
 	}

--- a/lib/api_account.go
+++ b/lib/api_account.go
@@ -9,16 +9,19 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/httputils"
 	"boscoin.io/sebak/lib/observer"
 )
-
-const GetAccountHandlerPattern = "/account/{address}"
 
 func (api NetworkHandlerAPI) GetAccountHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	address := vars["address"]
-	var blk *block.BlockAccount
-	var err error
+
+	var (
+		blk *block.BlockAccount
+		err error
+	)
+
 	if blk, err = block.GetBlockAccount(api.storage, address); err != nil {
 		if err == errors.ErrorStorageRecordDoesNotExist {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
@@ -28,42 +31,18 @@ func (api NetworkHandlerAPI) GetAccountHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	switch r.Header.Get("Accept") {
-	case "text/event-stream":
-		var readyChan = make(chan struct{})
+	if httputils.IsEventStream(r) {
+		event := fmt.Sprintf("address-%s", address)
+		es := NewDefaultEventStream(w, r)
+		es.Render(blk)
+		es.Run(observer.BlockAccountObserver, event)
+		return
+	}
 
-		// Trigger event for data already stored in the storage
-		iterateId := common.GetUniqueIDFromUUID()
-		go func() {
-			<-readyChan
-			observer.BlockAccountObserver.Trigger(fmt.Sprintf("iterate-%s", iterateId), blk)
-		}()
-
-		callBackFunc := func(args ...interface{}) (account []byte, err error) {
-			blk := args[1].(*block.BlockAccount)
-			if account, err = blk.Serialize(); err != nil {
-				return []byte{}, errors.ErrorBlockAccountDoesNotExists
-			}
-			return account, nil
-		}
-
-		event := fmt.Sprintf("iterate-%s", iterateId)
-		event += " " + fmt.Sprintf("address-%s", address)
-		streaming(observer.BlockAccountObserver, r, w, event, callBackFunc, readyChan)
-	default:
-		var s []byte
-		if s, err = blk.Serialize(); err != nil {
-			http.Error(w, "Error reading request body", http.StatusInternalServerError)
-			return
-		}
-		if _, err = w.Write(s); err != nil {
-			http.Error(w, "Error reading request body", http.StatusInternalServerError)
-			return
-		}
+	if err := httputils.WriteJSON(w, 200, blk); err != nil {
+		http.Error(w, "Error reading request body", http.StatusInternalServerError)
 	}
 }
-
-const GetAccountTransactionsHandlerPattern = "/account/{address}/transactions"
 
 func (api NetworkHandlerAPI) GetAccountTransactionsHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
@@ -122,8 +101,6 @@ func (api NetworkHandlerAPI) GetAccountTransactionsHandler(w http.ResponseWriter
 		}
 	}
 }
-
-const GetAccountOperationsHandlerPattern = "/account/{address}/operations"
 
 func (api NetworkHandlerAPI) GetAccountOperationsHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)

--- a/lib/block_operation.go
+++ b/lib/block_operation.go
@@ -93,6 +93,7 @@ func (bo *BlockOperation) Save(st *sebakstorage.LevelDBBackend) (err error) {
 
 	event := "saved"
 	event += " " + fmt.Sprintf("source-%s", bo.Source)
+	event += " " + fmt.Sprintf("bo-source-%s", bo.Source)
 	event += " " + fmt.Sprintf("hash-%s", bo.Hash)
 	observer.BlockOperationObserver.Trigger(event, bo)
 

--- a/lib/block_transaction.go
+++ b/lib/block_transaction.go
@@ -161,7 +161,9 @@ func (bt *BlockTransaction) Save(st *sebakstorage.LevelDBBackend) (err error) {
 		}
 	}
 	event := "saved"
+	event += " " + "bt-saved"
 	event += " " + fmt.Sprintf("source-%s", bt.Source)
+	event += " " + fmt.Sprintf("bt-source-%s", bt.Source)
 	event += " " + fmt.Sprintf("hash-%s", bt.Hash)
 	observer.BlockTransactionObserver.Trigger(event, bt)
 	bt.isSaved = true

--- a/lib/httputils/httputils.go
+++ b/lib/httputils/httputils.go
@@ -1,0 +1,11 @@
+package httputils
+
+import "net/http"
+
+func IsEventStream(r *http.Request) bool {
+	if r.Header.Get("Accept") == "text/event-stream" {
+		return true
+
+	}
+	return false
+}

--- a/lib/httputils/httputils.go
+++ b/lib/httputils/httputils.go
@@ -2,6 +2,7 @@ package httputils
 
 import "net/http"
 
+// IsEventStream checks request header accept is text/event-stream
 func IsEventStream(r *http.Request) bool {
 	if r.Header.Get("Accept") == "text/event-stream" {
 		return true

--- a/lib/httputils/json.go
+++ b/lib/httputils/json.go
@@ -1,0 +1,42 @@
+package httputils
+
+import (
+	"encoding/json"
+	"net/http"
+
+	common "boscoin.io/sebak/lib/common"
+)
+
+func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
+	w.Header().Set("content-type", "application/json")
+	w.WriteHeader(code)
+
+	if s, ok := v.(common.Serializable); ok {
+		return writeSerializable(w, s)
+	}
+
+	bs, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	if _, err := w.Write(bs); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeSerializable(w http.ResponseWriter, s common.Serializable) error {
+
+	bs, err := s.Serialize()
+	if err != nil {
+		return err
+	}
+
+	if _, err := w.Write(bs); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lib/httputils/json.go
+++ b/lib/httputils/json.go
@@ -3,33 +3,14 @@ package httputils
 import (
 	"encoding/json"
 	"net/http"
-
-	common "boscoin.io/sebak/lib/common"
 )
 
+// WriteJSON writes the value v to the http response as json encoding
 func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
 	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(code)
 
-	if s, ok := v.(common.Serializable); ok {
-		return writeSerializable(w, s)
-	}
-
 	bs, err := json.Marshal(v)
-	if err != nil {
-		return err
-	}
-
-	if _, err := w.Write(bs); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func writeSerializable(w http.ResponseWriter, s common.Serializable) error {
-
-	bs, err := s.Serialize()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Related  #286  
Closes  #299 
Fix #310

### Background

Using EventStream in APIHandlers
For writing a response, add `httputils` pkg. For now, this pkg has a little funcs for HTTP handling
```
   +IsEventStream(r *http.Request) : bool
   +WriteJSON(w http.ResponseWriter, code int, v interface{}) : error
```


### Solution

```
    if httputils.IsEventStream(r) {
        event := fmt.Sprintf("address-%s", address)
        es := NewDefaultEventStream(w, r)
        es.Render(blk)
        es.Run(observer.BlockAccountObserver, event)
        return
    }

    if err := httputils.WriteJSON(w, 200, blk); err != nil {
        http.Error(w, "Error reading request body", http.StatusInternalServerError)
    }
```

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

- We will consider with #118, #19 and this PR 
