### PR TITLE
modify for removing data race and related refactoring

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -22,10 +22,11 @@ import (
 
 	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 
+	"strconv"
+
 	"boscoin.io/sebak/lib"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/node/runner"
-	"strconv"
 )
 
 const defaultNetwork string = "https"
@@ -337,7 +338,7 @@ func runNode() error {
 		return err
 	}
 
-	isaac, err := consensus.NewISAAC([]byte(flagNetworkID), localNode, policy)
+	isaac, err := consensus.NewISAAC([]byte(flagNetworkID), localNode, policy, nt)
 	if err != nil {
 		log.Crit("failed to launch consensus", "error", err)
 		return err

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -89,7 +89,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, mn *network.HTTP2Net
 	mn = network.NewHTTP2Network(config)
 
 	p, _ := consensus.NewDefaultVotingThresholdPolicy(30, 30)
-	is, _ := consensus.NewISAAC(networkID, localNode, p)
+	is, _ := consensus.NewISAAC(networkID, localNode, p, mn)
 	st, _ := storage.NewTestMemoryLevelDBBackend()
 	// Make the latest block
 	{

--- a/lib/node/runner/broadcaster_test.go
+++ b/lib/node/runner/broadcaster_test.go
@@ -16,8 +16,10 @@ func TestConnectionManagerBroadcaster(t *testing.T) {
 	recv := make(chan struct{})
 
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -39,7 +39,6 @@ type BallotChecker struct {
 	IsNew              bool
 	Ballot             block.Ballot
 	VotingHole         common.VotingHole
-	RoundVote          *consensus.RoundVote
 	Result             consensus.RoundVoteResult
 	VotingFinished     bool
 	FinishedVotingHole common.VotingHole
@@ -106,17 +105,8 @@ func BallotAlreadyFinished(c common.Checker, args ...interface{}) (err error) {
 // BallotAlreadyVoted checks the node of ballot voted.
 func BallotAlreadyVoted(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
-	rr := checker.NodeRunner.Consensus().RunningRounds
-
-	var found bool
-	var runningRound *consensus.RunningRound
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
-		return
-	}
-
-	if runningRound.IsVoted(checker.Ballot) {
+	if checker.NodeRunner.Consensus().IsVoted(checker.Ballot) {
 		err = errors.ErrorBallotAlreadyVoted
-		return
 	}
 
 	return
@@ -128,40 +118,8 @@ func BallotAlreadyVoted(c common.Checker, args ...interface{}) (err error) {
 func BallotVote(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
-	roundHash := checker.Ballot.Round().Hash()
-	rr := checker.NodeRunner.Consensus().RunningRounds
-
-	var isNew bool
-	var found bool
-	var runningRound *consensus.RunningRound
-	if runningRound, found = rr[roundHash]; !found {
-		proposer := checker.NodeRunner.CalculateProposer(
-			checker.Ballot.Round().BlockHeight,
-			checker.Ballot.Round().Number,
-		)
-
-		runningRound, err = consensus.NewRunningRound(proposer, checker.Ballot)
-		if err != nil {
-			return
-		}
-
-		rr[roundHash] = runningRound
-		isNew = true
-	} else {
-		if _, found = runningRound.Voted[checker.Ballot.Proposer()]; !found {
-			isNew = true
-		}
-
-		runningRound.Vote(checker.Ballot)
-	}
-
-	checker.IsNew = isNew
-	checker.RoundVote, err = runningRound.RoundVote(checker.Ballot.Proposer())
-	if err != nil {
-		return
-	}
-
-	checker.Log.Debug("ballot voted", "runningRound", runningRound, "new", isNew)
+	checker.IsNew, err = checker.NodeRunner.Consensus().Vote(checker.Ballot)
+	checker.Log.Debug("ballot voted", "ballot", checker.Ballot, "new", checker.IsNew)
 
 	return
 }
@@ -179,17 +137,14 @@ func BallotIsSameProposer(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	rr := checker.NodeRunner.Consensus().RunningRounds
-	var runningRound *consensus.RunningRound
-	var found bool
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
+	if !checker.NodeRunner.Consensus().HasRunningRound(checker.Ballot.Round().Hash()) {
 		err = errors.New("`RunningRound` not found")
 		return
 	}
 
-	if runningRound.Proposer != checker.Ballot.Proposer() {
+	if !checker.NodeRunner.Consensus().HasSameProposer(checker.Ballot) {
 		checker.VotingHole = common.VotingNO
-		checker.Log.Debug("ballot has different proposer", "proposer", runningRound.Proposer)
+		checker.Log.Debug("ballot has different proposer", "proposer", checker.Ballot.Proposer())
 		return
 	}
 
@@ -204,10 +159,7 @@ func BallotCheckResult(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	result, votingHole, finished := checker.RoundVote.CanGetVotingResult(
-		checker.NodeRunner.Consensus().VotingThresholdPolicy,
-		checker.Ballot.State(),
-	)
+	result, votingHole, finished := checker.NodeRunner.Consensus().CanGetVotingResult(checker.Ballot)
 
 	checker.Result = result
 	checker.VotingFinished = finished
@@ -239,8 +191,9 @@ func INITBallotValidateTransactions(c common.Checker, args ...interface{}) (err 
 	if !checker.IsNew || checker.VotingFinished {
 		return
 	}
-
-	if checker.RoundVote.IsVotedByNode(checker.Ballot.State(), checker.LocalNode.Address()) {
+	var voted bool
+	voted, err = checker.NodeRunner.Consensus().IsVotedByNode(checker.Ballot, checker.LocalNode.Address())
+	if voted || err != nil {
 		err = errors.ErrorBallotAlreadyVoted
 		return
 	}
@@ -295,15 +248,12 @@ func SIGNBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 	newBallot.SetVote(common.BallotStateSIGN, checker.VotingHole)
 	newBallot.Sign(checker.LocalNode.Keypair(), checker.NetworkID)
 
-	rr := checker.NodeRunner.Consensus().RunningRounds
-
-	var runningRound *consensus.RunningRound
-	var found bool
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
+	if !checker.NodeRunner.Consensus().HasRunningRound(checker.Ballot.Round().Hash()) {
 		err = errors.New("RunningRound not found")
 		return
+
 	}
-	runningRound.Vote(newBallot)
+	checker.NodeRunner.Consensus().Vote(newBallot)
 
 	checker.NodeRunner.ConnectionManager().Broadcast(newBallot)
 	checker.Log.Debug("ballot will be broadcasted", "newBallot", newBallot)
@@ -334,15 +284,12 @@ func ACCEPTBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 	newBallot.SetVote(common.BallotStateACCEPT, checker.FinishedVotingHole)
 	newBallot.Sign(checker.LocalNode.Keypair(), checker.NetworkID)
 
-	rr := checker.NodeRunner.Consensus().RunningRounds
-	var runningRound *consensus.RunningRound
-	var found bool
-	if runningRound, found = rr[checker.Ballot.Round().Hash()]; !found {
+	if !checker.NodeRunner.Consensus().HasRunningRound(checker.Ballot.Round().Hash()) {
 		err = errors.New("RunningRound not found")
 		return
-	}
-	runningRound.Vote(newBallot)
 
+	}
+	checker.NodeRunner.Consensus().Vote(newBallot)
 	checker.NodeRunner.ConnectionManager().Broadcast(newBallot)
 	checker.Log.Debug("ballot will be broadcasted", "newBallot", newBallot)
 

--- a/lib/node/runner/checker_message_test.go
+++ b/lib/node/runner/checker_message_test.go
@@ -21,7 +21,7 @@ func TestMessageChecker(t *testing.T) {
 	}
 
 	validMessage := common.NetworkMessage{Type: common.TransactionMessage, Data: b}
-	nodeRunner, localNode := MakeNodeRunner(nil)
+	nodeRunner, localNode := MakeNodeRunner()
 	checker := &MessageChecker{
 		DefaultChecker: common.DefaultChecker{},
 		NodeRunner:     nodeRunner,
@@ -83,7 +83,7 @@ func TestMessageCheckerWithInvalidMessage(t *testing.T) {
 	}
 
 	invalidMessage := common.NetworkMessage{Type: common.TransactionMessage, Data: b}
-	nodeRunner, localNode := MakeNodeRunner(nil)
+	nodeRunner, localNode := MakeNodeRunner()
 	checker := &MessageChecker{
 		NodeRunner: nodeRunner,
 		LocalNode:  localNode,

--- a/lib/node/runner/isaac_simulation_test.go
+++ b/lib/node/runner/isaac_simulation_test.go
@@ -31,7 +31,9 @@ func TestISAACSimulationProposer(t *testing.T) {
 	nodeRunner := nodeRunners[0]
 
 	// `nodeRunner` is proposer's runner
-	nodeRunner.SetProposerCalculator(SelfProposerCalculator{})
+	nodeRunner.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nodeRunner,
+	})
 	proposer := nodeRunner.localNode
 
 	nodeRunner.Consensus().SetLatestConsensusedBlock(genesisBlock)
@@ -46,11 +48,13 @@ func TestISAACSimulationProposer(t *testing.T) {
 	roundNumber := uint64(0)
 	err = nodeRunner.proposeNewBallot(roundNumber)
 	require.Nil(t, err)
+
+	b := nodeRunner.Consensus().LatestConfirmedBlock()
 	round := round.Round{
 		Number:      roundNumber,
-		BlockHeight: nodeRunner.Consensus().LatestConfirmedBlock.Height,
-		BlockHash:   nodeRunner.Consensus().LatestConfirmedBlock.Hash,
-		TotalTxs:    nodeRunner.Consensus().LatestConfirmedBlock.TotalTxs,
+		BlockHeight: b.Height,
+		BlockHash:   b.Hash,
+		TotalTxs:    b.TotalTxs,
 	}
 	runningRounds := nodeRunner.Consensus().RunningRounds
 
@@ -97,7 +101,7 @@ func TestISAACSimulationProposer(t *testing.T) {
 
 	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(common.BallotStateACCEPT)))
 
-	block := nodeRunner.Consensus().LatestConfirmedBlock
+	block := nodeRunner.Consensus().LatestConfirmedBlock()
 	require.Equal(t, proposer.Address(), block.Proposer)
 	require.Equal(t, 1, len(block.Transactions))
 	require.Equal(t, tx.GetHash(), block.Transactions[0])

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -145,11 +145,12 @@ func (sm *ISAACStateManager) Start() {
 }
 
 func (sm *ISAACStateManager) broadcastExpiredBallot(state consensus.ISAACState) {
+	b := sm.nr.consensus.LatestConfirmedBlock()
 	round := round.Round{
 		Number:      state.Round.Number,
-		BlockHeight: sm.nr.consensus.LatestConfirmedBlock.Height,
-		BlockHash:   sm.nr.consensus.LatestConfirmedBlock.Hash,
-		TotalTxs:    sm.nr.consensus.LatestConfirmedBlock.TotalTxs,
+		BlockHeight: b.Height,
+		BlockHash:   b.Hash,
+		TotalTxs:    b.TotalTxs,
 	}
 
 	newExpiredBallot := block.NewBallot(sm.nr.localNode, round, []string{})
@@ -172,7 +173,7 @@ func (sm *ISAACStateManager) resetTimer(timer *time.Timer, state common.BallotSt
 
 func (sm *ISAACStateManager) proposeOrWait(timer *time.Timer, state consensus.ISAACState) {
 	timer.Reset(time.Duration(1 * time.Hour))
-	proposer := sm.nr.CalculateProposer(state.Round.BlockHeight, state.Round.Number)
+	proposer := sm.nr.Consensus().CalculateProposer(state.Round.BlockHeight, state.Round.Number)
 	log.Debug("calculated proposer", "proposer", proposer)
 
 	if proposer == sm.nr.localNode.Address() {
@@ -184,7 +185,7 @@ func (sm *ISAACStateManager) proposeOrWait(timer *time.Timer, state consensus.IS
 			timer.Reset(sm.Conf.TimeoutSIGN)
 			sm.transitSignal()
 		} else {
-			log.Error("failed to proposeNewBallot", "height", sm.nr.consensus.LatestConfirmedBlock.Height, "error", err)
+			log.Error("failed to proposeNewBallot", "height", sm.nr.consensus.LatestConfirmedBlock().Height, "error", err)
 			sm.setState(state)
 			timer.Reset(sm.Conf.TimeoutINIT)
 		}

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -22,8 +22,10 @@ func TestStateINITProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 
@@ -57,8 +59,10 @@ func TestStateINITNotProposer(t *testing.T) {
 	nr := nodeRunners[0]
 
 	b := NewTestBroadcaster(nil)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 
@@ -88,9 +92,11 @@ func TestStateINITTimeoutNotProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
-	proposer := nr.CalculateProposer(0, 0)
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
@@ -144,9 +150,11 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
-	proposer := nr.CalculateProposer(0, 0)
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 
 	require.Equal(t, nr.localNode.Address(), proposer)
 
@@ -208,9 +216,11 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
-	proposer := nr.CalculateProposer(0, 0)
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
@@ -267,13 +277,15 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(&SelfProposerThenNotProposer{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(&SelfProposerThenNotProposer{
+		nodeRunner: nr,
+	})
 
-	proposer := nr.CalculateProposer(0, 0)
+	proposer := nr.Consensus().CalculateProposer(0, 0)
 	require.Equal(t, nr.localNode.Address(), proposer)
 
-	proposer = nr.CalculateProposer(0, 1)
+	proposer = nr.Consensus().CalculateProposer(0, 1)
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
@@ -333,8 +345,10 @@ func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 
 	recvBroadcast := make(chan struct{})
 	b := NewTestBroadcaster(recvBroadcast)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(TheOtherProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(TheOtherProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 
@@ -380,8 +394,10 @@ func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
 
 	recv := make(chan struct{})
 	b := NewTestBroadcaster(recv)
-	nr.SetBroadcaster(b)
-	nr.SetProposerCalculator(SelfProposerCalculator{})
+	nr.Consensus().SetBroadcaster(b)
+	nr.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nr,
+	})
 
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -59,7 +59,7 @@ func createTestNodeRunner(n int) []*NodeRunner {
 	for i := 0; i < n; i++ {
 		v := nodes[i]
 		p, _ := consensus.NewDefaultVotingThresholdPolicy(66, 66)
-		is, _ := consensus.NewISAAC(networkID, v, p)
+		is, _ := consensus.NewISAAC(networkID, v, p, ns[i])
 		st, _ := storage.NewTestMemoryLevelDBBackend()
 
 		account.Save(st)
@@ -151,10 +151,10 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 	)
 	for _, node := range nodes {
 		vth, _ := consensus.NewDefaultVotingThresholdPolicy(66, 66)
-		is, _ := consensus.NewISAAC(networkID, node, vth)
 		st, _ := storage.NewTestMemoryLevelDBBackend()
 		networkConfig, _ := network.NewHTTP2NetworkConfigFromEndpoint(node.Alias(), node.Endpoint())
 		network := network.NewHTTP2Network(networkConfig)
+		is, _ := consensus.NewISAAC(networkID, node, vth, network)
 		nodeRunner, _ := NewNodeRunner(string(networkID), node, vth, network, is, st)
 
 		genesisAccount.Save(nodeRunner.Storage())

--- a/lib/node/runner/proposer_calculator_test.go
+++ b/lib/node/runner/proposer_calculator_test.go
@@ -11,11 +11,13 @@ func TestProposerCalculator(t *testing.T) {
 	nodeRunners := createTestNodeRunner(1)
 
 	nodeRunner := nodeRunners[0]
-	nodeRunner.SetProposerCalculator(SelfProposerCalculator{})
+	nodeRunner.Consensus().SetProposerCalculator(SelfProposerCalculator{
+		nodeRunner: nodeRunner,
+	})
 
-	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(1, 0))
-	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(2, 0))
-	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.CalculateProposer(2, 1))
+	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.Consensus().CalculateProposer(1, 0))
+	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.Consensus().CalculateProposer(2, 0))
+	require.Equal(t, nodeRunner.localNode.Address(), nodeRunner.Consensus().CalculateProposer(2, 1))
 }
 
 // All 3 nodes have the same proposer at each round
@@ -37,9 +39,9 @@ func TestNodesHaveSameProposers(t *testing.T) {
 
 	for i := uint64(0); i < maximumBlockHeight; i++ {
 		for j := uint64(0); j < maximumRoundNumber; j++ {
-			proposers0[i*maximumRoundNumber] = nr0.CalculateProposer(i, j)
-			proposers1[i*maximumRoundNumber] = nr1.CalculateProposer(i, j)
-			proposers2[i*maximumRoundNumber] = nr2.CalculateProposer(i, j)
+			proposers0[i*maximumRoundNumber] = nr0.Consensus().CalculateProposer(i, j)
+			proposers1[i*maximumRoundNumber] = nr1.Consensus().CalculateProposer(i, j)
+			proposers2[i*maximumRoundNumber] = nr2.Consensus().CalculateProposer(i, j)
 		}
 	}
 


### PR DESCRIPTION
### Background
<!--
    Explain why this pull request was created.
-->
The branch [`impl-new-isaac`](https://github.com/bosnet/sebak/pull/358) has data race in `RunningRounds` so I should modify to pass.
In this implementing process, refactoring is needed because ISAAC should have `ProposerCalculator`.
Without it, [This](https://github.com/Charleslee522/sebak/compare/impl-new-isaac...Charleslee522:data-race-running-round?expand=1#diff-7f79ac520823e445bff5cd70f53bcf59L138) codes cannot be moved into `ISAAC`.

### Solution
<!-- 
    Explain how you solved this problem.
-->
1. Refactoring
   * ISAAC also has connectionManager
   * ISAAC has ProposerCalculator
1. Data race
   * Use RWLock in ISAAC and RLock and RUnlock in method which is include RunningRounds.
   * All `RunningRounds` related logic is in ISAAC, not in Checker.
   * Use RWLock in LatestConfirmedBlock method.

ps. I wanted to and tried to breakdown but it's not easy because all changes are related.