### PR TITLE
Merging HTTP Logs(Combined and Error) To Log15

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -113,14 +113,6 @@
   version = "v1.1.1"
 
 [[projects]]
-  digest = "1:fe47be2bd5d0196679d314fcc6e02f40a51e641c09e1541528a05cccefee9b0e"
-  name = "github.com/gorilla/handlers"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "90663712d74cb411cbef281bc1e08c19d1a76145"
-  version = "v1.3.0"
-
-[[projects]]
   digest = "1:bf5cf1d53d703332e9bd8984c69784645b73a938317bf5ace9aadf20ac49379a"
   name = "github.com/gorilla/mux"
   packages = ["."]
@@ -186,6 +178,14 @@
   packages = ["xdr3"]
   pruneopts = "NT"
   revision = "a875e7c9fa2388ce03279f6b5ba1c2ccd1f9e917"
+
+[[projects]]
+  digest = "1:1164c67de2421e9be8aa047865ca55f4269b8ca98b9b45843b6f5b6b0cc29c2d"
+  name = "github.com/nvellon/hal"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "d5526dbaf6448b3cac35d44a2fb5c2ddb0081437"
+  version = "v0.3.0"
 
 [[projects]]
   digest = "1:3b517122f3aad1ecce45a630ea912b3092b4729f25532a911d0cb2935a1f9352"
@@ -413,16 +413,15 @@
     "github.com/ethereum/go-ethereum/rlp",
     "github.com/ethereum/go-ethereum/trie",
     "github.com/google/uuid",
-    "github.com/gorilla/handlers",
     "github.com/gorilla/mux",
     "github.com/inconshreveable/log15",
-    "github.com/magiconair/properties/assert",
+    "github.com/nvellon/hal",
     "github.com/oklog/run",
-    "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/satori/go.uuid",
     "github.com/spf13/cobra",
     "github.com/stellar/go/keypair",
+    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/syndtr/goleveldb/leveldb",
     "github.com/syndtr/goleveldb/leveldb/iterator",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,14 +22,6 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:c819830f4f5ef85874a90ac3cbcc96cd322c715f5c96fbe4722eacd3dafbaa07"
-  name = "github.com/beorn7/perks"
-  packages = ["quantile"]
-  pruneopts = "NT"
-  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
-
-[[projects]]
-  branch = "master"
   digest = "1:cf6f658c1797ec82080e933d055e47abde46b595f60f8ef87586fb73df6b2e75"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
@@ -79,14 +71,6 @@
   pruneopts = "NT"
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
-
-[[projects]]
-  digest = "1:d7cb4458ea8782e6efacd8f4940796ec559c90833509c436f40c4085b98156dd"
-  name = "github.com/golang/protobuf"
-  packages = ["proto"]
-  pruneopts = "NT"
-  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
-  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -172,20 +156,20 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:ea1db000388d88b31db7531c83016bef0d6db0d908a07794bfc36aca16fbf935"
-  name = "github.com/matttproud/golang_protobuf_extensions"
-  packages = ["pbutil"]
-  pruneopts = "NT"
-  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
-  version = "v1.0.1"
-
-[[projects]]
   branch = "master"
   digest = "1:9dc2f88f4fb4757aeca31aad614951f2c54ae416543a277e664c509b5c4c433a"
   name = "github.com/nullstyle/go-xdr"
   packages = ["xdr3"]
   pruneopts = "NT"
   revision = "a875e7c9fa2388ce03279f6b5ba1c2ccd1f9e917"
+
+[[projects]]
+  digest = "1:1164c67de2421e9be8aa047865ca55f4269b8ca98b9b45843b6f5b6b0cc29c2d"
+  name = "github.com/nvellon/hal"
+  packages = ["."]
+  pruneopts = "NT"
+  revision = "d5526dbaf6448b3cac35d44a2fb5c2ddb0081437"
+  version = "v0.3.0"
 
 [[projects]]
   digest = "1:3b517122f3aad1ecce45a630ea912b3092b4729f25532a911d0cb2935a1f9352"
@@ -210,50 +194,6 @@
   pruneopts = "NT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
-
-[[projects]]
-  digest = "1:a22debd993d18b9203c985810f33f52e7583724800ee8d15e7d362e7175639d1"
-  name = "github.com/prometheus/client_golang"
-  packages = [
-    "prometheus",
-    "prometheus/promhttp",
-  ]
-  pruneopts = "NT"
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
-
-[[projects]]
-  branch = "master"
-  digest = "1:c2cc5049e927e2749c0d5163c9f8d924880d83e84befa732b9aad0b6be227bed"
-  name = "github.com/prometheus/client_model"
-  packages = ["go"]
-  pruneopts = "NT"
-  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
-
-[[projects]]
-  branch = "master"
-  digest = "1:fa652fffdb9a8a025500345a0e1472db5b3c07a8b20f33a3ae2c13f59d6f29d4"
-  name = "github.com/prometheus/common"
-  packages = [
-    "expfmt",
-    "internal/bitbucket.org/ww/goautoneg",
-    "model",
-  ]
-  pruneopts = "NT"
-  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
-
-[[projects]]
-  branch = "master"
-  digest = "1:3c54832e04d11b79309415c5da9a5d85940ea367c1693ae0aebf26b0ee405ca1"
-  name = "github.com/prometheus/procfs"
-  packages = [
-    ".",
-    "internal/util",
-    "nfs",
-    "xfs",
-  ]
-  pruneopts = "NT"
-  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
   digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
