### PR TITLE
Page support

### DIFF
--- a/lib/block/account_test.go
+++ b/lib/block/account_test.go
@@ -53,9 +53,9 @@ func TestSortMultipleBlockAccount(t *testing.T) {
 	}
 
 	var saved []string
-	iterFunc, closeFunc := GetBlockAccountAddressesByCreated(st, false)
+	iterFunc, closeFunc := GetBlockAccountAddressesByCreated(st, nil)
 	for {
-		address, hasNext := iterFunc()
+		address, hasNext, _ := iterFunc()
 		if !hasNext {
 			break
 		}
@@ -81,9 +81,9 @@ func TestGetSortedBlockAccounts(t *testing.T) {
 	}
 
 	var saved []string
-	iterFunc, closeFunc := GetBlockAccountsByCreated(st, false)
+	iterFunc, closeFunc := GetBlockAccountsByCreated(st, nil)
 	for {
-		ba, hasNext := iterFunc()
+		ba, hasNext, _ := iterFunc()
 		if !hasNext {
 			break
 		}
@@ -113,9 +113,9 @@ func TestBlockAccountSaveBlockAccountSequenceIDs(t *testing.T) {
 	}
 
 	var fetched []BlockAccountSequenceID
-	iterFunc, closeFunc := GetBlockAccountSequenceIDByAddress(st, b.Address, false)
+	iterFunc, closeFunc := GetBlockAccountSequenceIDByAddress(st, b.Address, &storage.IteratorOptions{Reverse: false})
 	for {
-		bac, hasNext := iterFunc()
+		bac, hasNext, _ := iterFunc()
 		if !hasNext {
 			break
 		}

--- a/lib/block/ballot.go
+++ b/lib/block/ballot.go
@@ -264,7 +264,7 @@ func FinishBallot(st *storage.LevelDBBackend, ballot Ballot, transactionPool *tr
 		tx := transactions[hash]
 		raw, _ := json.Marshal(tx)
 
-		bt := NewBlockTransactionFromTransaction(blk.Hash, tx, raw)
+		bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, tx, raw)
 		if err = bt.Save(ts); err != nil {
 			ts.Discard()
 			return

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -15,7 +15,7 @@ func TestNewBlockOperationFromOperation(t *testing.T) {
 	_, tx := transaction.TestMakeTransaction(networkID, 1)
 
 	op := tx.B.Operations[0]
-	bo := NewBlockOperationFromOperation(op, tx)
+	bo := NewBlockOperationFromOperation(op, tx, 0)
 
 	require.Equal(t, bo.Type, op.H.Type)
 	require.Equal(t, bo.TxHash, tx.H.Hash)
@@ -79,9 +79,9 @@ func TestGetSortedBlockOperationsByTxHash(t *testing.T) {
 
 	for _, txHash := range txHashes {
 		var saved []BlockOperation
-		iterFunc, closeFunc := GetBlockOperationsByTxHash(st, txHash, false)
+		iterFunc, closeFunc := GetBlockOperationsByTxHash(st, txHash, nil)
 		for {
-			bo, hasNext := iterFunc()
+			bo, hasNext, _ := iterFunc()
 			if !hasNext {
 				break
 			}
@@ -101,14 +101,14 @@ func TestBlockOperationSaveByTransacton(t *testing.T) {
 
 	_, tx := transaction.TestMakeTransaction(networkID, 10)
 	block := TestMakeNewBlock([]string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, tx, common.MustJSONMarshal(tx))
+	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, common.MustJSONMarshal(tx))
 	err := bt.Save(st)
 	require.Nil(t, err)
 
 	var saved []BlockOperation
-	iterFunc, closeFunc := GetBlockOperationsByTxHash(st, tx.GetHash(), false)
+	iterFunc, closeFunc := GetBlockOperationsByTxHash(st, tx.GetHash(), nil)
 	for {
-		bo, hasNext := iterFunc()
+		bo, hasNext, _ := iterFunc()
 		if !hasNext {
 			break
 		}

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -58,7 +58,7 @@ func TestMakeNewBlockOperation(networkID []byte, n int) (bos []BlockOperation) {
 	_, tx := transaction.TestMakeTransaction(networkID, n)
 
 	for _, op := range tx.B.Operations {
-		bos = append(bos, NewBlockOperationFromOperation(op, tx))
+		bos = append(bos, NewBlockOperationFromOperation(op, tx, 0))
 	}
 
 	return
@@ -69,5 +69,5 @@ func TestMakeNewBlockTransaction(networkID []byte, n int) BlockTransaction {
 
 	block := TestMakeNewBlock([]string{tx.GetHash()})
 	a, _ := tx.Serialize()
-	return NewBlockTransactionFromTransaction(block.Hash, tx, a)
+	return NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 }

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -16,7 +16,7 @@ func TestNewBlockTransaction(t *testing.T) {
 	_, tx := transaction.TestMakeTransaction(networkID, 1)
 	a, _ := tx.Serialize()
 	block := TestMakeNewBlock([]string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, tx, a)
+	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 
 	require.Equal(t, bt.Hash, tx.H.Hash)
 	require.Equal(t, bt.SequenceID, tx.B.SequenceID)
@@ -93,7 +93,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -110,16 +110,16 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
 
 	{
 		var saved []BlockTransaction
-		iterFunc, closeFunc := GetBlockTransactionsBySource(st, kp.Address(), false)
+		iterFunc, closeFunc := GetBlockTransactionsBySource(st, kp.Address(), nil)
 		for {
-			bo, hasNext := iterFunc()
+			bo, hasNext, _ := iterFunc()
 			if !hasNext {
 				break
 			}
@@ -137,9 +137,9 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 	{
 		// reverse order
 		var saved []BlockTransaction
-		iterFunc, closeFunc := GetBlockTransactionsBySource(st, kp.Address(), true)
+		iterFunc, closeFunc := GetBlockTransactionsBySource(st, kp.Address(), &storage.IteratorOptions{Reverse: true})
 		for {
-			bo, hasNext := iterFunc()
+			bo, hasNext, _ := iterFunc()
 			if !hasNext {
 				break
 			}
@@ -176,15 +176,15 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
 
 	var saved []BlockTransaction
-	iterFunc, closeFunc := GetBlockTransactionsByConfirmed(st, false)
+	iterFunc, closeFunc := GetBlockTransactionsByConfirmed(st, nil)
 	for {
-		bo, hasNext := iterFunc()
+		bo, hasNext, _ := iterFunc()
 		if !hasNext {
 			break
 		}
@@ -201,9 +201,9 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 	{
 		// reverse order
 		var saved []BlockTransaction
-		iterFunc, closeFunc := GetBlockTransactionsByConfirmed(st, true)
+		iterFunc, closeFunc := GetBlockTransactionsByConfirmed(st, &storage.IteratorOptions{Reverse: true})
 		for {
-			bo, hasNext := iterFunc()
+			bo, hasNext, _ := iterFunc()
 			if !hasNext {
 				break
 			}
@@ -256,7 +256,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -274,7 +274,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -291,16 +291,16 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
 
 	{
 		var saved []BlockTransaction
-		iterFunc, closeFunc := GetBlockTransactionsByAccount(st, kp.Address(), false)
+		iterFunc, closeFunc := GetBlockTransactionsByAccount(st, kp.Address(), nil)
 		for {
-			bo, hasNext := iterFunc()
+			bo, hasNext, _ := iterFunc()
 			if !hasNext {
 				break
 			}
@@ -335,7 +335,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	block0 := TestMakeNewBlock(txHashes0)
 	for _, tx := range txs0 {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block0.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block0.Hash, block0.Height, tx, a)
 		require.Nil(t, bt.Save(st))
 	}
 
@@ -352,15 +352,15 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	block1 := TestMakeNewBlock(txHashes1)
 	for _, tx := range txs1 {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block1.Hash, tx, a)
+		bt := NewBlockTransactionFromTransaction(block1.Hash, block1.Height, tx, a)
 		require.Nil(t, bt.Save(st))
 	}
 
 	{
 		var saved []BlockTransaction
-		iterFunc, closeFunc := GetBlockTransactionsByBlock(st, block0.Hash, false)
+		iterFunc, closeFunc := GetBlockTransactionsByBlock(st, block0.Hash, nil)
 		for {
-			bo, hasNext := iterFunc()
+			bo, hasNext, _ := iterFunc()
 			if !hasNext {
 				break
 			}
@@ -377,9 +377,9 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 
 	{
 		var saved []BlockTransaction
-		iterFunc, closeFunc := GetBlockTransactionsByBlock(st, block1.Hash, false)
+		iterFunc, closeFunc := GetBlockTransactionsByBlock(st, block1.Hash, nil)
 		for {
-			bo, hasNext := iterFunc()
+			bo, hasNext, _ := iterFunc()
 			if !hasNext {
 				break
 			}
@@ -393,4 +393,111 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 			require.Equal(t, bt.Hash, createdOrder1[i], "order mismatch")
 		}
 	}
+}
+
+func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
+	kp, _ := keypair.Random()
+	st, _ := storage.NewTestMemoryLevelDBBackend()
+
+	numTxs := 5
+
+	// To check iteration order by height
+	var transactionOrder []string
+
+	// Make transactions with height 2 first
+	{
+		var createdOrder []string
+		txs := []transaction.Transaction{}
+		txHashes := []string{}
+		for i := 0; i < numTxs; i++ {
+			tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+			txs = append(txs, tx)
+			createdOrder = append(createdOrder, tx.GetHash())
+			txHashes = append(txHashes, tx.GetHash())
+		}
+
+		block := TestMakeNewBlock(txHashes)
+		block.Height++
+		for _, tx := range txs {
+			a, _ := tx.Serialize()
+			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+			err := bt.Save(st)
+			require.Nil(t, err)
+		}
+		transactionOrder = append(transactionOrder, createdOrder...)
+		block.Save(st)
+	}
+
+	// Make transactions with height 1
+	{
+		var createdOrder []string
+		txs := []transaction.Transaction{}
+		txHashes := []string{}
+		for i := 0; i < numTxs; i++ {
+			tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+			txs = append(txs, tx)
+			createdOrder = append(createdOrder, tx.GetHash())
+			txHashes = append(txHashes, tx.GetHash())
+		}
+
+		block := TestMakeNewBlock(txHashes)
+		for _, tx := range txs {
+			a, _ := tx.Serialize()
+			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+			err := bt.Save(st)
+			require.Nil(t, err)
+		}
+
+		transactionOrder = append(createdOrder, transactionOrder...)
+		block.Save(st)
+	}
+
+	var halfSaved []BlockTransaction
+	var theCursor []byte
+	// Check transaction order by block height
+	{
+		var saved []BlockTransaction
+		var cursors [][]byte
+		iterFunc, closeFunc := GetBlockTransactionsByAccount(st, kp.Address(), nil)
+		for {
+			bo, hasNext, cursor := iterFunc()
+			if !hasNext {
+				break
+			}
+			cc := make([]byte, len(cursor))
+			copy(cc, cursor)
+			cursors = append(cursors, cc)
+			saved = append(saved, bo)
+		}
+		closeFunc()
+
+		require.Equal(t, len(saved), len(transactionOrder))
+		for i, bt := range saved {
+			require.Equal(t, bt.Hash, transactionOrder[i])
+		}
+
+		halfSaved = saved[len(saved)/2:]
+		theCursor = cursors[len(saved)/2]
+	}
+
+	// Check transactions filtered by cursor
+	{
+		var saved []BlockTransaction
+		iterFunc, closeFunc := GetBlockTransactionsByAccount(st, kp.Address(), &storage.IteratorOptions{Reverse: false, Cursor: theCursor})
+		for {
+			bo, hasNext, _ := iterFunc()
+			if !hasNext {
+				break
+			}
+
+			saved = append(saved, bo)
+		}
+		closeFunc()
+
+		require.Equal(t, len(halfSaved), len(saved))
+		for i, bt := range saved {
+			require.Equal(t, bt.Hash, halfSaved[i].Hash)
+		}
+	}
+
 }

--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -9,9 +9,12 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"encoding/binary"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stellar/go/keypair"
 )
+
+const MaxUintEncodeByte = 8
 
 func GetUniqueIDFromUUID() string {
 	return uuid.Must(uuid.NewV1(), nil).String()
@@ -163,4 +166,10 @@ func IsStringMapEqualWithHash(a, b map[string]bool) bool {
 // MakeSignature makes signature from given hash string
 func MakeSignature(kp keypair.KP, networkID []byte, hash string) ([]byte, error) {
 	return kp.Sign(append(networkID, []byte(hash)...))
+}
+
+func EncodeUint64ToByteSlice(i uint64) [MaxUintEncodeByte]byte {
+	var b [MaxUintEncodeByte]byte
+	binary.BigEndian.PutUint64(b[:], i)
+	return b
 }

--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -24,8 +24,7 @@ type ISAAC struct {
 
 func NewISAAC(networkID []byte, node *node.LocalNode, votingThresholdPolicy common.VotingThresholdPolicy) (is *ISAAC, err error) {
 	is = &ISAAC{
-		NetworkID:             networkID,
-		Node:                  node,
+		NetworkID: networkID, Node: node,
 		VotingThresholdPolicy: votingThresholdPolicy,
 		TransactionPool:       transaction.NewTransactionPool(),
 		RunningRounds:         map[string]*RunningRound{},

--- a/lib/network/api/account.go
+++ b/lib/network/api/account.go
@@ -10,6 +10,7 @@ import (
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/network/httputils"
+	"boscoin.io/sebak/lib/storage"
 )
 
 func (api NetworkHandlerAPI) GetAccountHandler(w http.ResponseWriter, r *http.Request) {
@@ -49,9 +50,9 @@ func (api NetworkHandlerAPI) GetAccountTransactionsHandler(w http.ResponseWriter
 
 	readFunc := func(cnt int) []*block.BlockTransaction {
 		var txs []*block.BlockTransaction
-		iterFunc, closeFunc := block.GetBlockTransactionsByAccount(api.storage, address, false)
+		iterFunc, closeFunc := block.GetBlockTransactionsByAccount(api.storage, address, &storage.IteratorOptions{Reverse: false})
 		for {
-			t, hasNext := iterFunc()
+			t, hasNext, _ := iterFunc()
 			if !hasNext || cnt == 0 {
 				break
 			}
@@ -88,9 +89,9 @@ func (api NetworkHandlerAPI) GetAccountOperationsHandler(w http.ResponseWriter, 
 
 	readFunc := func(cnt int) []*block.BlockOperation {
 		var txs []*block.BlockOperation
-		iterFunc, closeFunc := block.GetBlockOperationsBySource(api.storage, address, false)
+		iterFunc, closeFunc := block.GetBlockOperationsBySource(api.storage, address, &storage.IteratorOptions{Reverse: false})
 		for {
-			t, hasNext := iterFunc()
+			t, hasNext, _ := iterFunc()
 			if !hasNext || cnt == 0 {
 				break
 			}

--- a/lib/network/api/api_test.go
+++ b/lib/network/api/api_test.go
@@ -156,7 +156,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	for _, tx := range txs {
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
 		err = bt.Save(storage)
 		require.Nil(t, err)
 		btmap[bt.Hash] = bt
@@ -183,7 +183,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 			if !assert.Nil(t, err) {
 				panic(err)
 			}
-			bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, tx, a)
+			bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
 			err = bt.Save(storage)
 			if !assert.Nil(t, err) {
 				panic(err)
@@ -223,6 +223,7 @@ func TestGetAccountTransactionsHandler(t *testing.T) {
 	require.Nil(t, err)
 	var receivedBts []block.BlockTransaction
 	json.Unmarshal(readByte, &receivedBts)
+	fmt.Println(receivedBts[0])
 
 	require.Equal(t, len(btmap), len(receivedBts), "length is not same")
 
@@ -260,7 +261,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 	for _, tx := range txs {
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
 		bt.Save(storage)
 
 		for _, boHash := range bt.Operations {
@@ -290,7 +291,7 @@ func TestGetAccountOperationsHandler(t *testing.T) {
 			if !assert.Nil(t, err) {
 				panic(err)
 			}
-			bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, tx, a)
+			bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
 			bt.Save(storage)
 
 			for _, boHash := range bt.Operations {
@@ -364,7 +365,7 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 	require.Nil(t, err)
 
 	theBlock := block.TestMakeNewBlock([]string{tx.GetHash()})
-	bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, tx, a)
+	bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
 
 	// Do a Request
 	url := ts.URL + fmt.Sprintf("/transactions/%s", bt.Hash)
@@ -431,7 +432,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 	for _, tx := range txs {
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
 		err = bt.Save(storage)
 		require.Nil(t, err)
 		btmap[bt.Hash] = bt
@@ -458,7 +459,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 			if !assert.Nil(t, err) {
 				panic(err)
 			}
-			bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, tx, a)
+			bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
 			err = bt.Save(storage)
 			if !assert.Nil(t, err) {
 				panic(err)

--- a/lib/network/api/resource_test.go
+++ b/lib/network/api/resource_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 	"github.com/stretchr/testify/require"
@@ -48,7 +49,7 @@ func TestAPIResourceAccount(t *testing.T) {
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction("dummy", tx, a)
+		bt := block.NewBlockTransactionFromTransaction("dummy", 0, tx, a)
 		bt.Save(storage)
 
 		rt := &APIResourceTransaction{
@@ -87,7 +88,7 @@ func TestAPIResourceAccount(t *testing.T) {
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction("dummy", tx, a)
+		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, tx, a)
 		bt.Save(storage)
 		bo, err := block.GetBlockOperation(storage, bt.Operations[0])
 
@@ -123,7 +124,7 @@ func TestAPIResourceAccount(t *testing.T) {
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 3)
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction("dummy", tx, a)
+		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, tx, a)
 		bt.Save(storage)
 
 		var rol []APIResource

--- a/lib/network/api/transaction.go
+++ b/lib/network/api/transaction.go
@@ -7,6 +7,7 @@ import (
 	"boscoin.io/sebak/lib/network/httputils"
 
 	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/storage"
 	"github.com/gorilla/mux"
 )
 
@@ -14,9 +15,9 @@ func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *ht
 
 	readFunc := func(cnt int) []*block.BlockTransaction {
 		var txs []*block.BlockTransaction
-		iterFunc, closeFunc := block.GetBlockTransactions(api.storage, false)
+		iterFunc, closeFunc := block.GetBlockTransactions(api.storage, &storage.IteratorOptions{Reverse: false})
 		for {
-			t, hasNext := iterFunc()
+			t, hasNext, _ := iterFunc()
 			if !hasNext || cnt == 0 {
 				break
 			}

--- a/lib/storage/statedb.go
+++ b/lib/storage/statedb.go
@@ -47,7 +47,7 @@ func (s *StateDB) Remove(k string) error {
 }
 
 func (s *StateDB) GetIterator(prefix string, reverse bool) (func() (IterItem, bool), func()) {
-	return s.levelDB.GetIterator(prefix, reverse)
+	return s.levelDB.GetIterator(prefix, &IteratorOptions{Reverse: reverse})
 }
 
 func (s *StateDB) News(vs ...Item) error {

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -13,7 +13,7 @@ var SupportedStorageType []string = []string{
 }
 
 type IterItem struct {
-	N     int64
+	N     uint64
 	Key   []byte
 	Value []byte
 }


### PR DESCRIPTION
### Github Issue
#122 

### Background
For the client API pagination needed to be supported
To implement this feature, cursor and limit required

### Solution

* iterator 

IteratorOptions struct is newly introduced
```
type IteratorOptions struct {
	Reverse bool
	Cursor  []byte
	Limit   uint64
}
```
The GetIterator function get the IteratorOptions as argument
```func (st *LevelDBBackend) GetIterator(prefix string, option *IteratorOptions) (func() (IterItem, bool), func())```

The wrapping function for each model is changed like this

first returned function (next function) return one more value which denote the key
the key can be used for cursor
```
func LoadBlockTransactionsInsideIterator(
	st *sebakstorage.LevelDBBackend,
	iterFunc func() (sebakstorage.IterItem, bool),
	closeFunc func(),
) (
	func() (BlockTransaction, bool, []byte),
	func(),
) 
```

* reverse index key management

The reverse index for transactions, blocks, and operations is like this
{key_prefix}-{index_item}-{block_height}-{sequence_id}-{uuid}

Hence, the ordering follows this priority

block height
sequence number
created time
All of the nodes have the same order of block height and sequence number
And created time may diverse

Consequently, the cursor can be used for any nodes when the cursor consists block height and sequence number.


### Possible Drawbacks
reverse index key may too long