### PR TITLE
Fix argon2 salt length over 16 bytes

### DIFF
--- a/lib/common/hash.go
+++ b/lib/common/hash.go
@@ -7,7 +7,7 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
-var HashSalt = []byte("sebak")
+var HashSalt = []byte("boscoin-sebak-network")
 
 func MakeHash(b []byte) []byte {
 	return argon2.Key(b, HashSalt, 3, 32*1024, 4, 32)

--- a/lib/transaction/operation_test.go
+++ b/lib/transaction/operation_test.go
@@ -23,7 +23,7 @@ func TestMakeHashOfOperationBodyPayment(t *testing.T) {
 	}
 	hashed := op.MakeHashString()
 
-	expected := "8AALKhfgCu2w3ZtbESXHG5ko93Jb1L1yCmFopoJubQh9"
+	expected := "EtjjYMYZEoY21VyG6VnMK2Bzc3DoYYXcEDC23nmZi83R"
 	require.Equal(t, hashed, expected)
 }
 

--- a/tests/account-creation/request_1_2821_create_account_1.json
+++ b/tests/account-creation/request_1_2821_create_account_1.json
@@ -3,7 +3,7 @@
   "H": {
     "version": "",
     "created": "2018-01-01T00:00:00.000000000Z",
-    "signature": "3KKJupeKutdTkh7PnasZ2TVe3YvkoApVxZmiq596JroMYrjnRswXbj9oAzsp3rh5aS9RdT1K8udHUmJrjQQVgbBC"
+    "signature": "3R2EGcq2LTogf9b4h8zEESMYg9R7Quz35gaiFYeWASb44tZgyuzv3yDH7my6C9tDt3QDCfGpaLxFYN5MDfTruDQn"
   },
   "B": {
     "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",

--- a/tests/account-creation/request_2_2822_pay_to_account_1.json
+++ b/tests/account-creation/request_2_2822_pay_to_account_1.json
@@ -3,7 +3,7 @@
   "H": {
     "version": "",
     "created": "2018-01-01T00:00:00.000000000Z",
-    "signature": "3oWmCMNHExRQnZVEBSH16ZBgLE6ayz7t1fsjzTjAB6WpXMpkDJbhcL8KudqFFG21XmfSXnJH1BLhnBUh4p68yFeR"
+    "signature": "XgRa2q9WEn5wTadbzVfiL8aCNSzwGZd2aNxE43yafDsNdFDksLMLoAn5Ws98nU5ngsGCJdFspmTJBrJ5ZieWJmu"
   },
   "B": {
     "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",

--- a/tests/overdraft/README.md
+++ b/tests/overdraft/README.md
@@ -25,10 +25,10 @@ here is how to do it.
 ## Commands used
 
 ```sh
-docker run --network host -it sebak wallet payment ${PUBKEY3} 10_000 ${SECRET1} --endpoint=https://127.0.0.1:2821 --create --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY3} 1000000 ${SECRET1} --endpoint=https://127.0.0.1:2821 --create --verbose
 docker run --network host -it sebak wallet payment ${PUBKEY3} 0 ${SECRET1} --endpoint=https://127.0.0.1:2821 --verbose
 docker run --network host -it sebak wallet payment ${PUBKEY3} 1 ${SECRET1} --endpoint=https://127.0.0.1:2821 --verbose
-docker run --network host -it sebak wallet payment ${PUBKEY1} 100 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
-docker run --network host -it sebak wallet payment ${PUBKEY1} 2 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
-docker run --network host -it sebak wallet payment ${PUBKEY1} 1 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY1} 999000 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY1} 990001 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY1} 990001 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
 ```

--- a/tests/overdraft/request_1_2821_create_account_1.json
+++ b/tests/overdraft/request_1_2821_create_account_1.json
@@ -3,7 +3,7 @@
   "H": {
     "version": "",
     "created": "2018-09-27T16:26:22.830373928+09:00",
-    "signature": "5TVx3JQHgZhHGcNLAyLfJQfssu4Hh7QRWBfjymEd7i1yC2s3yjSjKs92nwdkupKjFsQdbUNZHdkSQhicrT8ZSVWz"
+    "signature": "dtKmTGnYfkkv3ZBCxtKUSHYL3dMzWDM8NSQJq4uMdcc5GqVaRDwpmAS29M7LUKTcBnz93Q6aGFRh2x7gyB9eX8t"
   },
   "B": {
     "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",

--- a/tests/overdraft/request_2_2821_no_amount_tx.json
+++ b/tests/overdraft/request_2_2821_no_amount_tx.json
@@ -3,12 +3,12 @@
   "H": {
     "version": "",
     "created": "2018-09-27T16:11:35.177557660+09:00",
-    "signature": "28p4QQ52UCCiioSmQv6d76f5mdcxfbfkVYtfYayzx4G2cPJDKE6j8mkiQakT5SfFDDYTzkLVvMbY69j81rKHRQRZ"
+    "signature": "jPiRoP1xLT9bBvi8DKVE9TEgMHfdv3eVvo4ccypvJxrJGZGSMBFNiWancDXGHtwVq5KWDzcicZYZU7Coyp1Ru7x"
   },
   "B": {
     "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",
     "fee": "10000",
-    "sequenceID": 0,
+    "sequenceID": 1,
     "operations": [
       {
         "H": {

--- a/tests/overdraft/request_3_2823_one_gon_payment.json
+++ b/tests/overdraft/request_3_2823_one_gon_payment.json
@@ -3,7 +3,7 @@
   "H": {
     "version": "",
     "created": "2018-09-19T04:27:28.824927300Z",
-    "signature": "659Z4JeLpz2i27nyN6gaDDhHQs87pSuU6ms6JAwJEwWrsh7A6o6UpjW9nH54wzYnJYPKt9oEwdZA4RbFxDPQyJ1v"
+    "signature": "2vo9PkjXte4QqXhr9yBVUbZFZSsPS6MnzsSZGaTqnwTi5CdzSkyw6sbfpwThrPQcS7V4J68UXV7cQW1Z9FhXCPDb"
   },
   "B": {
     "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",

--- a/tests/overdraft/request_4_2823_overdraft_by_99.json
+++ b/tests/overdraft/request_4_2823_overdraft_by_99.json
@@ -3,7 +3,7 @@
   "H": {
     "version": "",
     "created": "2018-09-27T14:33:37.938031382+09:00",
-    "signature": "uVfEmWiRDampA22wjGjAaRa8PmpMaZQ9yjdT1KwX6BKee85hPKvvaorU8kS6iDexQ1G5ziyxLbEE2rQtXLD2KWj"
+    "signature": "5kM4wk1eQugqr1oYpoBWQFXcKTc3VvYenRTD6HjZJrkRRrHVmw3fcqEZFraGwj8EmFWi6oN7HEAphYjc47f2VRGC"
   },
   "B": {
     "source": "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4",

--- a/tests/overdraft/request_5_2821_overdraft_by_1.json
+++ b/tests/overdraft/request_5_2821_overdraft_by_1.json
@@ -3,7 +3,7 @@
   "H": {
     "version": "",
     "created": "2018-09-27T14:34:59.042780273+09:00",
-    "signature": "3SSWV2Mo6wrJSF5QgtLuLCPR2g6ECL73tQRoB8Pbc9LT8X57bbrMHGk66pHjd1kBY5GzuumzxDgCU2mm9patQzSp"
+    "signature": "2skNFLYJuaLEuAndNsND5sQv4uxHxAKiqzSAjFG7Yn6bYMkHqFathUE8PrNbSoFisaMQbP2csFi8CdDRy1akz3RY"
   },
   "B": {
     "source": "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4",

--- a/tests/overdraft/request_6_2821_emptying_account.json
+++ b/tests/overdraft/request_6_2821_emptying_account.json
@@ -3,7 +3,7 @@
   "H": {
     "version": "",
     "created": "2018-09-27T14:27:28.050051320+09:00",
-    "signature": "4GQwemoXaStJpsRutWVEPbx1fwFn5k9pcTPvFymS46yyNyaXKiyVyfbQFJaR2Ro7p54DuNbLwPHXVCvUkq4fP5wK"
+    "signature": "2yho374KpZ69s9uBpProvJyqHT7evGhT757avfQPqMvp7aAKUbBohiw92SxyWc7FxAMcA27CxMufjwwQD9WWc5EZ"
   },
   "B": {
     "source": "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4",


### PR DESCRIPTION
### Github Issue
N/A

### Background
While implementing hashing in JavaScript, I found the salt length for Argon2 is only 5 bytes. 
However, [JavaScript Argon2 library](https://github.com/ranisalt/node-argon2) thrown an error `Error: Salt is too short` when I use `sebak` as the salt. 
[As IETF argon2 documents](https://tools.ietf.org/id/draft-josefsson-argon2-00.html#rfc.section.3.1) said:

> Nonce S, typically a random salt. May have any length from 8 to 2^32 - 1 bytes. 16 bytes is recommended for password hashing. 

### Solution
Increase the salt length over 16 bytes.

### Possible Drawbacks
I don't know. Performance maybe? 
