### PR TITLE
Transaction: Do not rely on sender's hash

### DIFF
--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -179,9 +179,7 @@ func UnmarshalNodeItemResponse(d []byte) (itemType NodeItemDataType, b interface
 		err = unmarshal(&t)
 		b = t
 	case NodeItemTransaction:
-		var t transaction.Transaction
-		err = unmarshal(&t)
-		b = t
+		b, err = transaction.NewTransactionFromJSON(d[len(sc.Bytes())+1:])
 	case NodeItemError:
 		var t errors.Error
 		err = unmarshal(&t)

--- a/lib/node/runner/checker_message_test.go
+++ b/lib/node/runner/checker_message_test.go
@@ -71,7 +71,7 @@ func TestMessageChecker(t *testing.T) {
 	require.Equal(t, err, errors.ErrorNewButKnownMessage)
 }
 
-func TestMessageCheckerWithInvalidMessage(t *testing.T) {
+func TestMessageCheckerWithInvalidHash(t *testing.T) {
 	_, invalidTx := transaction.TestMakeTransaction(networkID, 1)
 	invalidTx.H.Hash = "wrong hash"
 
@@ -92,11 +92,10 @@ func TestMessageCheckerWithInvalidMessage(t *testing.T) {
 	}
 
 	err = TransactionUnmarshal(checker)
-	require.EqualError(t, err, errors.ErrorSignatureVerificationFailed.Message)
+	require.Nil(t, err)
 
 	checker.Message.Data = []byte{}
 	err = TransactionUnmarshal(checker)
 	require.EqualError(t, err, "unexpected end of JSON input")
 	require.NotEqual(t, checker.Transaction, invalidTx)
-
 }

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -55,6 +55,9 @@ func NewTransactionFromJSON(b []byte) (tx Transaction, err error) {
 		Operations: operations,
 	}
 
+	// Set the hash
+	tx.H.Hash = tx.B.MakeHashString()
+
 	return
 }
 
@@ -90,7 +93,6 @@ var TransactionWellFormedCheckerFuncs = []common.CheckerFunc{
 	CheckTransactionBaseFee,
 	CheckTransactionOperation,
 	CheckTransactionVerifySignature,
-	CheckTransactionHashMatch,
 }
 
 func (tx Transaction) IsWellFormed(networkID []byte) (err error) {
@@ -173,9 +175,12 @@ func (tx *Transaction) Sign(kp keypair.KP, networkID []byte) {
 }
 
 type TransactionHeader struct {
-	Version   string `json:"version"`
-	Created   string `json:"created"`
-	Hash      string `json:"hash"`
+	Version string `json:"version"`
+	Created string `json:"created"`
+	// Hash of this transaction
+	// This is cached and not serialized when sent, because the remote node
+	// has to validate it anyway.
+	Hash      string `json:"-"`
 	Signature string `json:"signature"`
 }
 

--- a/lib/transaction/transaction_checker.go
+++ b/lib/transaction/transaction_checker.go
@@ -100,13 +100,3 @@ func CheckTransactionVerifySignature(c common.Checker, args ...interface{}) (err
 	}
 	return
 }
-
-func CheckTransactionHashMatch(c common.Checker, args ...interface{}) (err error) {
-	checker := c.(*TransactionChecker)
-	if checker.Transaction.H.Hash != checker.Transaction.B.MakeHashString() {
-		err = errors.ErrorHashDoesNotMatch
-		return
-	}
-
-	return
-}

--- a/tests/account-creation/request_1_2821_create_account_1.json
+++ b/tests/account-creation/request_1_2821_create_account_1.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-01-01T00:00:00.000000000Z",
-    "hash": "B9n71T2RwHPFY7uyZKZh9tXCdRCHAngakoZQXw5ZExfQ",
     "signature": "5zdcFUaYAXZ7ZNyKWzfw2b9GENS65mFtgXC4KVcXhJWAARGAHLa1faewwdCEMuQVgaHQojd6r86svXP8xn4zKvCT"
   },
   "B": {

--- a/tests/account-creation/request_2_2822_pay_to_account_1.json
+++ b/tests/account-creation/request_2_2822_pay_to_account_1.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-01-01T00:00:00.000000000Z",
-    "hash": "2g3ZSrEnsUWeX5Mxz5uTh2b4KVpVQS7Ek2HzZd759FHn",
     "signature": "3oWmCMNHExRQnZVEBSH16ZBgLE6ayz7t1fsjzTjAB6WpXMpkDJbhcL8KudqFFG21XmfSXnJH1BLhnBUh4p68yFeR"
   },
   "B": {

--- a/tests/overdraft/request_1_2821_create_account_1.json
+++ b/tests/overdraft/request_1_2821_create_account_1.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-09-19T04:25:53.763285000Z",
-    "hash": "4Rh1z7QdfUK9QyHCknj8RupZEEoogFSXjrWpFKkUrrTR",
     "signature": "5kSPFsUcDncs5y8Gz7hA6y2qYMipzJYYcfaT9qchhyLBGKj8JrZ4eCMv3WA1URLJvUfeZxu1TpFf1oxGgJ7bxiEY"
   },
   "B": {

--- a/tests/overdraft/request_2_2821_no_amount_tx.json
+++ b/tests/overdraft/request_2_2821_no_amount_tx.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-09-19T04:26:41.304736300Z",
-    "hash": "GEJ3Qs3Q38aspLmarqhZUq9wi2pdXWBQTmkFQdNPGnhv",
     "signature": "43efdDCVdc3MrvH5cKfKn88CYV9oGnPGNzcYRtycEPvWjoZRMZkCNZ6H6kaGpGRSL7SUkuS5YaR2QYsbEbpLQYGV"
   },
   "B": {

--- a/tests/overdraft/request_3_2823_one_gon_payment.json
+++ b/tests/overdraft/request_3_2823_one_gon_payment.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-09-19T04:27:28.824927300Z",
-    "hash": "92G8WeyUptheSQDN6c8cZqKU8xDfVegNsYdmgFsvn3w",
     "signature": "659Z4JeLpz2i27nyN6gaDDhHQs87pSuU6ms6JAwJEwWrsh7A6o6UpjW9nH54wzYnJYPKt9oEwdZA4RbFxDPQyJ1v"
   },
   "B": {

--- a/tests/overdraft/request_4_2823_overdraft_by_99.json
+++ b/tests/overdraft/request_4_2823_overdraft_by_99.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-09-19T04:32:24.190227000Z",
-    "hash": "2uwCUyWvFdoHXnotSFYGYcbfaoAS1TkNpNSVMZW8Sbmr",
     "signature": "3ZV2NDzf58Fk7Trahv85ySyEU8jLhTxVpVnH7Z11guGRVj36UT8cii3UQ4tRqKRYkg3uaGEQULBTTsRa5GqgcwSc"
   },
   "B": {

--- a/tests/overdraft/request_5_2821_overdraft_by_1.json
+++ b/tests/overdraft/request_5_2821_overdraft_by_1.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-09-19T04:33:14.525390700Z",
-    "hash": "2LXq9id9RBsmGkKYb9kVpYFbSJapmUfbtPhuUL2NnXC9",
     "signature": "5jkAYUNEAD4rjboxByeuDfcXYinG9QBmB31JhAAeu9jsxThZrxDxe3JjVV1s1xYxALhDwUkVDzsbAsJybwJnXwkC"
   },
   "B": {

--- a/tests/overdraft/request_6_2821_emptying_account.json
+++ b/tests/overdraft/request_6_2821_emptying_account.json
@@ -3,7 +3,6 @@
   "H": {
     "version": "",
     "created": "2018-09-19T04:33:43.341709100Z",
-    "hash": "8jhDqTKspd82R8Dcvr5tKEm3G6XcuRrahuSAAvzR9zCo",
     "signature": "k6J6y6jXxSUuHHu84Cgu9BbMkG4k7bCZPdkZH76M3umxgYwVUAWG1PADXMFUyf1yu2vHLAFFQHgJhAd8qYwgPjD"
   },
   "B": {


### PR DESCRIPTION
```
It does not make sense to include the tx hash in the query,
because we have to validate it anyway.
Instead, just omit it and calculate it on deserialization,
saving both bandwidth and CPU time.
```

Found when working on #387 and #412 
It will also make tests easier to update :)