### PR TITLE
filter type for operation API

### DIFF
--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -93,6 +93,7 @@ func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 	event += " " + fmt.Sprintf("source-%s", bo.Source)
 	event += " " + fmt.Sprintf("hash-%s", bo.Hash)
 	event += " " + fmt.Sprintf("txhash-%s", bo.TxHash)
+	event += " " + fmt.Sprintf("sourcewithtype-%s%s", bo.Source, bo.Type)
 	observer.BlockOperationObserver.Trigger(event, bo)
 
 	return nil

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -93,7 +93,7 @@ func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 	event += " " + fmt.Sprintf("source-%s", bo.Source)
 	event += " " + fmt.Sprintf("hash-%s", bo.Hash)
 	event += " " + fmt.Sprintf("txhash-%s", bo.TxHash)
-	event += " " + fmt.Sprintf("sourcewithtype-%s%s", bo.Source, bo.Type)
+	event += " " + fmt.Sprintf("source-type-%s%s", bo.Source, bo.Type)
 	observer.BlockOperationObserver.Trigger(event, bo)
 
 	return nil

--- a/lib/network/api/operation.go
+++ b/lib/network/api/operation.go
@@ -21,9 +21,7 @@ func (api NetworkHandlerAPI) GetOperationsByAccountHandler(w http.ResponseWriter
 	address := vars["id"]
 	options, err := storage.NewDefaultListOptionsFromQuery(r.URL.Query())
 
-	oTypeStr := r.URL.Query().Get("type")
-	var oType transaction.OperationType
-	oType = transaction.OperationType(oTypeStr)
+	oType := transaction.OperationType(r.URL.Query().Get("type"))
 
 	if err != nil {
 		http.Error(w, errors.ErrorInvalidQueryString.Error(), http.StatusBadRequest)

--- a/lib/network/api/operation_test.go
+++ b/lib/network/api/operation_test.go
@@ -10,7 +10,7 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/network/api/resource"
-	"boscoin.io/sebak/lib/transaction"
+	"boscoin.io/sebak/lib/transaction/operation"
 	"github.com/stretchr/testify/require"
 	"strings"
 	"sync"
@@ -61,7 +61,7 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	// Do a Request
 	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
 	{
-		url := url + "?type=" + string(transaction.OperationCreateAccount)
+		url := url + "?type=" + string(operation.TypeCreateAccount)
 		respBody, err := request(ts, url, false)
 		require.Nil(t, err)
 		defer respBody.Close()
@@ -77,7 +77,7 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	}
 
 	{
-		url := url + "?type=" + string(transaction.OperationPayment)
+		url := url + "?type=" + string(operation.TypePayment)
 		respBody, err := request(ts, url, false)
 		require.Nil(t, err)
 		defer respBody.Close()

--- a/lib/network/api/operation_test.go
+++ b/lib/network/api/operation_test.go
@@ -10,6 +10,7 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/network/api/resource"
+	"boscoin.io/sebak/lib/transaction"
 	"github.com/stretchr/testify/require"
 	"strings"
 	"sync"
@@ -45,6 +46,58 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 		hash := bt["hash"].(string)
 
 		require.Equal(t, hash, boList[i].Hash, "hash is not same")
+	}
+}
+
+func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
+	ts, storage, err := prepareAPIServer()
+	require.Nil(t, err)
+	defer storage.Close()
+	defer ts.Close()
+
+	kp, boList, err := prepareOps(storage, 0, 10, nil)
+	require.Nil(t, err)
+
+	// Do a Request
+	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
+	{
+		url := url + "?type=" + string(transaction.OperationCreateAccount)
+		respBody, err := request(ts, url, false)
+		require.Nil(t, err)
+		defer respBody.Close()
+		reader := bufio.NewReader(respBody)
+
+		readByte, err := ioutil.ReadAll(reader)
+		require.Nil(t, err)
+
+		recv := make(map[string]interface{})
+		json.Unmarshal(readByte, &recv)
+		records := recv["_embedded"].(map[string]interface{})["records"]
+		require.Nil(t, records)
+	}
+
+	{
+		url := url + "?type=" + string(transaction.OperationPayment)
+		respBody, err := request(ts, url, false)
+		require.Nil(t, err)
+		defer respBody.Close()
+		reader := bufio.NewReader(respBody)
+
+		readByte, err := ioutil.ReadAll(reader)
+		require.Nil(t, err)
+
+		recv := make(map[string]interface{})
+		json.Unmarshal(readByte, &recv)
+		records := recv["_embedded"].(map[string]interface{})["records"].([]interface{})
+
+		require.Equal(t, len(boList), len(records), "length is not same")
+
+		for i, r := range records {
+			bt := r.(map[string]interface{})
+			hash := bt["hash"].(string)
+
+			require.Equal(t, hash, boList[i].Hash, "hash is not same")
+		}
 	}
 
 }

--- a/lib/transaction/operation/operation.go
+++ b/lib/transaction/operation/operation.go
@@ -20,6 +20,18 @@ const (
 	TypeInflation            OperationType = "inflation"
 )
 
+func IsValidOperationType(oType string) bool {
+	_, b := common.InStringArray([]string{
+		string(TypeCreateAccount),
+		string(TypePayment),
+		string(TypeCongressVoting),
+		string(TypeCongressVotingResult),
+		string(TypeCollectTxFee),
+		string(TypeInflation),
+	}, oType)
+	return b
+}
+
 var KindsNormalTransaction map[OperationType]struct{} = map[OperationType]struct{}{
 	TypeCreateAccount:        struct{}{},
 	TypePayment:              struct{}{},


### PR DESCRIPTION
### Github Issue
#394 

### Background
#356 #311 
Operation API support query for `type`

### Solution
There are 2 alternatives

1. reverse index for operation
Write Heavy, Read Light
Make one more set for operation index with `type-xxx` prefix

2. filter out not matched
Write Light, Read Heavy
No index added
Filter out not matched object at the handler

IMO,
This usage is rarely called.
Hence, I adopted the second option

### Possible Drawbacks
Or... Is it really needed?