@@ -416,12 +356,13 @@
     "github.com/gorilla/handlers",
     "github.com/gorilla/mux",
     "github.com/inconshreveable/log15",
-    "github.com/magiconair/properties/assert",
+    "github.com/nvellon/hal",
     "github.com/oklog/run",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/satori/go.uuid",
     "github.com/spf13/cobra",
     "github.com/stellar/go/keypair",
+    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/syndtr/goleveldb/leveldb",
     "github.com/syndtr/goleveldb/leveldb/iterator",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,6 +22,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:c819830f4f5ef85874a90ac3cbcc96cd322c715f5c96fbe4722eacd3dafbaa07"
+  name = "github.com/beorn7/perks"
+  packages = ["quantile"]
+  pruneopts = "NT"
+  revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
+
+[[projects]]
+  branch = "master"
   digest = "1:cf6f658c1797ec82080e933d055e47abde46b595f60f8ef87586fb73df6b2e75"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
@@ -71,6 +79,14 @@
   pruneopts = "NT"
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
+
+[[projects]]
+  digest = "1:d7cb4458ea8782e6efacd8f4940796ec559c90833509c436f40c4085b98156dd"
+  name = "github.com/golang/protobuf"
+  packages = ["proto"]
+  pruneopts = "NT"
+  revision = "aa810b61a9c79d51363740d207bb46cf8e620ed5"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -156,20 +172,20 @@
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:ea1db000388d88b31db7531c83016bef0d6db0d908a07794bfc36aca16fbf935"
+  name = "github.com/matttproud/golang_protobuf_extensions"
+  packages = ["pbutil"]
+  pruneopts = "NT"
+  revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:9dc2f88f4fb4757aeca31aad614951f2c54ae416543a277e664c509b5c4c433a"
   name = "github.com/nullstyle/go-xdr"
   packages = ["xdr3"]
   pruneopts = "NT"
   revision = "a875e7c9fa2388ce03279f6b5ba1c2ccd1f9e917"
-
-[[projects]]
-  digest = "1:1164c67de2421e9be8aa047865ca55f4269b8ca98b9b45843b6f5b6b0cc29c2d"
-  name = "github.com/nvellon/hal"
-  packages = ["."]
-  pruneopts = "NT"
-  revision = "d5526dbaf6448b3cac35d44a2fb5c2ddb0081437"
-  version = "v0.3.0"
 
 [[projects]]
   digest = "1:3b517122f3aad1ecce45a630ea912b3092b4729f25532a911d0cb2935a1f9352"
@@ -194,6 +210,50 @@
   pruneopts = "NT"
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
+
+[[projects]]
+  digest = "1:a22debd993d18b9203c985810f33f52e7583724800ee8d15e7d362e7175639d1"
+  name = "github.com/prometheus/client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = "NT"
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:c2cc5049e927e2749c0d5163c9f8d924880d83e84befa732b9aad0b6be227bed"
+  name = "github.com/prometheus/client_model"
+  packages = ["go"]
+  pruneopts = "NT"
+  revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
+
+[[projects]]
+  branch = "master"
+  digest = "1:fa652fffdb9a8a025500345a0e1472db5b3c07a8b20f33a3ae2c13f59d6f29d4"
+  name = "github.com/prometheus/common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = "NT"
+  revision = "c7de2306084e37d54b8be01f3541a8464345e9a5"
+
+[[projects]]
+  branch = "master"
+  digest = "1:3c54832e04d11b79309415c5da9a5d85940ea367c1693ae0aebf26b0ee405ca1"
+  name = "github.com/prometheus/procfs"
+  packages = [
+    ".",
+    "internal/util",
+    "nfs",
+    "xfs",
+  ]
+  pruneopts = "NT"
+  revision = "05ee40e3a273f7245e8777337fc7b46e533a9a92"
 
 [[projects]]
   digest = "1:6bc0652ea6e39e22ccd522458b8bdd8665bf23bdc5a20eec90056e4dc7e273ca"
@@ -356,13 +416,13 @@
     "github.com/gorilla/handlers",
     "github.com/gorilla/mux",
     "github.com/inconshreveable/log15",
-    "github.com/nvellon/hal",
+    "github.com/magiconair/properties/assert",
     "github.com/oklog/run",
