### PR TITLE
Fixed the empty `Ballot.H.Hash`

### DIFF
--- a/lib/ballot/ballot_test.go
+++ b/lib/ballot/ballot_test.go
@@ -139,3 +139,13 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 		require.Error(t, err, errors.ErrorMessageHasIncorrectTime)
 	}
 }
+
+func TestBallotEmptyHash(t *testing.T) {
+	kp, _ := keypair.Random()
+	localNode, _ := node.NewLocalNode(kp, &common.Endpoint{}, "")
+	r := round.Round{}
+	b := NewBallot(localNode, r, []string{})
+	b.Sign(kp, networkID)
+
+	require.True(t, len(b.GetHash()) > 0)
+}

--- a/lib/error/base.go
+++ b/lib/error/base.go
@@ -1,11 +1,17 @@
 package errors
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"io"
+	"sort"
+
+	"github.com/ethereum/go-ethereum/rlp"
+)
 
 type Error struct {
-	Code    uint   `json:"code"`
-	Message string `json:"message"`
-	Data    map[string]interface{}
+	Code    uint                   `json:"code"`
+	Message string                 `json:"message"`
+	Data    map[string]interface{} `json:"data" rlp:"-"`
 }
 
 func (o *Error) Serialize() (b []byte, err error) {
@@ -18,7 +24,6 @@ func (o *Error) Error() string {
 	return string(b)
 }
 
-// SetData sets `Error.Data`
 func (o *Error) SetData(k string, v interface{}) *Error {
 	o.Data[k] = v
 
@@ -26,18 +31,45 @@ func (o *Error) SetData(k string, v interface{}) *Error {
 }
 
 func (o *Error) Clone() *Error {
-	data := map[string]interface{}{}
-	if o.Data != nil {
+	var new Error
+	new = *o
+
+	new.Data = map[string]interface{}{}
+	if o.Data != nil && len(o.Data) > 0 {
 		for k, v := range o.Data {
-			data[k] = v
+			new.Data[k] = v
 		}
 	}
 
-	return &Error{
+	return &new
+}
+
+func (o *Error) EncodeRLP(w io.Writer) (err error) {
+	if o == nil {
+		return rlp.Encode(w, []uint{})
+	}
+
+	if o.Data != nil && len(o.Data) > 0 {
+		var d [][2]interface{}
+
+		var keys []string
+		for k, _ := range o.Data {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			d = append(d, [2]interface{}{k, o.Data[k]})
+		}
+		err = rlp.Encode(w, d)
+	}
+
+	return rlp.Encode(w, struct {
+		Code    uint
+		Message string
+	}{
 		Code:    o.Code,
 		Message: o.Message,
-		Data:    data,
-	}
+	})
 }
 
 func NewError(code uint, message string) *Error {

--- a/lib/error/base_test.go
+++ b/lib/error/base_test.go
@@ -1,0 +1,45 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrorsClone(t *testing.T) {
+	require.Equal(t, ErrorBlockAlreadyExists, ErrorBlockAlreadyExists)
+
+	e := ErrorBlockAlreadyExists
+	e0 := ErrorBlockAlreadyExists.Clone()
+	require.NotEqual(t, fmt.Sprintf("%p", e), fmt.Sprintf("%p", e0))
+
+	{
+		e.Code = 200
+		require.NotEqual(t, e.Code, e0.Code)
+	}
+
+	{
+		e0.SetData("showme", "killme")
+		require.NotEqual(t, e.Data, e0.Data)
+	}
+}
+
+func TestErrorsRLP(t *testing.T) {
+	{
+		_, err := rlp.EncodeToBytes(ErrorBlockAlreadyExists)
+		require.Nil(t, err)
+	}
+
+	{ // with `SetData()`, the rlp encoded value must be different
+		encoded, err := rlp.EncodeToBytes(ErrorBlockAlreadyExists)
+		require.Nil(t, err)
+
+		e := ErrorBlockAlreadyExists.Clone()
+		e.SetData("findme", "killme")
+		encoded0, err := rlp.EncodeToBytes(e)
+		require.Nil(t, err)
+		require.NotEqual(t, encoded, encoded0)
+	}
+}


### PR DESCRIPTION
### Github Issue

resolves #451 

### Background

The `Ballot.H.Hash` is empty in the serialized output.

### Solution

This was caused by `rlp.Encode()` for `errors.Error.Data`.
