### PR TITLE
remove NodeRunner.CloseConsensus and rename isTargetLater() arg

### DIFF
--- a/lib/isaac.go
+++ b/lib/isaac.go
@@ -143,6 +143,8 @@ func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh common.Vo
 	is.Lock()
 	defer is.Unlock()
 
+	is.SetLatestRound(round)
+
 	if vh == common.VotingNOTYET {
 		err = errors.New("invalid VotingHole, `VotingNOTYET`")
 		return

--- a/lib/isaac_state_manager.go
+++ b/lib/isaac_state_manager.go
@@ -60,18 +60,18 @@ func (sm *ISAACStateManager) TransitISAACState(round round.Round, ballotState co
 	}
 }
 
-func isTargetLater(current ISAACState, target ISAACState) (result bool) {
-	if current.round.BlockHeight > target.round.BlockHeight {
+func isTargetLater(state ISAACState, target ISAACState) (result bool) {
+	if state.round.BlockHeight > target.round.BlockHeight {
 		result = false
-	} else if current.round.BlockHeight < target.round.BlockHeight {
+	} else if state.round.BlockHeight < target.round.BlockHeight {
 		result = true
-	} else { // current.round.BlockHeight == target.round.BlockHeight
-		if current.round.Number > target.round.Number {
+	} else { // state.round.BlockHeight == target.round.BlockHeight
+		if state.round.Number > target.round.Number {
 			result = false
-		} else if current.round.Number < target.round.Number {
+		} else if state.round.Number < target.round.Number {
 			result = true
-		} else { // current.round.Number == target.round.Number
-			if current.ballotState >= target.ballotState {
+		} else { // state.round.Number == target.round.Number
+			if state.ballotState >= target.ballotState {
 				result = false
 			} else {
 				result = true

--- a/lib/isaac_state_transit_test.go
+++ b/lib/isaac_state_transit_test.go
@@ -1,5 +1,4 @@
 // We can test that a node broadcast propose ballot or B(`EXP`) in ISAACStateManager.
-// when the timeout is expired,
 package sebak
 
 import (

--- a/lib/node_runner.go
+++ b/lib/node_runner.go
@@ -518,7 +518,3 @@ func (nr *NodeRunner) proposeNewBallot(roundNumber uint64) error {
 
 	return nil
 }
-
-func (nr *NodeRunner) CloseConsensus(ballot Ballot) {
-	nr.consensus.SetLatestRound(ballot.Round())
-}

--- a/lib/node_runner_checker.go
+++ b/lib/node_runner_checker.go
@@ -485,7 +485,6 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) (err error) {
 		checker.Ballot.Round(),
 		checker.FinishedVotingHole,
 	)
-	checker.NodeRunner.CloseConsensus(checker.Ballot)
 
 	return
 }


### PR DESCRIPTION
### Background
I have a unit test that will be uploaded to me, but before I upload it, I'm uploading irrelevant code changes as pr.

### Solution
I removed NodeRunner.CloseConsensus cause it has only one method call(SetLatestRound).
I renamed isTargetLater() arg `current` to `state` cause it fits better.