### PR TITLE
node.NodeState to node.State

### DIFF
--- a/lib/node/localNode.go
+++ b/lib/node/localNode.go
@@ -23,7 +23,7 @@ type LocalNode struct {
 
 	keypair *keypair.Full
 
-	state      NodeState
+	state      State
 	alias      string
 	endpoint   *common.Endpoint
 	validators map[ /* Node.Address() */ string]*Validator
@@ -36,7 +36,7 @@ func NewLocalNode(kp *keypair.Full, endpoint *common.Endpoint, alias string) (n 
 
 	n = &LocalNode{
 		keypair:    kp,
-		state:      NodeStateNONE,
+		state:      StateNONE,
 		alias:      alias,
 		endpoint:   endpoint,
 		validators: map[string]*Validator{},
@@ -68,24 +68,24 @@ func (n *LocalNode) DeepEqual(a Node) bool {
 	return true
 }
 
-func (n *LocalNode) State() NodeState {
+func (n *LocalNode) State() State {
 	return n.state
 }
 
 func (n *LocalNode) SetBooting() {
-	n.state = NodeStateBOOTING
+	n.state = StateBOOTING
 }
 
 func (n *LocalNode) SetSync() {
-	n.state = NodeStateSYNC
+	n.state = StateSYNC
 }
 
 func (n *LocalNode) SetConsensus() {
-	n.state = NodeStateCONSENSUS
+	n.state = StateCONSENSUS
 }
 
 func (n *LocalNode) SetTerminating() {
-	n.state = NodeStateTERMINATING
+	n.state = StateTERMINATING
 }
 
 func (n *LocalNode) Address() string {

--- a/lib/node/node.go
+++ b/lib/node/node.go
@@ -12,7 +12,7 @@ type Node interface {
 	Equal(Node) bool
 	DeepEqual(Node) bool
 	Serialize() ([]byte, error)
-	State() NodeState
+	State() State
 	SetBooting()
 	SetSync()
 	SetConsensus()

--- a/lib/node/node_state.go
+++ b/lib/node/node_state.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 )
 
-type NodeState uint
+type State uint
 
 const (
-	NodeStateNONE NodeState = iota
-	NodeStateBOOTING
-	NodeStateSYNC
-	NodeStateCONSENSUS
-	NodeStateTERMINATING
+	StateNONE State = iota
+	StateBOOTING
+	StateSYNC
+	StateCONSENSUS
+	StateTERMINATING
 )
 
-var NodeInitState = NodeStateNONE
+var NodeInitState = StateNONE
 
-func (s NodeState) String() string {
+func (s State) String() string {
 	switch s {
 	case 0:
 		return "NONE"
@@ -33,11 +33,11 @@ func (s NodeState) String() string {
 	return ""
 }
 
-func (s NodeState) MarshalJSON() ([]byte, error) {
+func (s State) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf("\"%s\"", s.String())), nil
 }
 
-func (s *NodeState) UnmarshalJSON(b []byte) (err error) {
+func (s *State) UnmarshalJSON(b []byte) (err error) {
 	var c int
 	switch string(b[1 : len(b)-1]) {
 	case "NONE":
@@ -52,7 +52,7 @@ func (s *NodeState) UnmarshalJSON(b []byte) (err error) {
 		c = 4
 	}
 
-	*s = NodeState(c)
+	*s = State(c)
 
 	return
 }

--- a/lib/node/node_state_test.go
+++ b/lib/node/node_state_test.go
@@ -7,58 +7,58 @@ import (
 )
 
 func TestNodeInitState(t *testing.T) {
-	require.Equal(t, NodeInitState, NodeStateNONE)
+	require.Equal(t, NodeInitState, StateNONE)
 }
 
 func TestNodeStateString(t *testing.T) {
-	require.Equal(t, NodeStateNONE.String(), "NONE")
-	require.Equal(t, NodeStateBOOTING.String(), "BOOTING")
-	require.Equal(t, NodeStateSYNC.String(), "SYNC")
-	require.Equal(t, NodeStateCONSENSUS.String(), "CONSENSUS")
-	require.Equal(t, NodeStateTERMINATING.String(), "TERMINATING")
+	require.Equal(t, StateNONE.String(), "NONE")
+	require.Equal(t, StateBOOTING.String(), "BOOTING")
+	require.Equal(t, StateSYNC.String(), "SYNC")
+	require.Equal(t, StateCONSENSUS.String(), "CONSENSUS")
+	require.Equal(t, StateTERMINATING.String(), "TERMINATING")
 }
 
 func TestNodeStateMarshalJSON(t *testing.T) {
-	ret, err := NodeStateNONE.MarshalJSON()
+	ret, err := StateNONE.MarshalJSON()
 	require.Equal(t, err, nil)
 	require.Equal(t, "\"NONE\"", string(ret))
 
-	ret, err = NodeStateBOOTING.MarshalJSON()
+	ret, err = StateBOOTING.MarshalJSON()
 	require.Equal(t, err, nil)
 	require.Equal(t, "\"BOOTING\"", string(ret))
 
-	ret, err = NodeStateSYNC.MarshalJSON()
+	ret, err = StateSYNC.MarshalJSON()
 	require.Equal(t, err, nil)
 	require.Equal(t, "\"SYNC\"", string(ret))
 
-	ret, err = NodeStateCONSENSUS.MarshalJSON()
+	ret, err = StateCONSENSUS.MarshalJSON()
 	require.Equal(t, err, nil)
 	require.Equal(t, "\"CONSENSUS\"", string(ret))
 
-	ret, err = NodeStateTERMINATING.MarshalJSON()
+	ret, err = StateTERMINATING.MarshalJSON()
 	require.Equal(t, err, nil)
 	require.Equal(t, "\"TERMINATING\"", string(ret))
 }
 
 func TestNodeStateUnmarshalJSON(t *testing.T) {
-	ns := NodeStateNONE
-	nodeStateByteArray, _ := NodeStateNONE.MarshalJSON()
+	ns := StateNONE
+	nodeStateByteArray, _ := StateNONE.MarshalJSON()
 	ns.UnmarshalJSON(nodeStateByteArray)
-	require.Equal(t, NodeStateNONE, ns)
+	require.Equal(t, StateNONE, ns)
 
-	nodeStateByteArray, _ = NodeStateBOOTING.MarshalJSON()
+	nodeStateByteArray, _ = StateBOOTING.MarshalJSON()
 	ns.UnmarshalJSON(nodeStateByteArray)
-	require.Equal(t, NodeStateBOOTING, ns)
+	require.Equal(t, StateBOOTING, ns)
 
-	nodeStateByteArray, _ = NodeStateSYNC.MarshalJSON()
+	nodeStateByteArray, _ = StateSYNC.MarshalJSON()
 	ns.UnmarshalJSON(nodeStateByteArray)
-	require.Equal(t, NodeStateSYNC, ns)
+	require.Equal(t, StateSYNC, ns)
 
-	nodeStateByteArray, _ = NodeStateCONSENSUS.MarshalJSON()
+	nodeStateByteArray, _ = StateCONSENSUS.MarshalJSON()
 	ns.UnmarshalJSON(nodeStateByteArray)
-	require.Equal(t, NodeStateCONSENSUS, ns)
+	require.Equal(t, StateCONSENSUS, ns)
 
-	nodeStateByteArray, _ = NodeStateTERMINATING.MarshalJSON()
+	nodeStateByteArray, _ = StateTERMINATING.MarshalJSON()
 	ns.UnmarshalJSON(nodeStateByteArray)
-	require.Equal(t, NodeStateTERMINATING, ns)
+	require.Equal(t, StateTERMINATING, ns)
 }

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -18,19 +18,19 @@ func TestNodeStateChange(t *testing.T) {
 
 	node, _ := NewLocalNode(kp, endpoint, "")
 
-	require.Equal(t, NodeStateNONE, node.State())
+	require.Equal(t, StateNONE, node.State())
 
 	node.SetBooting()
-	require.Equal(t, NodeStateBOOTING, node.State())
+	require.Equal(t, StateBOOTING, node.State())
 
 	node.SetSync()
-	require.Equal(t, NodeStateSYNC, node.State())
+	require.Equal(t, StateSYNC, node.State())
 
 	node.SetConsensus()
-	require.Equal(t, NodeStateCONSENSUS, node.State())
+	require.Equal(t, StateCONSENSUS, node.State())
 
 	node.SetTerminating()
-	require.Equal(t, NodeStateTERMINATING, node.State())
+	require.Equal(t, StateTERMINATING, node.State())
 
 }
 

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -22,13 +22,13 @@ type ValidatorFromJSON struct {
 	Alias    string           `json:"alias"`
 	Address  string           `json:"address"`
 	Endpoint *common.Endpoint `json:"endpoint"`
-	State    NodeState        `json:"state"`
+	State    State            `json:"state"`
 }
 
 type Validator struct {
 	sync.Mutex
 
-	state    NodeState
+	state    State
 	alias    string
 	address  string
 	endpoint *common.Endpoint
@@ -57,24 +57,24 @@ func (v *Validator) DeepEqual(a Node) bool {
 	return true
 }
 
-func (v *Validator) State() NodeState {
+func (v *Validator) State() State {
 	return v.state
 }
 
 func (v *Validator) SetBooting() {
-	v.state = NodeStateBOOTING
+	v.state = StateBOOTING
 }
 
 func (v *Validator) SetSync() {
-	v.state = NodeStateSYNC
+	v.state = StateSYNC
 }
 
 func (v *Validator) SetConsensus() {
-	v.state = NodeStateCONSENSUS
+	v.state = StateCONSENSUS
 }
 
 func (v *Validator) SetTerminating() {
-	v.state = NodeStateTERMINATING
+	v.state = StateTERMINATING
 }
 
 func (v *Validator) Address() string {
@@ -130,7 +130,7 @@ func NewValidator(address string, endpoint *common.Endpoint, alias string) (v *V
 	}
 
 	v = &Validator{
-		state:    NodeStateNONE,
+		state:    StateNONE,
 		alias:    alias,
 		address:  address,
 		endpoint: endpoint,

--- a/lib/node/validator_test.go
+++ b/lib/node/validator_test.go
@@ -103,7 +103,7 @@ func TestValidatorNewValidatorFromString(t *testing.T) {
 
 	require.Equal(t, "v1", validator.Alias())
 	require.Equal(t, "https://localhost:5000", validator.Endpoint().String())
-	require.Equal(t, NodeStateNONE, validator.State())
+	require.Equal(t, StateNONE, validator.State())
 }
 
 func TestValidatorUnMarshalJSON(t *testing.T) {
@@ -126,5 +126,5 @@ func TestValidatorUnMarshalJSON(t *testing.T) {
 
 	require.Equal(t, "v1", validator.Alias())
 	require.Equal(t, "https://localhost:5000", validator.Endpoint().String())
-	require.Equal(t, NodeStateNONE, validator.State())
+	require.Equal(t, StateNONE, validator.State())
 }


### PR DESCRIPTION
The `node.State` is simpler and more intuitive than `node.NodeState`.