### PR TITLE
Get The Missing Transactions From Proposer

### DIFF
--- a/lib/error/base.go
+++ b/lib/error/base.go
@@ -5,6 +5,7 @@ import "encoding/json"
 type Error struct {
 	Code    uint   `json:"code"`
 	Message string `json:"message"`
+	Data    map[string]interface{}
 }
 
 func (o *Error) Serialize() (b []byte, err error) {
@@ -17,6 +18,28 @@ func (o *Error) Error() string {
 	return string(b)
 }
 
+// SetData sets `Error.Data`
+func (o *Error) SetData(k string, v interface{}) *Error {
+	o.Data[k] = v
+
+	return o
+}
+
+func (o *Error) Clone() *Error {
+	data := map[string]interface{}{}
+	if o.Data != nil {
+		for k, v := range o.Data {
+			data[k] = v
+		}
+	}
+
+	return &Error{
+		Code:    o.Code,
+		Message: o.Message,
+		Data:    data,
+	}
+}
+
 func NewError(code uint, message string) *Error {
-	return &Error{Code: code, Message: message}
+	return &Error{Code: code, Message: message, Data: map[string]interface{}{}}
 }

--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -54,4 +54,5 @@ var (
 	ErrorInvalidContentType                   = NewError(147, "found invalid 'Content-Type'")
 	ErrorStorageRecordAlreadyExists           = NewError(148, "record already exists in storage")
 	ErrorStorageCoreError                     = NewError(149, "storage error")
+	ErrorContentTypeNotJSON                   = NewError(150, "`Content-Type` must be 'application/json'")
 )

--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -8,18 +8,20 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/transaction"
 )
 
 const GetBlocksPattern = "/blocks"
 
