### PR TITLE
Add LevelDB.Walk to support cursor

### DIFF
--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -328,10 +328,33 @@ func (st *LevelDBBackend) GetIterator(prefix string, option *IteratorOptions) (f
 		})
 }
 
-type WalkFunc func(key, value []byte) (bool, error)
+type (
+	WalkFunc   func(key, value []byte) (bool, error)
+	WalkOption struct {
+		Cursor  string
+		Limit   uint64
+		Reverse bool
+	}
+)
 
-//TODO(anarcher): walkOption? := { prefix,cursor,reverse }
-func (st *LevelDBBackend) Walk(prefix, cursor string, reverse bool, walkFunc WalkFunc) error {
+func NewWalkOption(cursor string, limit uint64, reverse bool) *WalkOption {
+	o := &WalkOption{
+		Cursor:  cursor,
+		Limit:   limit,
+		Reverse: reverse,
+	}
+	return o
+}
+
+func (st *LevelDBBackend) Walk(prefix string, option *WalkOption, walkFunc WalkFunc) error {
+	if option == nil {
+		option = &WalkOption{
+			Cursor:  prefix,
+			Reverse: false,
+			Limit:   10,
+		}
+	}
+
 	var dbRange *leveldbUtil.Range
 	if len(prefix) > 0 {
 		dbRange = leveldbUtil.BytesPrefix(st.makeKey(prefix))
@@ -341,17 +364,24 @@ func (st *LevelDBBackend) Walk(prefix, cursor string, reverse bool, walkFunc Wal
 	defer iter.Release()
 
 	var iterFunc func() bool
-	if reverse == true {
+	if option.Reverse == true {
 		iterFunc = iter.Prev
 	} else {
 		iterFunc = iter.Next
 	}
 
+	cursor := option.Cursor
 	if cursor == "" {
 		cursor = prefix
 	}
 
+	var cnt uint64 = 0
+
 	for ok := iter.Seek(st.makeKey(cursor)); ok; ok = iterFunc() {
+		if cnt >= option.Limit {
+			return iter.Error()
+		}
+
 		if next, err := walkFunc(iter.Key(), iter.Value()); err != nil {
 			return err
 		} else if next == false {
@@ -361,6 +391,7 @@ func (st *LevelDBBackend) Walk(prefix, cursor string, reverse bool, walkFunc Wal
 		if iter.Error() != nil {
 			return iter.Error()
 		}
+		cnt++
 	}
 
 	return iter.Error()

--- a/lib/storage/leveldb_test.go
+++ b/lib/storage/leveldb_test.go
@@ -542,7 +542,8 @@ func TestLevelDBWalk(t *testing.T) {
 		cnt        int
 	)
 
-	err := st.Walk("test-", "test-1", false, func(k, v []byte) (bool, error) {
+	walkOption := NewWalkOption("test-1", 10, false)
+	err := st.Walk("test-", walkOption, func(k, v []byte) (bool, error) {
 		cnt++
 		walkedKeys = append(walkedKeys, string(k))
 		return true, nil


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Related to:  #122 

### Background

Instead of Iterator, Use Walk such like https://golang.org/pkg/path/filepath/#Walk
I am not sure this approach is suitable for leveldbBackend so it is a pr for a question which is suitable or not. 

```
    var walkedKeys []string
    // prefix,cursor,reverse,walkFunc
    err := st.Walk("test-", "test-1", false, func(k, v []byte) (bool, error) { 
        cnt++
        walkedKeys = append(walkedKeys, string(k))
        return true, nil
    })
```


### Solution

Because of using walkFunc via callbackFunc,Inside Walk func  close leveldb.Release().


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

```
func GetBlockAccountCheckpointByAddr(...) ([]*BlockAccountcheckporint,error) {
...
}
```

- `filepath.WalkFunc` just returns error and `filepath.SkipError` handles it. (https://golang.org/pkg/path/filepath/#pkg-variables)
- WalkFunc can use `IterItem` instead `k,v []byte` too. 




