### PR TITLE
Fix WriteHeader Content-Type typo

### DIFF
--- a/lib/network/httputils/json.go
+++ b/lib/network/httputils/json.go
@@ -13,14 +13,14 @@ type HALResource interface {
 
 // WriteJSON writes the value v to the http response as json encoding
 func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
-	w.WriteHeader(code)
-
 	if h, ok := v.(HALResource); ok {
-		w.Header().Set("content-type", "application/hal+json")
+		w.Header().Set("Content-Type", "application/hal+json")
 		v = h.Resource()
 	} else {
-		w.Header().Set("content-type", "application/json")
+		w.Header().Set("Content-Type", "application/json")
 	}
+
+	w.WriteHeader(code)
 
 	bs, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Fix  Header typo ( `content-type` -> `Content-Type`) and relocation `w.WriteHeader(code)`

### Background

- Fix  Header typo ( `content-type` -> `Content-Type`)
- Relocation `w.WriteHeader(code)` after Set headers

