### PR TITLE
Organize operation type (#356)

### DIFF
--- a/lib/transaction/operation.go
+++ b/lib/transaction/operation.go
@@ -15,6 +15,9 @@ type OperationType string
 const (
 	OperationCreateAccount OperationType = "create-account"
 	OperationPayment                     = "payment"
+	OperationVotingResult                = "voting-result"
+	OperationProposal                    = "proposal"
+	OperationMembership                  = "membership"
 )
 
 type Operation struct {
@@ -126,4 +129,21 @@ type OperationBody interface {
 	IsWellFormed([]byte) error
 	TargetAddress() string
 	GetAmount() common.Amount
+}
+
+type OperationBodyImpl struct {
+}
+
+func (ob OperationBodyImpl) IsWellFormed(networkID []byte) (err error) {
+	err = nil
+	return
+}
+
+func (ob OperationBodyImpl) TargetAddress() string {
+	return "none"
+}
+
+func (ob OperationBodyImpl) GetAmount() (a common.Amount) {
+	a = 0
+	return
 }

--- a/lib/transaction/operation_create_account.go
+++ b/lib/transaction/operation_create_account.go
@@ -9,6 +9,7 @@ import (
 )
 
 type OperationBodyCreateAccount struct {
+	OperationBodyImpl
 	Target string        `json:"target"`
 	Amount common.Amount `json:"amount"`
 }

--- a/lib/transaction/operation_payment.go
+++ b/lib/transaction/operation_payment.go
@@ -10,6 +10,7 @@ import (
 )
 
 type OperationBodyPayment struct {
+	OperationBodyImpl
 	Target string        `json:"target"`
 	Amount common.Amount `json:"amount"`
 }

--- a/lib/transaction/operation_test.go
+++ b/lib/transaction/operation_test.go
@@ -22,7 +22,7 @@ func TestMakeHashOfOperationBodyPayment(t *testing.T) {
 	}
 	hashed := op.MakeHashString()
 
-	expected := "8AALKhfgCu2w3ZtbESXHG5ko93Jb1L1yCmFopoJubQh9"
+	expected := "ARoxeSi5HqbyqbMhanSiDC3PjTvAf2B2vb5h5g63fxLF"
 	require.Equal(t, hashed, expected)
 }
 


### PR DESCRIPTION
### Background
We defined operation type for the transfer feature(`payment`, `createAccount`) until now.
And the methods which is defined in `OperationBody` interface are `Validate()`, `IsWellFormed()`, `TargetAddress()`, `GetAmount()`.
There is a need to define more operation type increasingly.
But the methods of `OperationBody` interface isn't general for other operation type.(e.g. `operation_voting_result`, `operation_proposal` ...). However `OperationBody` implementation for voting result should have GetAmount() method to satisfy interface.
It will be good if `OperationBody` struct doesn't need to implement unnecessary methods repeatedly and use current `OperationBody` interface continually.


### Solution
Implement default struct about interface.
The default struct define the methods which should be generated.
Each operation type inherit default struct and define the method only needed for it.