-type GetBlocksDataType string
+type NodeItemDataType string
 
 const (
-	GetBlocksDataTypeBlock       GetBlocksDataType = "block"
-	GetBlocksDataTypeHeader      GetBlocksDataType = "header"
-	GetBlocksDataTypeTransaction GetBlocksDataType = "transaction"
-	GetBlocksDataTypeOperation   GetBlocksDataType = "operation"
-	GetBlocksDataTypeError       GetBlocksDataType = "error"
+	NodeItemBlock            NodeItemDataType = "block"
+	NodeItemBlockHeader      NodeItemDataType = "block-header"
+	NodeItemBlockTransaction NodeItemDataType = "block-transaction"
+	NodeItemBlockOperation   NodeItemDataType = "block-operation"
+	NodeItemTransaction      NodeItemDataType = "transaction"
+	NodeItemError            NodeItemDataType = "error"
 )
 
 func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Request) {
@@ -108,13 +110,13 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 	w.Header().Set("X-SEBAK-RESULT-COUNT", string(len(bs)))
 
 	for _, b := range bs {
-		var itemType GetBlocksDataType
+		var itemType NodeItemDataType
 		if options.Mode == GetBlocksOptionsModeHeader {
-			itemType = GetBlocksDataTypeHeader
-			renderGetBlocksItem(w, itemType, b.(*block.Block).Header)
+			itemType = NodeItemBlockHeader
+			nh.renderNodeItem(w, itemType, b.(*block.Block).Header)
 		} else {
-			itemType = GetBlocksDataTypeBlock
-			renderGetBlocksItem(w, itemType, b.(*block.Block))
+			itemType = NodeItemBlock
+			nh.renderNodeItem(w, itemType, b.(*block.Block))
 		}
 
 		if options.Mode == GetBlocksOptionsModeFull {
@@ -125,17 +127,17 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 			bk := b.(*block.Block)
 			for _, t := range bk.Transactions {
 				if tx, err = block.GetBlockTransaction(nh.storage, t); err != nil {
-					renderGetBlocksItem(w, GetBlocksDataTypeError, err)
+					nh.renderNodeItem(w, NodeItemError, err)
 					continue
 				}
-				renderGetBlocksItem(w, GetBlocksDataTypeTransaction, tx)
+				nh.renderNodeItem(w, NodeItemBlockTransaction, tx)
 
 				for _, opHash := range tx.Operations {
 					if op, err = block.GetBlockOperation(nh.storage, opHash); err != nil {
-						renderGetBlocksItem(w, GetBlocksDataTypeError, err)
+						nh.renderNodeItem(w, NodeItemError, err)
 						continue
 					}
-					renderGetBlocksItem(w, GetBlocksDataTypeOperation, op)
+					nh.renderNodeItem(w, NodeItemBlockOperation, op)
 				}
 			}
 		}
@@ -144,17 +146,7 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 	return
 }
 
-func renderGetBlocksItem(w http.ResponseWriter, itemType GetBlocksDataType, o interface{}) {
-	s, err := json.Marshal(o)
-	if err != nil {
-		itemType = GetBlocksDataTypeError
-		s = []byte(err.Error())
-	}
-
-	w.Write(append([]byte(itemType+" "), append(s, '\n')...))
-}
-
-func UnmarshalGetBlocksHandlerItem(d []byte) (itemType GetBlocksDataType, b interface{}, err error) {
+func UnmarshalGetBlocksHandlerItem(d []byte) (itemType NodeItemDataType, b interface{}, err error) {
 	sc := bufio.NewScanner(bytes.NewReader(d))
 	sc.Split(bufio.ScanWords)
 	sc.Scan()
@@ -166,25 +158,29 @@ func UnmarshalGetBlocksHandlerItem(d []byte) (itemType GetBlocksDataType, b inte
 		return nil
 	}
 
-	itemType = GetBlocksDataType(sc.Text())
+	itemType = NodeItemDataType(sc.Text())
 	switch itemType {
-	case GetBlocksDataTypeBlock:
+	case NodeItemBlock:
 		var t block.Block
 		err = unmarshal(&t)
 		b = t
-	case GetBlocksDataTypeHeader:
+	case NodeItemBlockHeader:
 		var t block.Header
 		err = unmarshal(&t)
 		b = t
-	case GetBlocksDataTypeTransaction:
+	case NodeItemBlockTransaction:
 		var t block.BlockTransaction
 		err = unmarshal(&t)
 		b = t
-	case GetBlocksDataTypeOperation:
+	case NodeItemBlockOperation:
 		var t block.BlockOperation
 		err = unmarshal(&t)
 		b = t
-	case GetBlocksDataTypeError:
+	case NodeItemTransaction:
+		var t transaction.Transaction
+		err = unmarshal(&t)
+		b = t
+	case NodeItemError:
 		var t errors.Error
 		err = unmarshal(&t)
 		b = t

--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -150,6 +150,9 @@ func UnmarshalNodeItemResponse(d []byte) (itemType NodeItemDataType, b interface
 	sc := bufio.NewScanner(bytes.NewReader(d))
 	sc.Split(bufio.ScanWords)
 	sc.Scan()
+	if err = sc.Err(); err != nil {
+		return
+	}
 
 	unmarshal := func(o interface{}) error {
 		if err := json.Unmarshal(d[len(sc.Bytes())+1:], o); err != nil {

--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -44,7 +44,7 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 		options.SetCursor([]byte(cursorBlock.NewBlockKeyConfirmed()))
 	}
 
-	var bs []interface{}
+	var bs []*block.Block
 	if len(options.Hashes) > 0 {
 		for _, hash := range options.Hashes {
 			if exists, err := block.ExistsBlock(nh.storage, hash); err != nil {
@@ -113,10 +113,10 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 		var itemType NodeItemDataType
 		if options.Mode == GetBlocksOptionsModeHeader {
 			itemType = NodeItemBlockHeader
-			nh.renderNodeItem(w, itemType, b.(*block.Block).Header)
+			nh.renderNodeItem(w, itemType, b.Header)
 		} else {
 			itemType = NodeItemBlock
-			nh.renderNodeItem(w, itemType, b.(*block.Block))
+			nh.renderNodeItem(w, itemType, b)
 		}
 
 		if options.Mode == GetBlocksOptionsModeFull {
@@ -124,8 +124,7 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 			var tx block.BlockTransaction
 			var op block.BlockOperation
 
-			bk := b.(*block.Block)
-			for _, t := range bk.Transactions {
+			for _, t := range b.Transactions {
 				if tx, err = block.GetBlockTransaction(nh.storage, t); err != nil {
 					nh.renderNodeItem(w, NodeItemError, err)
 					continue

--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -146,7 +146,7 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 	return
 }
 
-func UnmarshalGetBlocksHandlerItem(d []byte) (itemType NodeItemDataType, b interface{}, err error) {
+func UnmarshalNodeItemResponse(d []byte) (itemType NodeItemDataType, b interface{}, err error) {
 	sc := bufio.NewScanner(bytes.NewReader(d))
 	sc.Split(bufio.ScanWords)
 	sc.Scan()

--- a/lib/node/runner/api_block_options.go
+++ b/lib/node/runner/api_block_options.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/storage"
 )
 
@@ -105,7 +106,7 @@ func (g *GetBlocksOptions) parseBlockHashes() (err error) {
 	// `hash` can get from post data
 	if g.r.Method == "POST" {
 		if g.r.Header.Get("Content-Type") != "application/json" {
-			err = fmt.Errorf("`Content-Type` must be 'application/json'")
+			err = errors.ErrorContentTypeNotJSON
 			return
 		}
 

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -96,17 +96,17 @@ func (p *HelperTestGetBlocksHandler) Done() {
 	p.st.Close()
 }
 
-func (p *HelperTestGetBlocksHandler) UnmarshalFromResponseBody(body io.ReadCloser) (
-	rbs map[GetBlocksDataType][]interface{},
+func unmarshalFromNodeItemResponseBody(body io.ReadCloser) (
+	rbs map[NodeItemDataType][]interface{},
 	err error,
 ) {
 	defer body.Close()
 
-	rbs = map[GetBlocksDataType][]interface{}{}
+	rbs = map[NodeItemDataType][]interface{}{}
 
 	sc := bufio.NewScanner(body)
 	for sc.Scan() {
-		var itemType GetBlocksDataType
+		var itemType NodeItemDataType
 		var b interface{}
 		itemType, b, err = UnmarshalGetBlocksHandlerItem(sc.Bytes())
 
@@ -134,12 +134,12 @@ func TestGetBlocksHandler(t *testing.T) {
 	require.Nil(t, err)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+	rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 	require.Nil(t, err)
-	require.Equal(t, len(p.blocks), len(rbs[GetBlocksDataTypeHeader]))
+	require.Equal(t, len(p.blocks), len(rbs[NodeItemBlockHeader]))
 
 	for i, b := range p.blocks {
-		rb := rbs[GetBlocksDataTypeHeader][i].(block.Header)
+		rb := rbs[NodeItemBlockHeader][i].(block.Header)
 		require.Equal(t, b.Height, rb.Height)
 
 		s, _ := b.Header.Serialize()
@@ -165,12 +165,12 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 		resp, _ := p.server.Client().Do(req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, len(p.blocks), len(rbs[GetBlocksDataTypeBlock]))
+		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
-			rb := rbs[GetBlocksDataTypeBlock][i].(block.Block)
+			rb := rbs[NodeItemBlock][i].(block.Block)
 			require.Equal(t, b.Hash, rb.Hash)
 
 			s, _ := b.Serialize()
@@ -189,12 +189,12 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 		resp, _ := p.server.Client().Do(req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, int(options.Limit()), len(rbs[GetBlocksDataTypeBlock]))
+		require.Equal(t, int(options.Limit()), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks[:options.Limit()] {
-			rb := rbs[GetBlocksDataTypeBlock][i].(block.Block)
+			rb := rbs[NodeItemBlock][i].(block.Block)
 			require.Equal(t, b.Hash, rb.Hash)
 
 			s, _ := b.Serialize()
@@ -213,12 +213,12 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 		resp, _ := p.server.Client().Do(req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, len(p.blocks), len(rbs[GetBlocksDataTypeBlock]))
+		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
-			rb := rbs[GetBlocksDataTypeBlock][len(p.blocks)-1-i].(block.Block)
+			rb := rbs[NodeItemBlock][len(p.blocks)-1-i].(block.Block)
 			require.Equal(t, b.Hash, rb.Hash)
 
 			s, _ := b.Serialize()
@@ -240,12 +240,12 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 		resp, _ := p.server.Client().Do(req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, len(expectedBlocks), len(rbs[GetBlocksDataTypeBlock]))
+		require.Equal(t, len(expectedBlocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range expectedBlocks {
-			rb := rbs[GetBlocksDataTypeBlock][i].(block.Block)
+			rb := rbs[NodeItemBlock][i].(block.Block)
 			require.Equal(t, b.Hash, rb.Hash)
 
 			s, _ := b.Serialize()
@@ -387,13 +387,13 @@ func TestGetBlocksHandlerWithHeightRange(t *testing.T) {
 		resp, _ := p.server.Client().Do(req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, expectedLength, len(rbs[GetBlocksDataTypeBlock]))
+		require.Equal(t, expectedLength, len(rbs[NodeItemBlock]))
 
 		for i := 1; i < 1+expectedLength; i++ {
 			b := p.blocks[i]
-			rb := rbs[GetBlocksDataTypeBlock][i-1].(block.Block)
+			rb := rbs[NodeItemBlock][i-1].(block.Block)
 			require.Equal(t, b.Height, rb.Height)
 			require.Equal(t, b.Hash, rb.Hash)
 
@@ -420,12 +420,12 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, len(p.blocks), len(rbs[GetBlocksDataTypeHeader]))
+		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlockHeader]))
 
 		for i, b := range p.blocks {
-			rb := rbs[GetBlocksDataTypeHeader][i].(block.Header)
+			rb := rbs[NodeItemBlockHeader][i].(block.Header)
 			require.Equal(t, b.Height, rb.Height)
 
 			s, _ := b.Header.Serialize()
@@ -505,9 +505,9 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 		resp, _ := p.server.Client().Do(req)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, int(expectedLength), len(rbs[GetBlocksDataTypeHeader]))
+		require.Equal(t, int(expectedLength), len(rbs[NodeItemBlockHeader]))
 	}
 }
 
@@ -528,12 +528,12 @@ func TestGetBlocksHandlerWithModeBlock(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, len(p.blocks), len(rbs[GetBlocksDataTypeBlock]))
+		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
-			rb := rbs[GetBlocksDataTypeBlock][i].(block.Block)
+			rb := rbs[NodeItemBlock][i].(block.Block)
 			require.Equal(t, b.Hash, rb.Hash)
 
 			s, _ := b.Serialize()
@@ -560,12 +560,12 @@ func TestGetBlocksHandlerWithModeHeader(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, len(p.blocks), len(rbs[GetBlocksDataTypeHeader]))
+		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlockHeader]))
 
 		for i, b := range p.blocks {
-			rb := rbs[GetBlocksDataTypeHeader][i].(block.Header)
+			rb := rbs[NodeItemBlockHeader][i].(block.Header)
 			require.Equal(t, b.Height, rb.Height)
 
 			s, _ := b.Header.Serialize()
@@ -590,12 +590,12 @@ func TestGetBlocksHandlerWithModeFull(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		rbs, err := p.UnmarshalFromResponseBody(resp.Body)
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
-		require.Equal(t, len(p.blocks), len(rbs[GetBlocksDataTypeBlock]))
+		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
-			rb := rbs[GetBlocksDataTypeBlock][i].(block.Block)
+			rb := rbs[NodeItemBlock][i].(block.Block)
 			require.Equal(t, b.Hash, rb.Hash)
 
 			s, _ := b.Serialize()
@@ -607,7 +607,7 @@ func TestGetBlocksHandlerWithModeFull(t *testing.T) {
 		for _, b := range p.blocks {
 			expectedNumberOfTransactions += len(b.Transactions)
 		}
-		require.Equal(t, expectedNumberOfTransactions, len(rbs[GetBlocksDataTypeTransaction]))
+		require.Equal(t, expectedNumberOfTransactions, len(rbs[NodeItemBlockTransaction]))
 
 		var expectedNumberOfOperations int
 		var txInxdex int
@@ -617,7 +617,7 @@ func TestGetBlocksHandlerWithModeFull(t *testing.T) {
 				tx, _ := block.GetBlockTransaction(p.st, txHash)
 				expectedNumberOfOperations += len(tx.Operations)
 
-				rtx := rbs[GetBlocksDataTypeTransaction][txInxdex].(block.BlockTransaction)
+				rtx := rbs[NodeItemBlockTransaction][txInxdex].(block.BlockTransaction)
 				require.Equal(t, tx.Hash, rtx.Hash)
 
 				s, _ := tx.Serialize()
@@ -627,7 +627,7 @@ func TestGetBlocksHandlerWithModeFull(t *testing.T) {
 				for _, opHash := range tx.Operations {
 					op, _ := block.GetBlockOperation(p.st, opHash)
 
-					rop := rbs[GetBlocksDataTypeOperation][opInxdex].(block.BlockOperation)
+					rop := rbs[NodeItemBlockOperation][opInxdex].(block.BlockOperation)
 					require.Equal(t, op.Hash, rop.Hash)
 
 					s, _ := op.Serialize()
@@ -640,7 +640,7 @@ func TestGetBlocksHandlerWithModeFull(t *testing.T) {
 				txInxdex++
 			}
 		}
-		require.Equal(t, expectedNumberOfOperations, len(rbs[GetBlocksDataTypeOperation]))
+		require.Equal(t, expectedNumberOfOperations, len(rbs[NodeItemBlockOperation]))
 	}
 }
 

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -108,7 +108,7 @@ func unmarshalFromNodeItemResponseBody(body io.ReadCloser) (
 	for sc.Scan() {
 		var itemType NodeItemDataType
 		var b interface{}
-		itemType, b, err = UnmarshalGetBlocksHandlerItem(sc.Bytes())
+		itemType, b, err = UnmarshalNodeItemResponse(sc.Bytes())
 
 		rbs[itemType] = append(rbs[itemType], b)
 	}

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -20,11 +20,12 @@ type NetworkHandlerNode struct {
 	consensus *consensus.ISAAC
 }
 
-func NewNetworkHandlerNode(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend) *NetworkHandlerNode {
+func NewNetworkHandlerNode(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend, consensus *consensus.ISAAC) *NetworkHandlerNode {
 	return &NetworkHandlerNode{
 		localNode: localNode,
 		network:   network,
 		storage:   storage,
+		consensus: consensus,
 	}
 }
 

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -1,11 +1,13 @@
 package runner
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 	"strings"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
@@ -15,6 +17,7 @@ type NetworkHandlerNode struct {
 	localNode *node.LocalNode
 	network   network.Network
 	storage   *storage.LevelDBBackend
+	consensus *consensus.ISAAC
 }
 
 func NewNetworkHandlerNode(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend) *NetworkHandlerNode {
@@ -23,6 +26,20 @@ func NewNetworkHandlerNode(localNode *node.LocalNode, network network.Network, s
 		network:   network,
 		storage:   storage,
 	}
+}
+
+func (api NetworkHandlerNode) renderNodeItem(w http.ResponseWriter, itemType NodeItemDataType, o interface{}) {
+	s, err := json.Marshal(o)
+	if err != nil {
+		itemType = NodeItemError
+		s = []byte(err.Error())
+	}
+
+	api.writeNodeItem(w, itemType, s)
+}
+
+func (api NetworkHandlerNode) writeNodeItem(w http.ResponseWriter, itemType NodeItemDataType, s []byte) {
+	w.Write(append([]byte(itemType+" "), append(s, '\n')...))
 }
 
 func (api NetworkHandlerNode) NodeInfoHandler(w http.ResponseWriter, r *http.Request) {

--- a/lib/node/runner/api_transaction.go
+++ b/lib/node/runner/api_transaction.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
@@ -82,6 +83,7 @@ func (nh NetworkHandlerNode) GetNodeTransactionsHandler(w http.ResponseWriter, r
 			nh.renderNodeItem(w, NodeItemError, err)
 			return
 		}
+		fmt.Println(">>", string(btx.Message))
 		nh.writeNodeItem(w, NodeItemTransaction, btx.Message)
 	}
 

--- a/lib/node/runner/api_transaction.go
+++ b/lib/node/runner/api_transaction.go
@@ -1,0 +1,89 @@
+package runner
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+)
+
+const GetTransactionPattern string = "/transactions"
+
+func (nh NetworkHandlerNode) GetNodeTransactionsHandler(w http.ResponseWriter, r *http.Request) {
+	hashes := r.URL.Query()["hash"]
+	if r.Method == "POST" {
+		if r.Header.Get("Content-Type") != "application/json" {
+			http.Error(w, errors.ErrorContentTypeNotJSON.Error(), http.StatusBadRequest)
+			return
+		}
+
+		body, _ := ioutil.ReadAll(r.Body)
+		defer r.Body.Close()
+
+		if len(body) > 0 {
+			var postHashes []string
+			if err := json.Unmarshal(body, &postHashes); err != nil {
+				http.Error(w, errors.ErrorInvalidQueryString.Error(), http.StatusBadRequest)
+				return
+			}
+
+			hashes = append(hashes, postHashes...)
+		}
+	}
+	if len(hashes) < 1 {
+		http.Error(w, errors.ErrorInvalidQueryString.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Usually `GetNodeTransactionsHandler` will be used for finding the missing
+	// `Transaction`s from proposer, so it can not be over the maximum number of
+	// `Transaction`s in one `Ballot`.
+	if len(hashes) > common.MaxTransactionsInBallot {
+		http.Error(w, errors.ErrorInvalidQueryString.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-SEBAK-RESULT-COUNT", string(len(hashes)))
+
+	unknown := map[string]bool{}
+
+	// check in `TransactionPool`
+	for _, hash := range hashes {
+		if tx, found := nh.consensus.TransactionPool.Get(hash); !found {
+			unknown[hash] = true
+			continue
+		} else {
+			nh.renderNodeItem(w, NodeItemTransaction, tx)
+		}
+	}
+
+	// check in `BlockTransaction`
+	for _, hash := range hashes {
+		if _, found := unknown[hash]; !found {
+			continue
+		}
+
+		if exists, err := block.ExistBlockTransaction(nh.storage, hash); !exists || err != nil {
+			if !exists {
+				err := errors.ErrorTransactionNotFound.Clone().SetData("hash", hash)
+				nh.renderNodeItem(w, NodeItemError, err)
+				continue
+			}
+			nh.renderNodeItem(w, NodeItemError, err)
+			return
+		}
+
+		btx, err := block.GetBlockTransaction(nh.storage, hash)
+		if err != nil {
+			nh.renderNodeItem(w, NodeItemError, err)
+			return
+		}
+		nh.writeNodeItem(w, NodeItemTransaction, btx.Message)
+	}
+
+	return
+}

--- a/lib/node/runner/api_transaction.go
+++ b/lib/node/runner/api_transaction.go
@@ -67,7 +67,7 @@ func (nh NetworkHandlerNode) GetNodeTransactionsHandler(w http.ResponseWriter, r
 			continue
 		}
 
-		if exists, err := block.ExistBlockTransaction(nh.storage, hash); err != nil {
+		if exists, err := block.ExistsBlockTransaction(nh.storage, hash); err != nil {
 			nh.renderNodeItem(w, NodeItemError, err)
 			return
 		} else if !exists {

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -32,7 +32,7 @@ type HelperTestGetNodeTransactionsHandler struct {
 }
 
 func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
-	p.st, _ = storage.NewTestMemoryLevelDBBackend()
+	p.st = storage.NewTestStorage()
 
 	kp, _ := keypair.Random()
 	endpoint, _ := common.NewEndpointFromString(
@@ -43,7 +43,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 		networkID,
 		localNode,
 		nil,
-		network.NewConnectionManager(localNode, nil, nil, nil),
+		network.NewValidatorConnectionManager(localNode, nil, nil, nil),
 	)
 	p.consensus = isaac
 	apiHandler := NetworkHandlerNode{storage: p.st, consensus: isaac}

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -1,0 +1,374 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
+	"github.com/gorilla/mux"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+)
+
+type HelperTestGetNodeTransactionsHandler struct {
+	st                *storage.LevelDBBackend
+	server            *httptest.Server
+	blocks            []block.Block
+	transactionHashes []string
+	consensus         *consensus.ISAAC
+}
+
+func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
+	p.st, _ = storage.NewTestMemoryLevelDBBackend()
+
+	kp, _ := keypair.Random()
+	endpoint, _ := common.NewEndpointFromString(
+		fmt.Sprintf("http://localhost:12345"),
+	)
+	localNode, _ := node.NewLocalNode(kp, endpoint, "")
+	isaac, _ := consensus.NewISAAC(
+		networkID,
+		localNode,
+		nil,
+		network.NewConnectionManager(localNode, nil, nil, nil),
+	)
+	p.consensus = isaac
+	apiHandler := NetworkHandlerNode{storage: p.st, consensus: isaac}
+
+	router := mux.NewRouter()
+	router.HandleFunc(GetTransactionPattern, apiHandler.GetNodeTransactionsHandler).Methods("GET", "POST")
+
+	p.server = httptest.NewServer(router)
+
+	var bks []block.Block
+	for i := 0; i < 3; i++ {
+		bks = append(bks, p.createBlock())
+	}
+
+	for j := 0; j < 3; j++ {
+		_, tx := transaction.TestMakeTransaction(networkID, 2)
+		p.consensus.TransactionPool.Add(tx)
+	}
+
+	p.blocks = bks
+
+	return
+}
+
+func (p *HelperTestGetNodeTransactionsHandler) Done() {
+	p.server.Close()
+	p.st.Close()
+}
+
+func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
+	var txs []transaction.Transaction
+	var txHashes []string
+	for j := 0; j < 2; j++ {
+		_, tx := transaction.TestMakeTransaction(networkID, 2)
+		txHashes = append(txHashes, tx.GetHash())
+		txs = append(txs, tx)
+		p.transactionHashes = append(p.transactionHashes, tx.GetHash())
+	}
+
+	var height int
+	latest, err := block.GetLatestBlock(p.st)
+	if err == nil {
+		height = int(latest.Height)
+	} else {
+		if _, ok := err.(*errors.Error); !ok {
+			panic(err)
+		}
+		height = -1
+	}
+	bk := block.TestMakeNewBlock(txHashes)
+	bk.Height = uint64(height + 1)
+	bk.Save(p.st)
+
+	for _, tx := range txs {
+		b, _ := tx.Serialize()
+		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, tx, b)
+		if err = btx.Save(p.st); err != nil {
+			panic(err)
+		}
+	}
+
+	return bk
+}
+
+func (p *HelperTestGetNodeTransactionsHandler) URL(urlValues url.Values) (u *url.URL) {
+	u, _ = url.Parse(p.server.URL)
+	u.Path = GetTransactionPattern
+
+	if urlValues != nil {
+		u.RawQuery = urlValues.Encode()
+	}
+
+	return
+}
+
+func TestGetNodeTransactionsHandlerWithoutHashes(t *testing.T) {
+	p := &HelperTestGetNodeTransactionsHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	u := p.URL(nil)
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	require.Nil(t, err)
+	resp, err := p.server.Client().Do(req)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	body, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	responseError := errors.Error{}
+	err = json.Unmarshal(body, &responseError)
+	require.Nil(t, err)
+
+	require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
+}
+
+func TestGetNodeTransactionsHandlerWithUnknownHashes(t *testing.T) {
+	p := &HelperTestGetNodeTransactionsHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	{ // only unknown hash
+		unknownHashKey := "unknown-hash-key"
+		u := p.URL(nil)
+		u.RawQuery = fmt.Sprintf("hash=%s", unknownHashKey)
+
+		req, err := http.NewRequest("GET", u.String(), nil)
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
+		require.Nil(t, err)
+		require.Equal(t, 1, len(rbs[NodeItemError]))
+		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(errors.Error).Code)
+		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(errors.Error).Data["hash"])
+	}
+
+	{ // unknown hash + known hash
+		unknownHashKey := "unknown-hash-key"
+		query := url.Values{"hash": []string{unknownHashKey, p.transactionHashes[0]}}
+		u := p.URL(nil)
+		u.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("GET", u.String(), nil)
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
+		require.Nil(t, err)
+		require.Equal(t, 1, len(rbs[NodeItemError]))
+		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(errors.Error).Code)
+		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(errors.Error).Data["hash"])
+
+		require.Equal(t, 1, len(rbs[NodeItemTransaction]))
+
+		tx := rbs[NodeItemTransaction][0].(transaction.Transaction)
+		require.Equal(t, p.transactionHashes[0], tx.GetHash())
+	}
+}
+
+// TestGetNodeTransactionsHandlerPOST checks the basic response in POST method
+func TestGetNodeTransactionsHandlerPOST(t *testing.T) {
+	p := &HelperTestGetNodeTransactionsHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	{ // `Content-Type` must be `application/json`
+		query := url.Values{"hash": []string{p.transactionHashes[0]}}
+		u := p.URL(nil)
+		u.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("POST", u.String(), nil)
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		responseError := errors.Error{}
+		err = json.Unmarshal(body, &responseError)
+		require.Nil(t, err)
+
+		require.Equal(t, errors.ErrorContentTypeNotJSON.Code, responseError.Code)
+	}
+
+	{ // with `Content-Type=application/json`
+		query := url.Values{"hash": []string{p.transactionHashes[1]}}
+		u := p.URL(nil)
+		u.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("POST", u.String(), nil)
+		req.Header.Set("Content-Type", "application/json")
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
+		require.Nil(t, err)
+
+		require.Equal(t, 1, len(rbs))
+		require.Equal(t, 1, len(rbs[NodeItemTransaction]))
+
+		tx := rbs[NodeItemTransaction][0].(transaction.Transaction)
+		require.Equal(t, p.transactionHashes[1], tx.GetHash())
+	}
+}
+
+// TestGetNodeTransactionsHandlerWithMultipleHashes checks multiple transaction hash
+func TestGetNodeTransactionsHandlerWithMultipleHashes(t *testing.T) {
+	p := &HelperTestGetNodeTransactionsHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	{ // GET
+		txHashes := []string{p.transactionHashes[1], p.transactionHashes[len(p.transactionHashes)-2]}
+
+		u := p.URL(nil)
+		query := url.Values{"hash": txHashes}
+		u.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("GET", u.String(), nil)
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
+		require.Nil(t, err)
+
+		require.Equal(t, 1, len(rbs))
+		require.Equal(t, len(txHashes), len(rbs[NodeItemTransaction]))
+
+		for i, hash := range txHashes {
+			tx := rbs[NodeItemTransaction][i].(transaction.Transaction)
+			require.Equal(t, hash, tx.GetHash())
+		}
+	}
+
+	{ // POST
+		u := p.URL(nil)
+
+		txHashes := []string{p.transactionHashes[1], p.transactionHashes[len(p.transactionHashes)-2]}
+		var postData []string
+		postData = append(postData, txHashes...)
+
+		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(common.MustJSONMarshal(postData)))
+		req.Header.Set("Content-Type", "application/json")
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
+		require.Nil(t, err)
+
+		require.Equal(t, 1, len(rbs))
+		require.Equal(t, 2, len(rbs[NodeItemTransaction]))
+
+		for i, hash := range txHashes {
+			tx := rbs[NodeItemTransaction][i].(transaction.Transaction)
+			require.Equal(t, hash, tx.GetHash())
+		}
+	}
+}
+
+// transactions in `TransactionPool`
+func TestGetNodeTransactionsHandlerInTransactionPool(t *testing.T) {
+	p := &HelperTestGetNodeTransactionsHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	{
+		txHashes := []string{
+			p.consensus.TransactionPool.Hashes[1],
+			p.consensus.TransactionPool.Hashes[len(p.consensus.TransactionPool.Hashes)-2],
+		}
+
+		u := p.URL(nil)
+		query := url.Values{"hash": txHashes}
+		u.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("GET", u.String(), nil)
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
+		require.Nil(t, err)
+
+		require.Equal(t, 1, len(rbs))
+		require.Equal(t, 2, len(rbs[NodeItemTransaction]))
+
+		for i, hash := range txHashes {
+			tx := rbs[NodeItemTransaction][i].(transaction.Transaction)
+			require.Equal(t, hash, tx.GetHash())
+		}
+	}
+}
+
+// TestGetNodeTransactionsHandlerTooManyHashes checks when the number of hashes
+// reaches limit, `common.MaxTransactionsInBallot`.
+func TestGetNodeTransactionsHandlerTooManyHashes(t *testing.T) {
+	p := &HelperTestGetNodeTransactionsHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	MaxTransactionsInBallotOrig := common.MaxTransactionsInBallot
+	common.MaxTransactionsInBallot = 2
+	defer func() {
+		common.MaxTransactionsInBallot = MaxTransactionsInBallotOrig
+	}()
+
+	{
+		txHashes := []string{
+			p.consensus.TransactionPool.Hashes[1],
+			p.consensus.TransactionPool.Hashes[len(p.consensus.TransactionPool.Hashes)-2],
+			p.transactionHashes[0],
+			p.transactionHashes[1],
+			p.transactionHashes[2],
+		}
+
+		query := url.Values{"hash": txHashes}
+		u := p.URL(nil)
+		u.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("GET", u.String(), nil)
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		responseError := errors.Error{}
+		err = json.Unmarshal(body, &responseError)
+		require.Nil(t, err)
+
+		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
+	}
+}

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -124,7 +124,7 @@ func NewNodeRunner(
 }
 
 func (nr *NodeRunner) Ready() {
-	nodeHandler := NewNetworkHandlerNode(nr.localNode, nr.network, nr.storage)
+	nodeHandler := NewNetworkHandlerNode(nr.localNode, nr.network, nr.storage, nr.consensus)
 	apiHandler := api.NewNetworkHandlerAPI(nr.localNode, nr.network, nr.storage, network.UrlPathPrefixAPI)
 
 	nr.network.AddHandler(network.UrlPathPrefixNode+"/", nodeHandler.NodeInfoHandler)
@@ -132,6 +132,7 @@ func (nr *NodeRunner) Ready() {
 	nr.network.AddHandler(network.UrlPathPrefixNode+"/message", nodeHandler.MessageHandler)
 	nr.network.AddHandler(network.UrlPathPrefixNode+"/ballot", nodeHandler.BallotHandler)
 	nr.network.AddHandler(network.UrlPathPrefixNode+GetBlocksPattern, nodeHandler.GetBlocksHandler).Methods("GET", "POST")
+	nr.network.AddHandler(network.UrlPathPrefixNode+GetTransactionPattern, nodeHandler.GetNodeTransactionsHandler).Methods("GET", "POST")
 	nr.network.AddHandler("/metrics", promhttp.Handler().ServeHTTP)
 
 	nr.network.AddHandler(


### PR DESCRIPTION
## Github Issue

resolves #212 

## Background

Under the current impl of ISAAC, the incoming `Transaction`s will be
broadcasted, but not verified that the target node really received them. To fill
these missing `Transaction`s, the node will request the unknown `Transaction`s
of the `Ballot` of proposer node. This PR is for it.

## Solution

### `GET|POST /node/transactions`

* Basically the response will be same with `/node/blocks`. For more details #301 . 

#### Options

* `GET`

| name | type | description |
| -- | -- | -- |
| hash | `Hash` string | `Transaction` hash |

* `POST`

Set the list of hash like this,
```
[
  "AAA",
  "BBB",
  "CCC",
  "DDD"
]
```

Document type must be `application/json`. If list of hash is found in query string and post data, they will be merged :)

### Response

```
<NodeItemDataType> <json marshaled data>
```

In this api, there will be 2 `NodeItemDataType`, "transaction"(`NodeItemTransaction`) and "error"(`NodeItemError`).

```
transaction {"T":"transaction","H":{"version":"","created":"2018-09-18T09:52:53.702626239+09:00","hash":"FTJAPEKHNybgFWoBeoMCBuS47Y1Hb85c99eBQQ1ADA99","signature":"4hwYT5uns6QWPajTfXjmMQxbUHx6EuapUxcc83SDDVtd4nJj4JToZuAhR8khAjWPMCdRMC8RFi8oy86bvGzjBd9S"},"B":{"source":"GAPRM34PEEMMC5W4WFLUMGS3WSI2D3HRUSTBSIGHD2EBN7T35EBHTTGO","fee":"10000","sequenceID":0,"operations":[{"H":{"type":"payment"},"B":{"target":"GCTOG5UDXYWJHCR3VYMX3OGSZ4EWNJ56FOZG2U3HTKGQ3WRX3VHM65WI","amount":"495"}},{"H":{"type":"payment"},"B":{"target":"GBT7J5ZDR6COPS6IRMDC5MNZKNSKIP5UASEBG375OQ3JILB52YKVWB5X","amount":"466"}}]}}
```

To parse the response item, `runner.UnmarshalNodeItemResponse` can explain.