+    "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/satori/go.uuid",
     "github.com/spf13/cobra",
     "github.com/stellar/go/keypair",
-    "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "github.com/syndtr/goleveldb/leveldb",
     "github.com/syndtr/goleveldb/leveldb/iterator",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,3 @@
 [[constraint]]
   name = "gopkg.in/yaml.v2"
   version = "2.2.1"
-
-[[constraint]]
-  name = "github.com/prometheus/client_golang"
-  version = "0.8.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,3 +53,7 @@
 [[constraint]]
   name = "gopkg.in/yaml.v2"
   version = "2.2.1"
+
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "0.8.0"

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -330,7 +330,7 @@ func runNode() error {
 	localNode.AddValidators(validators...)
 
 	// create network
-	networkConfig, err := network.NewHTTP2NetworkConfigFromEndpoint(localNode, nodeEndpoint)
+	networkConfig, err := network.NewHTTP2NetworkConfigFromEndpoint(localNode.Alias(), nodeEndpoint)
 	if err != nil {
 		log.Crit("failed to create network", "error", err)
 		return err

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -40,8 +40,6 @@ var (
 	flagLogLevel       string = common.GetENVValue("SEBAK_LOG_LEVEL", defaultLogLevel.String())
 	flagLogFormat      string = common.GetENVValue("SEBAK_LOG_FORMAT", defaultLogFormat)
 	flagLog            string = common.GetENVValue("SEBAK_LOG", "")
-	flagHTTPLog        string = common.GetENVValue("SEBAK_HTTP_LOG", "")
-	flagHTTPError      string = common.GetENVValue("SEBAK_HTTP_ERROR_LOG", "")
 	flagVerbose        bool   = common.GetENVValue("SEBAK_VERBOSE", "0") == "1"
 	flagEndpointString string = common.GetENVValue(
 		"SEBAK_ENDPOINT",
@@ -131,8 +129,6 @@ func init() {
 	nodeCmd.Flags().StringVar(&flagLogLevel, "log-level", flagLogLevel, "log level, {crit, error, warn, info, debug}")
 	nodeCmd.Flags().StringVar(&flagLogFormat, "log-format", flagLogFormat, "log format, {terminal, json}")
 	nodeCmd.Flags().StringVar(&flagLog, "log", flagLog, "set log file")
-	nodeCmd.Flags().StringVar(&flagHTTPLog, "http-log", flagHTTPLog, "set http log file")
-	nodeCmd.Flags().StringVar(&flagHTTPError, "http-error-log", flagHTTPError, "set http error log file")
 	nodeCmd.Flags().BoolVar(&flagVerbose, "verbose", flagVerbose, "verbose")
 	nodeCmd.Flags().StringVar(&flagEndpointString, "endpoint", flagEndpointString, "endpoint uri to listen on")
 	nodeCmd.Flags().StringVar(&flagStorageConfigString, "storage", flagStorageConfigString, "storage uri")
@@ -207,7 +203,6 @@ func parseFlagsNode() {
 	queries.Add("TLSCertFile", flagTLSCertFile)
 	queries.Add("TLSKeyFile", flagTLSKeyFile)
 	queries.Add("IdleTimeout", "3s")
-	queries.Add("NodeName", node.MakeAlias(kp.Address()))
 	nodeEndpoint.RawQuery = queries.Encode()
 
 	if validators, err = parseFlagValidators(flagValidators); err != nil {
@@ -281,8 +276,6 @@ func parseFlagsNode() {
 	parsedFlags = append(parsedFlags, "\n\tlog-level", flagLogLevel)
 	parsedFlags = append(parsedFlags, "\n\tlog-format", flagLogFormat)
 	parsedFlags = append(parsedFlags, "\n\tlog", flagLog)
-	parsedFlags = append(parsedFlags, "\n\thttp-log", flagHTTPLog)
-	parsedFlags = append(parsedFlags, "\n\thttp-error-log", flagHTTPError)
 	parsedFlags = append(parsedFlags, "\n\tthreshold", flagThreshold)
 	parsedFlags = append(parsedFlags, "\n\ttimeout-init", flagTimeoutINIT)
 	parsedFlags = append(parsedFlags, "\n\ttimeout-sign", flagTimeoutSIGN)
@@ -333,14 +326,6 @@ func runNode() error {
 	networkConfig, err := network.NewHTTP2NetworkConfigFromEndpoint(localNode.Alias(), nodeEndpoint)
 	if err != nil {
 		log.Crit("failed to create network", "error", err)
-		return err
-	}
-	if err := networkConfig.SetLog(flagHTTPLog); err != nil {
-		log.Crit("failed to set `http-log`", "error", err)
-		return err
-	}
-	if err := networkConfig.SetErrorLog(flagHTTPError); err != nil {
-		log.Crit("failed to set `http-error-log`", "error", err)
 		return err
 	}
 

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -330,7 +330,7 @@ func runNode() error {
 	localNode.AddValidators(validators...)
 
 	// create network
-	networkConfig, err := network.NewHTTP2NetworkConfigFromEndpoint(nodeEndpoint)
+	networkConfig, err := network.NewHTTP2NetworkConfigFromEndpoint(localNode, nodeEndpoint)
 	if err != nil {
 		log.Crit("failed to create network", "error", err)
 		return err

--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -92,7 +92,7 @@ func NewHTTP2Network(config *HTTP2NetworkConfig) (h2n *HTTP2Network) {
 		tlsCertFile:    config.TLSCertFile,
 		tlsKeyFile:     config.TLSKeyFile,
 		receiveChannel: make(chan common.NetworkMessage),
-		log:            log.New(logging.Ctx{"node": config.Node.Alias()}),
+		log:            log.New(logging.Ctx{"node": config.NodeName}),
 	}
 	h2n.handlers = map[string]func(http.ResponseWriter, *http.Request){}
 	h2n.routers = map[string]*mux.Router{
@@ -117,7 +117,7 @@ func (t *HTTP2Network) GetClient(endpoint *common.Endpoint) NetworkClient {
 	client := NewHTTP2NetworkClient(endpoint, rawClient)
 
 	headers := http.Header{}
-	headers.Set("User-Agent", fmt.Sprintf("v-%s", t.config.Node.Alias()))
+	headers.Set("User-Agent", fmt.Sprintf("v-%s", t.config.NodeName))
 	client.SetDefaultHeaders(headers)
 
 	return client

--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -8,11 +8,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	logging "github.com/inconshreveable/log15"
 	"golang.org/x/net/http2"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/node"
 )
 
 type Handlers map[string]func(http.ResponseWriter, *http.Request)
@@ -57,6 +58,8 @@ type HTTP2Network struct {
 	handlers map[string]func(http.ResponseWriter, *http.Request)
 
 	config *HTTP2NetworkConfig
+	node   *node.LocalNode
+	log    logging.Logger
 }
 
 type HandlerFunc func(w http.ResponseWriter, r *http.Request)
@@ -89,6 +92,7 @@ func NewHTTP2Network(config *HTTP2NetworkConfig) (h2n *HTTP2Network) {
 		tlsCertFile:    config.TLSCertFile,
 		tlsKeyFile:     config.TLSKeyFile,
 		receiveChannel: make(chan common.NetworkMessage),
+		log:            log.New(logging.Ctx{"node": config.Node.Alias()}),
 	}
 	h2n.handlers = map[string]func(http.ResponseWriter, *http.Request){}
 	h2n.routers = map[string]*mux.Router{
@@ -113,7 +117,7 @@ func (t *HTTP2Network) GetClient(endpoint *common.Endpoint) NetworkClient {
 	client := NewHTTP2NetworkClient(endpoint, rawClient)
 
 	headers := http.Header{}
-	headers.Set("User-Agent", fmt.Sprintf("v-%s", t.config.NodeName))
+	headers.Set("User-Agent", fmt.Sprintf("v-%s", t.config.Node.Alias()))
 	client.SetDefaultHeaders(headers)
 
 	return client
@@ -141,7 +145,7 @@ func (t *HTTP2Network) setNotReadyHandler() {
 		}
 	})
 
-	t.server.Handler = handlers.CombinedLoggingHandler(t.config.Log, t.router)
+	t.server.Handler = Log15LoggingHandler{log: t.log, handler: t.router}
 }
 
 func (t *HTTP2Network) AddHandler(pattern string, handler http.HandlerFunc) (router *mux.Route) {
@@ -173,7 +177,7 @@ func (t *HTTP2Network) MessageBroker() MessageBroker {
 }
 
 func (t *HTTP2Network) Ready() error {
-	t.server.Handler = handlers.CombinedLoggingHandler(t.config.Log, t.router)
+	t.server.Handler = Log15LoggingHandler{log: t.log, handler: t.router}
 
 	t.ready = true
 
@@ -218,4 +222,96 @@ func (t *HTTP2Network) ReceiveChannel() chan common.NetworkMessage {
 
 func (t *HTTP2Network) ReceiveMessage() <-chan common.NetworkMessage {
 	return t.receiveChannel
+}
+
+type Log15LoggingHandler struct {
+	log     logging.Logger
+	handler http.Handler
+}
+
+func (l Log15LoggingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	uid := common.GenerateUUID()
+
+	username := "-"
+	if r.URL.User != nil {
+		if name := r.URL.User.Username(); name != "" {
+			username = name
+		}
+	}
+
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+
+	uri := r.RequestURI
+
+	// Requests using the CONNECT method over HTTP/2.0 must use
+	// the authority field (aka r.Host) to identify the target.
+	// Refer: https://httpwg.github.io/specs/rfc7540.html#CONNECT
+	if r.ProtoMajor == 2 && r.Method == "CONNECT" {
+		uri = r.Host
+	}
+	if uri == "" {
+		uri = r.URL.RequestURI()
+	}
+
+	l.log.Debug(
+		"http-request",
+		"request-id", uid,
+		"referer", r.Referer(),
+		"user-agent", r.UserAgent(),
+		"method", r.Method,
+		"host", host,
+		"username", username,
+		"uri", uri,
+		"proto", r.Proto,
+		"remote", r.RemoteAddr,
+	)
+
+	writer := &Log15ResponseWriter{w: w}
+	l.handler.ServeHTTP(writer, r)
+
+	l.log.Debug(
+		"http-response",
+		"request-id", uid,
+		"status", writer.Status(),
+		"size", writer.Size(),
+	)
+}
+
+type Log15ResponseWriter struct {
+	w      http.ResponseWriter
+	status int
+	size   int
+}
+
+func (l *Log15ResponseWriter) Header() http.Header {
+	return l.w.Header()
+}
+
+func (l *Log15ResponseWriter) Write(b []byte) (int, error) {
+	size, err := l.w.Write(b)
+	l.size += size
+	return size, err
+}
+
+func (l *Log15ResponseWriter) WriteHeader(s int) {
+	l.w.WriteHeader(s)
+	l.status = s
+}
+
+func (l *Log15ResponseWriter) Status() int {
+	return l.status
+}
+
+func (l *Log15ResponseWriter) Size() int {
+	return l.size
+}
+
+func (l *Log15ResponseWriter) Flush() {
+	f, ok := l.w.(http.Flusher)
+	if ok {
+		f.Flush()
+	}
 }

--- a/lib/network/http2_config.go
+++ b/lib/network/http2_config.go
@@ -2,9 +2,6 @@ package network
 
 import (
 	"errors"
-	"io"
-	goLog "log"
-	"os"
 	"strings"
 	"time"
 
@@ -23,9 +20,6 @@ type HTTP2NetworkConfig struct {
 
 	TLSCertFile,
 	TLSKeyFile string
-
-	Log      io.Writer
-	ErrorLog *goLog.Logger
 }
 
 func NewHTTP2NetworkConfigFromEndpoint(nodeName string, endpoint *common.Endpoint) (config *HTTP2NetworkConfig, err error) {
@@ -88,8 +82,6 @@ func NewHTTP2NetworkConfigFromEndpoint(nodeName string, endpoint *common.Endpoin
 		TLSCertFile:       TLSCertFile,
 		TLSKeyFile:        TLSKeyFile,
 	}
-	config.SetLog("")
-	config.SetErrorLog("")
 
 	return
 }
@@ -100,34 +92,4 @@ func (config HTTP2NetworkConfig) IsHTTPS() bool {
 
 func (config HTTP2NetworkConfig) String() string {
 	return string(common.MustJSONMarshal(config))
-}
-
-func (config *HTTP2NetworkConfig) SetLog(v string) error {
-	if len(v) < 1 {
-		config.Log = os.Stdout
-		return nil
-	}
-
-	httpLog, err := os.OpenFile(v, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	config.Log = httpLog
-
-	return nil
-}
-
-func (config *HTTP2NetworkConfig) SetErrorLog(v string) (err error) {
-	var logFile *os.File
-	if len(v) < 1 {
-		logFile = os.Stdout
-	} else {
-		logFile, err = os.OpenFile(v, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-		if err != nil {
-			return
-		}
-	}
-	config.ErrorLog = goLog.New(logFile, "", goLog.LstdFlags|goLog.Lmicroseconds)
-
-	return nil
 }

--- a/lib/network/http2_config.go
+++ b/lib/network/http2_config.go
@@ -9,10 +9,11 @@ import (
 	"time"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/node"
 )
 
 type HTTP2NetworkConfig struct {
-	NodeName string
+	Node     *node.LocalNode
 	Endpoint *common.Endpoint
 	Addr     string
 
@@ -28,10 +29,9 @@ type HTTP2NetworkConfig struct {
 	ErrorLog *goLog.Logger
 }
 
-func NewHTTP2NetworkConfigFromEndpoint(endpoint *common.Endpoint) (config *HTTP2NetworkConfig, err error) {
+func NewHTTP2NetworkConfigFromEndpoint(node *node.LocalNode, endpoint *common.Endpoint) (config *HTTP2NetworkConfig, err error) {
 	query := endpoint.Query()
 
-	var NodeName string
 	var ReadTimeout time.Duration = 0
 	var ReadHeaderTimeout time.Duration = 0
 	var WriteTimeout time.Duration = 0
@@ -78,15 +78,8 @@ func NewHTTP2NetworkConfigFromEndpoint(endpoint *common.Endpoint) (config *HTTP2
 		return
 	}
 
-	if v := query.Get("NodeName"); len(v) < 1 {
-		err = errors.New("`NodeName` must be given")
-		return
-	} else {
-		NodeName = v
-	}
-
 	config = &HTTP2NetworkConfig{
-		NodeName:          NodeName,
+		Node:              node,
 		Endpoint:          endpoint,
 		Addr:              endpoint.Host,
 		ReadTimeout:       ReadTimeout,

--- a/lib/network/http2_config.go
+++ b/lib/network/http2_config.go
@@ -9,11 +9,10 @@ import (
 	"time"
 
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/node"
 )
 
 type HTTP2NetworkConfig struct {
-	Node     *node.LocalNode
+	NodeName string
 	Endpoint *common.Endpoint
 	Addr     string
 
@@ -29,7 +28,7 @@ type HTTP2NetworkConfig struct {
 	ErrorLog *goLog.Logger
 }
 
-func NewHTTP2NetworkConfigFromEndpoint(node *node.LocalNode, endpoint *common.Endpoint) (config *HTTP2NetworkConfig, err error) {
+func NewHTTP2NetworkConfigFromEndpoint(nodeName string, endpoint *common.Endpoint) (config *HTTP2NetworkConfig, err error) {
 	query := endpoint.Query()
 
 	var ReadTimeout time.Duration = 0
@@ -79,7 +78,7 @@ func NewHTTP2NetworkConfigFromEndpoint(node *node.LocalNode, endpoint *common.En
 	}
 
 	config = &HTTP2NetworkConfig{
-		Node:              node,
+		NodeName:          nodeName,
 		Endpoint:          endpoint,
 		Addr:              endpoint.Host,
 		ReadTimeout:       ReadTimeout,

--- a/lib/network/http2_config_test.go
+++ b/lib/network/http2_config_test.go
@@ -11,9 +11,9 @@ import (
 )
 
 func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
+	var nodeName string = "showme"
 	{ // HTTPS + TLSCertFile + TLSKeyFile
 		queryValues := url.Values{}
-		queryValues.Set("NodeName", "showme")
 		queryValues.Set("TLSCertFile", "faketlscert")
 		queryValues.Set("TLSKeyFile", "faketlskey")
 
@@ -23,7 +23,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
 		require.Nil(t, err)
 	}
 
@@ -37,7 +37,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
 		require.NotNil(t, err)
 	}
 
@@ -51,7 +51,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
 		require.NotNil(t, err)
 	}
 
@@ -66,7 +66,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
 		require.Nil(t, err)
 	}
 }

--- a/lib/network/http2_config_test.go
+++ b/lib/network/http2_config_test.go
@@ -23,13 +23,12 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
 		require.Nil(t, err)
 	}
 
 	{ // HTTPS + TLSCertFile
 		queryValues := url.Values{}
-		queryValues.Set("NodeName", "showme")
 		queryValues.Set("TLSCertFile", "faketlscert")
 
 		endpoint := &common.Endpoint{
@@ -38,13 +37,12 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
 		require.NotNil(t, err)
 	}
 
 	{ // HTTPS + TLSKeyFile
 		queryValues := url.Values{}
-		queryValues.Set("NodeName", "showme")
 		queryValues.Set("TLSKeyFile", "faketlskey")
 
 		endpoint := &common.Endpoint{
@@ -53,13 +51,12 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
 		require.NotNil(t, err)
 	}
 
 	{ // HTTP
 		queryValues := url.Values{}
-		queryValues.Set("NodeName", "showme")
 		queryValues.Set("TLSCertFile", "faketlscert")
 		queryValues.Set("TLSKeyFile", "faketlskey")
 
@@ -69,7 +66,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 			RawQuery: queryValues.Encode(),
 		}
 
-		_, err := NewHTTP2NetworkConfigFromEndpoint(endpoint)
+		_, err := NewHTTP2NetworkConfigFromEndpoint(nil, endpoint)
 		require.Nil(t, err)
 	}
 }

--- a/lib/network/http2_network_log.go
+++ b/lib/network/http2_network_log.go
@@ -88,6 +88,7 @@ func (l HTTP2Log15Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	l.log.Debug(
+		"request",
 		"content-length", r.Header.Get("Content-Type"),
 		"content-type", r.ContentLength,
 		"headers", header,
@@ -97,7 +98,6 @@ func (l HTTP2Log15Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"proto", r.Proto,
 		"referer", r.Referer(),
 		"remote", r.RemoteAddr,
-		"request",
 		"uri", uri,
 		"user-agent", r.UserAgent(),
 	)

--- a/lib/network/http2_network_log.go
+++ b/lib/network/http2_network_log.go
@@ -1,0 +1,114 @@
+package network
+
+import (
+	"net/http"
+
+	logging "github.com/inconshreveable/log15"
+
+	"boscoin.io/sebak/lib/common"
+)
+
+type HTTP2ErrorLog15Writer struct {
+	l logging.Logger
+}
+
+func (w HTTP2ErrorLog15Writer) Write(b []byte) (int, error) {
+	w.l.Error("error", "error", string(b))
+	return 0, nil
+}
+
+type HTTP2ResponseLog15Writer struct {
+	w      http.ResponseWriter
+	status int
+	size   int
+}
+
+func (l *HTTP2ResponseLog15Writer) Header() http.Header {
+	return l.w.Header()
+}
+
+func (l *HTTP2ResponseLog15Writer) Write(b []byte) (int, error) {
+	size, err := l.w.Write(b)
+	l.size += size
+	return size, err
+}
+
+func (l *HTTP2ResponseLog15Writer) WriteHeader(s int) {
+	l.w.WriteHeader(s)
+	l.status = s
+}
+
+func (l *HTTP2ResponseLog15Writer) Status() int {
+	return l.status
+}
+
+func (l *HTTP2ResponseLog15Writer) Size() int {
+	return l.size
+}
+
+func (l *HTTP2ResponseLog15Writer) Flush() {
+	f, ok := l.w.(http.Flusher)
+	if ok {
+		f.Flush()
+	}
+}
+
+type HTTP2Log15Handler struct {
+	log     logging.Logger
+	handler http.Handler
+}
+
+var HeaderKeyFiltered []string = []string{
+	"Content-Length",
+	"Content-Type",
+	"Accept",
+	"Accept-Encoding",
+	"User-Agent",
+}
+
+// ServeHTTP will log in 2 phase, when request received and response sent. This
+// was derived from github.com/gorilla/handlers/handlers.go
+func (l HTTP2Log15Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	uid := common.GenerateUUID()
+
+	uri := r.RequestURI
+	if r.ProtoMajor == 2 && r.Method == "CONNECT" {
+		uri = r.Host
+	}
+	if uri == "" {
+		uri = r.URL.RequestURI()
+	}
+
+	header := http.Header{}
+	for key, value := range r.Header {
+		if _, found := common.InStringArray(HeaderKeyFiltered, key); found {
+			continue
+		}
+		header[key] = value
+	}
+
+	l.log.Debug(
+		"content-length", r.Header.Get("Content-Type"),
+		"content-type", r.ContentLength,
+		"headers", header,
+		"host", r.Host,
+		"id", uid,
+		"method", r.Method,
+		"proto", r.Proto,
+		"referer", r.Referer(),
+		"remote", r.RemoteAddr,
+		"request",
+		"uri", uri,
+		"user-agent", r.UserAgent(),
+	)
+
+	writer := &HTTP2ResponseLog15Writer{w: w}
+	l.handler.ServeHTTP(writer, r)
+
+	l.log.Debug(
+		"response",
+		"id", uid,
+		"status", writer.Status(),
+		"size", writer.Size(),
+	)
+}

--- a/lib/network/http2_test.go
+++ b/lib/network/http2_test.go
@@ -37,7 +37,7 @@ func getPort() string {
 
 func makeTestHTTP2NetworkForTLS(endpoint *common.Endpoint) (network *HTTP2Network, err error) {
 	var config *HTTP2NetworkConfig
-	if config, err = NewHTTP2NetworkConfigFromEndpoint(nil, endpoint); err != nil {
+	if config, err = NewHTTP2NetworkConfigFromEndpoint("showme", endpoint); err != nil {
 		return
 	}
 
@@ -82,7 +82,6 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 	require.NotNil(t, g)
 
 	queryValues := url.Values{}
-	queryValues.Set("NodeName", "showme")
 	queryValues.Set("TLSCertFile", g.GetCertPath())
 	queryValues.Set("TLSKeyFile", g.GetKeyPath())
 

--- a/lib/network/http2_test.go
+++ b/lib/network/http2_test.go
@@ -37,7 +37,7 @@ func getPort() string {
 
 func makeTestHTTP2NetworkForTLS(endpoint *common.Endpoint) (network *HTTP2Network, err error) {
 	var config *HTTP2NetworkConfig
-	if config, err = NewHTTP2NetworkConfigFromEndpoint(endpoint); err != nil {
+	if config, err = NewHTTP2NetworkConfigFromEndpoint(nil, endpoint); err != nil {
 		return
 	}
 
@@ -127,7 +127,7 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 // will be `HTTP` server, not `HTTPS`.
 func TestHTTP2NetworkWithoutTLS(t *testing.T) {
 	endpoint, err := common.NewEndpointFromString(
-		fmt.Sprintf("http://localhost:%s?NodeName=showme", getPort()),
+		fmt.Sprintf("http://localhost:%s", getPort()),
 	)
 	require.Nil(t, err)
 

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -73,20 +73,20 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, mn *network.HTTP2Net
 		return
 	}
 
+	kp, _ = keypair.Random()
+	localNode, _ := node.NewLocalNode(kp, endpoint, "")
+
 	queries := endpoint.Query()
 	queries.Add("TLSCertFile", g.GetCertPath())
 	queries.Add("TLSKeyFile", g.GetKeyPath())
 	endpoint.RawQuery = queries.Encode()
 
-	config, err = network.NewHTTP2NetworkConfigFromEndpoint(endpoint)
+	config, err = network.NewHTTP2NetworkConfigFromEndpoint(localNode, endpoint)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 	mn = network.NewHTTP2Network(config)
-
-	kp, _ = keypair.Random()
-	localNode, _ := node.NewLocalNode(kp, mn.Endpoint(), "")
 
 	p, _ := consensus.NewDefaultVotingThresholdPolicy(30, 30)
 	is, _ := consensus.NewISAAC(networkID, localNode, p)

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -81,7 +81,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, mn *network.HTTP2Net
 	queries.Add("TLSKeyFile", g.GetKeyPath())
 	endpoint.RawQuery = queries.Encode()
 
-	config, err = network.NewHTTP2NetworkConfigFromEndpoint(localNode, endpoint)
+	config, err = network.NewHTTP2NetworkConfigFromEndpoint(localNode.Alias(), endpoint)
 	if err != nil {
 		t.Error(err)
 		return

--- a/lib/node/runner/init_test.go
+++ b/lib/node/runner/init_test.go
@@ -3,9 +3,10 @@ package runner
 import (
 	logging "github.com/inconshreveable/log15"
 
+	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/test"
 )
 
 func init() {
-	SetLogging(logging.LvlDebug, test.LogHandler())
+	common.SetLogging(log, logging.LvlDebug, test.LogHandler())
 }

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -154,8 +154,6 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 		is, _ := consensus.NewISAAC(networkID, node, vth)
 		st, _ := storage.NewTestMemoryLevelDBBackend()
 		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node.Alias(), node.Endpoint())
-		networkConfig.SetLog("")
-		networkConfig.SetErrorLog("")
 		network := network.NewHTTP2Network(networkConfig)
 		nodeRunner, _ := NewNodeRunner(string(networkID), node, vth, network, is, st)
 

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -153,7 +153,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 		vth, _ := consensus.NewDefaultVotingThresholdPolicy(66, 66)
 		is, _ := consensus.NewISAAC(networkID, node, vth)
 		st, _ := storage.NewTestMemoryLevelDBBackend()
-		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node.Endpoint())
+		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node, node.Endpoint())
 		networkConfig.SetLog("")
 		networkConfig.SetErrorLog("")
 		network := network.NewHTTP2Network(networkConfig)

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -153,7 +153,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 		vth, _ := consensus.NewDefaultVotingThresholdPolicy(66, 66)
 		is, _ := consensus.NewISAAC(networkID, node, vth)
 		st, _ := storage.NewTestMemoryLevelDBBackend()
-		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node, node.Endpoint())
+		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node.Alias(), node.Endpoint())
 		networkConfig.SetLog("")
 		networkConfig.SetErrorLog("")
 		network := network.NewHTTP2Network(networkConfig)


### PR DESCRIPTION
### Github Issue

resolves #100 

### Background

The HTTP related logs, combined log and error log is separated from main log, which is 'log15'. @anarcher already suggested these logs would be merged into main log. With this, we can use http log and it's error log for analyzing logs.

> This PR is based on #345 , so you can simply verify the patch of this PR in https://github.com/spikeekips/sebak/compare/cleanup-log-messages...spikeekips:http-log-to-log15 .

### Solution

* Removed `--http-log` and `--http-error-log`
* `network.NewHTTP2NetworkConfigFromEndpoint` will get the node name as argument
* Removed `HTTP2NetworkConfig.SetLog()` and `HTTP2NetworkConfig.SetErrorLog()` 

Example of combined HTTP log:
```
{
    "content-length": "application/json",
    "content-type": 0,
    "headers": {},
    "host": "localhost:12345",
    "id": "31ad5230-efc6-4695-9d35-09ef61827aa2",
    "lvl": "dbug",
    "method": "GET",
    "module": "http",
    "msg": "request",
    "node": "GCPQ.7DUR",
    "proto": "HTTP/2.0",
    "referer": "",
    "remote": "127.0.0.1:49246",
    "t": "2018-09-10T14:28:51.674274602+09:00",
    "uri": "/node/",
    "user-agent": "Go-http-client/2.0"
}
```
Example of combined HTTP Error log:
```
{
    "error": "http: TLS handshake error from 127.0.0.1:49253: remote error: tls: unknown certificate authority\n",
    "lvl": "eror",
    "module": "http",
    "msg": "error",
    "node": "GCPQ.7DUR",
    "t": "2018-09-10T14:28:52.999860475+09:00"
}
```

* If `module` is `http` and `msg` is `request` it is request log
* If `module` is `http` and `msg` is `response` it is response log
* `request` and it's `response` can be matched by `id`.
* The normal HTTP logs of Apache, nginx and other web server just log the
  response log, this PR will log in 2 phase
```
client -> request - (log request) -> response - (log response) -> client 
```
* If `module` is `http` and `msg` is `error`, it is error log.