### PR TITLE
Add Client Api Version (/api/v1/)

### DIFF
--- a/lib/network/api/api.go
+++ b/lib/network/api/api.go
@@ -1,15 +1,18 @@
 package api
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/network/api/resource"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
-	"encoding/json"
-	"fmt"
 )
+
+const APIVersionV1 = "v1"
 
 // API Endpoint patterns
 const (
@@ -25,6 +28,7 @@ type NetworkHandlerAPI struct {
 	localNode *node.LocalNode
 	network   network.Network
 	storage   *storage.LevelDBBackend
+	version   string
 }
 
 func NewNetworkHandlerAPI(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend) *NetworkHandlerAPI {
@@ -32,7 +36,12 @@ func NewNetworkHandlerAPI(localNode *node.LocalNode, network network.Network, st
 		localNode: localNode,
 		network:   network,
 		storage:   storage,
+		version:   APIVersionV1,
 	}
+}
+
+func (api NetworkHandlerAPI) HandlerURLPattern(prefix string, pattern string) string {
+	return fmt.Sprintf("%s/%s%s", prefix, api.version, pattern)
 }
 
 func renderEventStream(args ...interface{}) ([]byte, error) {

--- a/lib/network/api/api.go
+++ b/lib/network/api/api.go
@@ -28,20 +28,22 @@ type NetworkHandlerAPI struct {
 	localNode *node.LocalNode
 	network   network.Network
 	storage   *storage.LevelDBBackend
+	urlPrefix string
 	version   string
 }
 
-func NewNetworkHandlerAPI(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend) *NetworkHandlerAPI {
+func NewNetworkHandlerAPI(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend, urlPrefix string) *NetworkHandlerAPI {
 	return &NetworkHandlerAPI{
 		localNode: localNode,
 		network:   network,
 		storage:   storage,
+		urlPrefix: urlPrefix,
 		version:   APIVersionV1,
 	}
 }
 
-func (api NetworkHandlerAPI) HandlerURLPattern(prefix string, pattern string) string {
-	return fmt.Sprintf("%s/%s%s", prefix, api.version, pattern)
+func (api NetworkHandlerAPI) HandlerURLPattern(pattern string) string {
+	return fmt.Sprintf("%s/%s%s", api.urlPrefix, api.version, pattern)
 }
 
 func renderEventStream(args ...interface{}) ([]byte, error) {

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -164,32 +164,31 @@ func (nr *NodeRunner) Ready() {
 		nr.localNode,
 		nr.network,
 		nr.storage,
+		network.UrlPathPrefixAPI,
 	)
 
-	apiPrefix := network.UrlPathPrefixAPI
-
 	nr.network.AddHandler(
-		apiHandler.HandlerURLPattern(apiPrefix, api.GetAccountHandlerPattern),
+		apiHandler.HandlerURLPattern(api.GetAccountHandlerPattern),
 		apiHandler.GetAccountHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		apiHandler.HandlerURLPattern(apiPrefix, api.GetAccountTransactionsHandlerPattern),
+		apiHandler.HandlerURLPattern(api.GetAccountTransactionsHandlerPattern),
 		apiHandler.GetTransactionsByAccountHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		apiHandler.HandlerURLPattern(apiPrefix, api.GetAccountOperationsHandlerPattern),
+		apiHandler.HandlerURLPattern(api.GetAccountOperationsHandlerPattern),
 		apiHandler.GetOperationsByAccountHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		apiHandler.HandlerURLPattern(apiPrefix, api.GetTransactionsHandlerPattern),
+		apiHandler.HandlerURLPattern(api.GetTransactionsHandlerPattern),
 		apiHandler.GetTransactionsHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		apiHandler.HandlerURLPattern(apiPrefix, api.GetTransactionByHashHandlerPattern),
+		apiHandler.HandlerURLPattern(api.GetTransactionByHashHandlerPattern),
 		apiHandler.GetTransactionByHashHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		apiHandler.HandlerURLPattern(apiPrefix, api.PostTransactionPattern),
+		apiHandler.HandlerURLPattern(api.PostTransactionPattern),
 		nodeHandler.MessageHandler,
 	).Methods("POST")
 

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -166,28 +166,30 @@ func (nr *NodeRunner) Ready() {
 		nr.storage,
 	)
 
+	apiPrefix := network.UrlPathPrefixAPI
+
 	nr.network.AddHandler(
-		network.UrlPathPrefixAPI+api.GetAccountHandlerPattern,
+		apiHandler.HandlerURLPattern(apiPrefix, api.GetAccountHandlerPattern),
 		apiHandler.GetAccountHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		network.UrlPathPrefixAPI+api.GetAccountTransactionsHandlerPattern,
+		apiHandler.HandlerURLPattern(apiPrefix, api.GetAccountTransactionsHandlerPattern),
 		apiHandler.GetTransactionsByAccountHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		network.UrlPathPrefixAPI+api.GetAccountOperationsHandlerPattern,
+		apiHandler.HandlerURLPattern(apiPrefix, api.GetAccountOperationsHandlerPattern),
 		apiHandler.GetOperationsByAccountHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		network.UrlPathPrefixAPI+api.GetTransactionsHandlerPattern,
+		apiHandler.HandlerURLPattern(apiPrefix, api.GetTransactionsHandlerPattern),
 		apiHandler.GetTransactionsHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		network.UrlPathPrefixAPI+api.GetTransactionByHashHandlerPattern,
+		apiHandler.HandlerURLPattern(apiPrefix, api.GetTransactionByHashHandlerPattern),
 		apiHandler.GetTransactionByHashHandler,
 	).Methods("GET")
 	nr.network.AddHandler(
-		network.UrlPathPrefixAPI+api.PostTransactionPattern,
+		apiHandler.HandlerURLPattern(apiPrefix, api.PostTransactionPattern),
 		nodeHandler.MessageHandler,
 	).Methods("POST")
 

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -16,7 +16,7 @@ function getAccount () # u16 port, string addr
     echo $(curl --insecure \
                   --request GET \
                   --header "Accept: application/json" \
-                  https://127.0.0.1:${1}/api/account/${2} \
+                  https://127.0.0.1:${1}/api/v1/account/${2} \
                   2>/dev/null)
 }
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Close: #342 

### Background

Support `/api/v1/...`

### Solution

```
apiPrefix := network.UrlPathPrefixAPI

    nr.network.AddHandler(
        apiHandler.HandlerURLPattern(api.GetAccountHandlerPattern),
        apiHandler.GetAccountHandler,
    ).Methods("GET")
    nr.network.AddHandler(
        apiHandler.HandlerURLPattern(api.GetAccountTransactionsHandlerPattern),
        apiHandler.GetAccountTransactionsHandler,
    ).Methods("GET")
    nr.network.AddHandler(
        apiHandler.HandlerURLPattern(api.GetAccountOperationsHandlerPattern),
        apiHandler.GetAccountOperationsHandler,
    ).Methods("GET")
    nr.network.AddHandler(
        apiHandler.HandlerURLPattern(api.GetTransactionsHandlerPattern),
        apiHandler.GetTransactionsHandler,
    ).Methods("GET")
    nr.network.AddHandler(
        apiHandler.HandlerURLPattern(api.GetTransactionByHashHandlerPattern),
        apiHandler.GetTransactionByHashHandler,
    ).Methods("GET")
    nr.network.AddHandler(
        apiHandler.HandlerURLPattern(api.PostTransactionPattern),
        nodeHandler.MessageHandler,
    ).Methods("POST")
```

```
const APIVersionV1 = "v1"

func (api NetworkHandlerAPI) HandlerURLPattern(pattern string) string {
    return fmt.Sprintf("%s/%s%s", api.urlPrefix, api.version, pattern)
}

```

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

If we needs to `v2` api , We should make a package such as `/api/handler/v1` , `/api/handler/v2`
