### PR TITLE
Cleanup: Remove some Node function, refactor `handleMessage`

### DIFF
--- a/lib/node/localNode.go
+++ b/lib/node/localNode.go
@@ -100,10 +100,6 @@ func (n *LocalNode) Alias() string {
 	return n.alias
 }
 
-func (n *LocalNode) SetAlias(s string) {
-	n.alias = s
-}
-
 func (n *LocalNode) Endpoint() *common.Endpoint {
 	return n.endpoint
 }

--- a/lib/node/localNode.go
+++ b/lib/node/localNode.go
@@ -57,17 +57,6 @@ func (n *LocalNode) Equal(a Node) bool {
 	return false
 }
 
-func (n *LocalNode) DeepEqual(a Node) bool {
-	if !n.Equal(a) {
-		return false
-	}
-	if n.Endpoint().String() != a.Endpoint().String() {
-		return false
-	}
-
-	return true
-}
-
 func (n *LocalNode) State() State {
 	return n.state
 }

--- a/lib/node/node.go
+++ b/lib/node/node.go
@@ -7,7 +7,6 @@ import (
 type Node interface {
 	Address() string
 	Alias() string
-	SetAlias(string)
 	Endpoint() *common.Endpoint
 	Equal(Node) bool
 	DeepEqual(Node) bool

--- a/lib/node/node.go
+++ b/lib/node/node.go
@@ -9,7 +9,6 @@ type Node interface {
 	Alias() string
 	Endpoint() *common.Endpoint
 	Equal(Node) bool
-	DeepEqual(Node) bool
 	Serialize() ([]byte, error)
 	State() State
 	SetBooting()

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -85,10 +85,6 @@ func (v *Validator) Alias() string {
 	return v.alias
 }
 
-func (v *Validator) SetAlias(s string) {
-	v.alias = s
-}
-
 func (v *Validator) Endpoint() *common.Endpoint {
 	return v.endpoint
 }

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -46,17 +46,6 @@ func (v *Validator) Equal(a Node) bool {
 	return false
 }
 
-func (v *Validator) DeepEqual(a Node) bool {
-	if !v.Equal(a) {
-		return false
-	}
-	if v.Endpoint().String() != a.Endpoint().String() {
-		return false
-	}
-
-	return true
-}
-
 func (v *Validator) State() State {
 	return v.state
 }


### PR DESCRIPTION
Pretty straightforward stuff. I think ultimately we could merge `Validator` and `LocalNode` into `Node`, if we take the Keypair out of `LocalNode`, but I'll leave that for another day.