### PR TITLE
Doc: Add paging section (api)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,6 +8,7 @@ SEBAK, the next BOScoin Tokennet with ISAAC consensus protocol
 <!-- partial(v1/models.md) -->
 <!-- partial(/v1/transactions.md) -->
 
+<!-- include(v1/paging.md) -->
 <!-- include(v1/accounts.md) -->
 <!-- include(v1/transactions.md) -->
 <!-- include(v1/models.md) -->

--- a/docs/v1/paging.md
+++ b/docs/v1/paging.md
@@ -1,0 +1,21 @@
+## Paging
+
+Pages represent a subset of a larger collection of objects. The SEBAK HTTP API utilizes `cursoring` to paginate large result sets. Cursoring separates results into pages 
+
+<h3> Cursor </h3>
+
+A `cursor` is a point to a specific location in resources. 
+
+<h3> Embedded Resources </h3>
+
+A page containts an embedded set of `records`, regardless of the contained resource.
+
+<h4> Links </h4> 
+
+|        | Example                                                |  Relation                          | 
+|--------|--------------------------------------------------------|------------------------------------|
+| Self   | `/transactions`                                        |                                    | 
+| Prev   | `/transactions?cursor={cursor}&reverse=false&limit=10` | The prevuous page of results       |
+| Next   | `/transactions?cursor={cursor}&reverse=true&limit=19`  | The next page of results           |
+
+


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

- Add Paging section, but It needs example sub section.. 


### Solution

![image](https://user-images.githubusercontent.com/12271/45731543-0f2fee00-bc13-11e8-859c-0d1937940af5.png)


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

For good navi-bar, I have to do like below:  ㅠ_ㅠ

```
## Paging

Pages represent a subset of a larger collection of objects. The SEBAK HTTP API utilizes `cursoring` to paginate large result sets. Cursoring separates results into pages

<h3> Cursor </h3>

A `cursor` is a point to a specific location in resources.

<h3> Embedded Resources </h3>

A page containts an embedded set of `records`, regardless of the contained resource.

<h4> Links </h4>
```
