### PR TITLE
Genesis block should have valid transaction

### DIFF
--- a/lib/block/block.go
+++ b/lib/block/block.go
@@ -66,7 +66,7 @@ func MakeGenesisBlock(st *storage.LevelDBBackend, account BlockAccount, networdI
 	}
 
 	// create create-account transaction.
-	opb := transaction.NewOperationBodyCreateAccount(account.Address, account.Balance)
+	opb := transaction.NewOperationBodyCreateAccount(account.Address, account.Balance, "")
 	op := transaction.Operation{
 		H: transaction.OperationHeader{
 			Type: transaction.OperationCreateAccount,

--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -154,7 +154,7 @@ func TestMakeGenesisBlock(t *testing.T) {
 	require.Equal(t, account.Address, bo.Source)
 
 	{
-		opb, err := bo.LoadBody()
+		opb, err := transaction.UnmarshalOperationBodyJSON(bo.Type, bo.Body)
 		require.Nil(t, err)
 
 		opbp := opb.(transaction.OperationBodyPayable)
@@ -214,7 +214,7 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 		bt, _ := GetBlockTransaction(st, bk.Transactions[0])
 		bo, _ := GetBlockOperation(st, bt.Operations[0])
 
-		opb, err := bo.LoadBody()
+		opb, err := transaction.UnmarshalOperationBodyJSON(bo.Type, bo.Body)
 		require.Nil(t, err)
 
 		opbp := opb.(transaction.OperationBodyPayable)

--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -152,8 +152,16 @@ func TestMakeGenesisBlock(t *testing.T) {
 	require.Equal(t, bt.Hash, bo.TxHash)
 	require.Equal(t, transaction.OperationCreateAccount, bo.Type)
 	require.Equal(t, account.Address, bo.Source)
-	require.Equal(t, account.Address, bo.Target)
-	require.Equal(t, account.Balance, bo.Amount)
+
+	{
+		opb, err := bo.LoadBody()
+		require.Nil(t, err)
+
+		opbp := opb.(transaction.OperationBodyPayable)
+
+		require.Equal(t, account.Address, opbp.TargetAddress())
+		require.Equal(t, account.Balance, opbp.GetAmount())
+	}
 }
 
 func TestMakeGenesisBlockOverride(t *testing.T) {
@@ -206,7 +214,12 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 		bt, _ := GetBlockTransaction(st, bk.Transactions[0])
 		bo, _ := GetBlockOperation(st, bt.Operations[0])
 
-		genesisAccount, err := GetBlockAccount(st, bo.Target)
+		opb, err := bo.LoadBody()
+		require.Nil(t, err)
+
+		opbp := opb.(transaction.OperationBodyPayable)
+
+		genesisAccount, err := GetBlockAccount(st, opbp.TargetAddress())
 		require.Nil(t, err)
 
 		require.Equal(t, account.Address, genesisAccount.Address)

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -138,10 +138,6 @@ func (bo BlockOperation) NewBlockOperationSourceKey() string {
 	)
 }
 
-func (bo BlockOperation) LoadBody() (body transaction.OperationBody, err error) {
-	return transaction.UnmarshalOperationBodyJSON(bo.Type, bo.Body)
-}
-
 func ExistsBlockOperation(st *storage.LevelDBBackend, hash string) (bool, error) {
 	return st.Has(GetBlockOperationKey(hash))
 }

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -138,6 +138,10 @@ func (bo BlockOperation) NewBlockOperationSourceKey() string {
 	)
 }
 
+func (bo BlockOperation) LoadBody() (body transaction.OperationBody, err error) {
+	return transaction.UnmarshalOperationBodyJSON(bo.Type, bo.Body)
+}
+
 func ExistsBlockOperation(st *storage.LevelDBBackend, hash string) (bool, error) {
 	return st.Has(GetBlockOperationKey(hash))
 }

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -10,6 +10,10 @@ const (
 	// BaseReserve is minimum amount of balance for new account. By default, it
 	// is `0.1` BOS.
 	BaseReserve Amount = 1000000
+
+	// GenesisBlockConfirmedTime is the time for the confirmed time of genesis
+	// block. This time is of the first commit of SEBAK.
+	GenesisBlockConfirmedTime string = "2018-04-17T5:07:31.000000000Z"
 )
 
 var (

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -111,7 +111,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Netw
 		balance := common.BaseFee.MustAdd(common.BaseReserve)
 		account := block.NewBlockAccount(address, balance)
 		account.Save(st)
-		block.MakeGenesisBlock(st, *account)
+		block.MakeGenesisBlock(st, *account, networkID)
 	}
 	conf := consensus.NewISAACConfiguration()
 	if nodeRunner, err = NewNodeRunner(string(networkID), localNode, p, n, is, st, conf); err != nil {

--- a/lib/node/runner/isaac_voting_empty_transaction_test.go
+++ b/lib/node/runner/isaac_voting_empty_transaction_test.go
@@ -38,7 +38,7 @@ func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
 	nr.Consensus().SetLatestConsensusedBlock(genesisBlock)
 	latestBlock := nr.Consensus().LatestConfirmedBlock()
 	require.Equal(t, uint64(1), latestBlock.Height)
-	require.Equal(t, uint64(0), latestBlock.TotalTxs)
+	require.Equal(t, uint64(1), latestBlock.TotalTxs)
 
 	// Generate proposed ballot in nr
 	err := nr.proposeNewBallot(0)
@@ -96,6 +96,6 @@ func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
 	lastConfirmedBlock := nr.Consensus().LatestConfirmedBlock()
 	require.Equal(t, proposer.Address(), lastConfirmedBlock.Proposer)
 	require.Equal(t, uint64(2), lastConfirmedBlock.Height)
-	require.Equal(t, uint64(0), lastConfirmedBlock.TotalTxs)
+	require.Equal(t, uint64(1), lastConfirmedBlock.TotalTxs)
 	require.Equal(t, 0, len(lastConfirmedBlock.Transactions))
 }

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -71,7 +71,7 @@ func createTestNodeRunner(n int, conf *consensus.ISAACConfiguration) []*NodeRunn
 		st := storage.NewTestStorage()
 
 		account.Save(st)
-		genesisBlock = block.MakeGenesisBlock(st, *account)
+		genesisBlock, _ = block.MakeGenesisBlock(st, *account, networkID)
 
 		nr, err := NewNodeRunner(string(networkID), localNode, policy, ns[i], is, st, conf)
 		if err != nil {
@@ -173,7 +173,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 		is, _ := consensus.NewISAAC(networkID, node, policy, connectionManager)
 
 		genesisAccount.Save(st)
-		block.MakeGenesisBlock(st, *genesisAccount)
+		block.MakeGenesisBlock(st, *genesisAccount, networkID)
 
 		nodeRunner, _ := NewNodeRunner(string(networkID), node, policy, n, is, st, consensus.NewISAACConfiguration())
 		nodeRunners = append(nodeRunners, nodeRunner)
@@ -244,7 +244,7 @@ func TestNodeRunnerTransactionBroadcast(t *testing.T) {
 	nodeRunner.Consensus().SetLatestConsensusedBlock(genesisBlock)
 	b := nodeRunner.Consensus().LatestConfirmedBlock()
 	require.Equal(t, uint64(1), b.Height)
-	require.Equal(t, uint64(0), b.TotalTxs)
+	require.Equal(t, uint64(1), b.TotalTxs)
 
 	var err error
 	err = nodeRunner.handleTransaction(message)

--- a/lib/node/runner/test.go
+++ b/lib/node/runner/test.go
@@ -145,7 +145,7 @@ func createNodeRunnerForTesting(n int, conf *consensus.ISAACConfiguration, recv 
 	st := storage.NewTestStorage()
 
 	account.Save(st)
-	genesisBlock = block.MakeGenesisBlock(st, *account)
+	genesisBlock, _ = block.MakeGenesisBlock(st, *account, networkID)
 
 	nr, err := NewNodeRunner(string(networkID), localNode, policy, ns[0], is, st, conf)
 	if err != nil {

--- a/lib/transaction/operation.go
+++ b/lib/transaction/operation.go
@@ -85,21 +85,33 @@ func (o *Operation) UnmarshalJSON(b []byte) (err error) {
 
 	o.H = oj.H
 
-	switch oj.H.Type {
-	case OperationCreateAccount:
-		var body OperationBodyCreateAccount
-		if err = json.Unmarshal(envelop, &body); err != nil {
-			return
-		}
-		o.B = body
-	case OperationPayment:
-		var body OperationBodyPayment
-		if err = json.Unmarshal(envelop, &body); err != nil {
-			return
-		}
-		o.B = body
-	default:
-		return errors.ErrorInvalidOperation
+	var body OperationBody
+	if body, err = UnmarshalOperationBodyJSON(oj.H.Type, envelop); err != nil {
+		return
 	}
+	o.B = body
+
+	return
+}
+
+func UnmarshalOperationBodyJSON(t OperationType, b []byte) (body OperationBody, err error) {
+	switch t {
+	case OperationCreateAccount:
+		var ob OperationBodyCreateAccount
+		if err = json.Unmarshal(b, &ob); err != nil {
+			return
+		}
+		body = ob
+	case OperationPayment:
+		var ob OperationBodyPayment
+		if err = json.Unmarshal(b, &ob); err != nil {
+			return
+		}
+		body = ob
+	default:
+		err = errors.ErrorInvalidOperation
+		return
+	}
+
 	return
 }


### PR DESCRIPTION
### Background

We can generate the genesis block by `block.MakeGenesisBlock`. Currently impl just create empty block and it uses the hash of genesis accoun and nothing. In ISAAC block created by Ballot, but genesis block can not have Ballot :)

### Solution

So, we can use Transction for genesis block to resolve this uncomfortable structural issue. Using Transaction in genesis block, we also solve another problem, that is, we can not find the genesis account from genesis block.  In this commit, I made the reason of genesis block :)

The genesis block has some noticeable things,

`MakeGenesisBlock` makes genesis block from genesis account and transaction.  This Transaction is different from other normal Transaction;

* must have only one `Operation`, `OperationCreateAccount`
* `Transaction.B.Source` is same with `OperationCreateAccount.Target`
* `Transaction.B.Fee` is 0
* `OperationCreateAccount.Amount` is same with balance of genesis account
* `OperationCreateAccount.Target` is genesis account

`block.TestMakeGenesisBlockFindGenesisAccount` can explain how to find genesis account.