### PR TITLE
WriteJSON support hal.Resource

### DIFF
--- a/lib/network/httputils/json.go
+++ b/lib/network/httputils/json.go
@@ -3,12 +3,24 @@ package httputils
 import (
 	"encoding/json"
 	"net/http"
+
+	"github.com/nvellon/hal"
 )
+
+type HALResource interface {
+	Resource() *hal.Resource
+}
 
 // WriteJSON writes the value v to the http response as json encoding
 func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
-	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(code)
+
+	if h, ok := v.(HALResource); ok {
+		w.Header().Set("content-type", "application/hal+json")
+		v = h.Resource()
+	} else {
+		w.Header().Set("content-type", "application/json")
+	}
 
 	bs, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Related to: #319 

### Background



### Solution

```
package httputils

import (
	"encoding/json"
	"net/http"

	"github.com/nvellon/hal"
)

type HALResource interface {
	Resource() *hal.Resource
}

// WriteJSON writes the value v to the http response as json encoding
func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
	w.WriteHeader(code)

	if h, ok := v.(HALResource); ok {
		w.Header().Set("content-type", "application/hal+json")
		v = h.Resource()
	} else {
		w.Header().Set("content-type", "application/json")
	}

	bs, err := json.Marshal(v)
	if err != nil {
		return err
	}

	if _, err := w.Write(bs); err != nil {
		return err
	}

	return nil
}
```


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->
