### PR TITLE
Set `BlockTransaction.Confirmed` by `Block.Confirmed`

### DIFF
--- a/lib/block/block.go
+++ b/lib/block/block.go
@@ -104,7 +104,7 @@ func MakeGenesisBlock(st *storage.LevelDBBackend, account BlockAccount, networdI
 	}
 
 	raw, _ := tx.Serialize()
-	bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, tx, raw)
+	bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx, raw)
 	if err = bt.Save(st); err != nil {
 		return
 	}

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -102,7 +102,7 @@ func TestBlockOperationSaveByTransacton(t *testing.T) {
 
 	_, tx := transaction.TestMakeTransaction(networkID, 10)
 	block := TestMakeNewBlock([]string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, common.MustJSONMarshal(tx))
+	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, common.MustJSONMarshal(tx))
 	err := bt.Save(st)
 	require.Nil(t, err)
 

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -61,5 +61,5 @@ func TestMakeNewBlockTransaction(networkID []byte, n int) BlockTransaction {
 
 	block := TestMakeNewBlock([]string{tx.GetHash()})
 	a, _ := tx.Serialize()
-	return NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+	return NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 }

--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -42,7 +42,7 @@ type BlockTransaction struct {
 	blockHeight uint64
 }
 
-func NewBlockTransactionFromTransaction(blockHash string, blockHeight uint64, tx transaction.Transaction, message []byte) BlockTransaction {
+func NewBlockTransactionFromTransaction(blockHash string, blockHeight uint64, confirmed string, tx transaction.Transaction, message []byte) BlockTransaction {
 	var opHashes []string
 	for _, op := range tx.B.Operations {
 		opHashes = append(opHashes, NewBlockOperationKey(op.MakeHashString(), tx.GetHash()))
@@ -58,8 +58,9 @@ func NewBlockTransactionFromTransaction(blockHash string, blockHeight uint64, tx
 		Operations: opHashes,
 		Amount:     tx.TotalAmount(true),
 
-		Created: tx.H.Created,
-		Message: message,
+		Confirmed: confirmed,
+		Created:   tx.H.Created,
+		Message:   message,
 
 		transaction: tx,
 
@@ -79,10 +80,8 @@ func (bt BlockTransaction) NewBlockTransactionKeySource() string {
 
 func (bt BlockTransaction) NewBlockTransactionKeyConfirmed() string {
 	return fmt.Sprintf(
-		"%s%s%s%s",
+		"%s%s",
 		GetBlockTransactionKeyPrefixConfirmed(bt.Confirmed),
-		common.EncodeUint64ToByteSlice(bt.blockHeight),
-		common.EncodeUint64ToByteSlice(bt.SequenceID),
 		common.GetUniqueIDFromUUID(),
 	)
 }
@@ -122,7 +121,6 @@ func (bt *BlockTransaction) Save(st *storage.LevelDBBackend) (err error) {
 		return
 	}
 
-	bt.Confirmed = common.NowISO8601()
 	if err = st.New(GetBlockTransactionKey(bt.Hash), bt); err != nil {
 		return
 	}

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -16,7 +16,7 @@ func TestNewBlockTransaction(t *testing.T) {
 	_, tx := transaction.TestMakeTransaction(networkID, 1)
 	a, _ := tx.Serialize()
 	block := TestMakeNewBlock([]string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 
 	require.Equal(t, bt.Hash, tx.H.Hash)
 	require.Equal(t, bt.SequenceID, tx.B.SequenceID)
@@ -93,7 +93,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -110,7 +110,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -176,7 +176,7 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -256,7 +256,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -274,7 +274,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -291,7 +291,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
 		require.Nil(t, err)
 	}
@@ -335,7 +335,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	block0 := TestMakeNewBlock(txHashes0)
 	for _, tx := range txs0 {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block0.Hash, block0.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block0.Hash, block0.Height, block0.Confirmed, tx, a)
 		require.Nil(t, bt.Save(st))
 	}
 
@@ -352,7 +352,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	block1 := TestMakeNewBlock(txHashes1)
 	for _, tx := range txs1 {
 		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block1.Hash, block1.Height, tx, a)
+		bt := NewBlockTransactionFromTransaction(block1.Hash, block1.Height, block1.Confirmed, tx, a)
 		require.Nil(t, bt.Save(st))
 	}
 
@@ -420,7 +420,7 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		block.Height++
 		for _, tx := range txs {
 			a, _ := tx.Serialize()
-			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 			err := bt.Save(st)
 			require.Nil(t, err)
 		}
@@ -443,7 +443,7 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		block := TestMakeNewBlock(txHashes)
 		for _, tx := range txs {
 			a, _ := tx.Serialize()
-			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, tx, a)
+			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 			err := bt.Save(st)
 			require.Nil(t, err)
 		}

--- a/lib/network/api/operation.go
+++ b/lib/network/api/operation.go
@@ -51,8 +51,8 @@ func (api NetworkHandlerAPI) GetOperationsByAccountHandler(w http.ResponseWriter
 
 	txs := readFunc() //TODO paging support
 	self := r.URL.String()
-	next := GetAccountOperationsHandlerPattern + "?" + options.SetCursor(cursor).SetReverse(false).URLValues().Encode()
-	prev := GetAccountOperationsHandlerPattern + "?" + options.SetReverse(true).URLValues().Encode()
+	next := GetAccountOperationsHandlerPattern + "?" + options.SetCursor(cursor).SetReverse(false).Encode()
+	prev := GetAccountOperationsHandlerPattern + "?" + options.SetReverse(true).Encode()
 	list := resource.NewResourceList(txs, self, next, prev)
 
 	if err := httputils.WriteJSON(w, 200, list); err != nil {

--- a/lib/network/api/resource/resource_test.go
+++ b/lib/network/api/resource/resource_test.go
@@ -44,7 +44,7 @@ func TestResourceAccount(t *testing.T) {
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction("dummy", 0, tx, a)
+		bt := block.NewBlockTransactionFromTransaction("dummy", 0, common.NowISO8601(), tx, a)
 		bt.Save(storage)
 
 		rt := NewTransaction(&bt)
@@ -72,7 +72,7 @@ func TestResourceAccount(t *testing.T) {
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
 		bt.Save(storage)
 		bo, err := block.GetBlockOperation(storage, bt.Operations[0])
 
@@ -97,7 +97,7 @@ func TestResourceAccount(t *testing.T) {
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 3)
 		a, err := tx.Serialize()
 		require.Nil(t, err)
-		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
 		bt.Save(storage)
 
 		var rol []Resource

--- a/lib/network/api/test.go
+++ b/lib/network/api/test.go
@@ -113,7 +113,7 @@ func prepareTxs(storage *storage.LevelDBBackend, blockHeight uint64, count int, 
 		if err != nil {
 			return nil, nil, err
 		}
-		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx, a)
 		err = bt.Save(storage)
 		if err != nil {
 			return nil, nil, err
@@ -147,7 +147,7 @@ func prepareTxsWithoutSave(blockHeight uint64, count int, kp *keypair.Full) (*ke
 		if err != nil {
 			return nil, nil, err
 		}
-		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx, a)
 		btList = append(btList, bt)
 	}
 	return kp, btList, nil
@@ -166,7 +166,7 @@ func prepareTxWithoutSave() (*keypair.Full, *transaction.Transaction, *block.Blo
 	}
 
 	theBlock := block.TestMakeNewBlock([]string{tx.GetHash()})
-	bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, tx, a)
+	bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx, a)
 	return kp, &tx, &bt, nil
 }
 

--- a/lib/network/api/transaction_test.go
+++ b/lib/network/api/transaction_test.go
@@ -5,10 +5,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
-	"testing"
-
 	"strings"
 	"sync"
+	"testing"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/observer"

--- a/lib/network/api/transaction_test.go
+++ b/lib/network/api/transaction_test.go
@@ -7,13 +7,14 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"strings"
+	"sync"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/network/api/resource"
 	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"sync"
 )
 
 func TestGetTransactionByHashHandler(t *testing.T) {

--- a/lib/network/api/tx_operations_test.go
+++ b/lib/network/api/tx_operations_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/network/api/resource"
 	"boscoin.io/sebak/lib/transaction"
@@ -67,7 +68,7 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	require.Nil(t, err)
 
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 10, kp)
-	bt := block.NewBlockTransactionFromTransaction("block-hash", 1, tx, nil)
+	bt := block.NewBlockTransactionFromTransaction("block-hash", 1, common.NowISO8601(), tx, nil)
 
 	boMap := make(map[string]block.BlockOperation)
 	for _, op := range tx.B.Operations {

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -71,7 +71,7 @@ func (p *HelperTestGetBlocksHandler) createBlock() block.Block {
 
 	for _, tx := range txs {
 		b, _ := tx.Serialize()
-		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, tx, b)
+		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx, b)
 		if err = btx.Save(p.st); err != nil {
 			panic(err)
 		}

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -10,6 +10,10 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/gorilla/mux"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/consensus"
@@ -18,9 +22,6 @@ import (
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
-	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
-	"github.com/stretchr/testify/require"
 )
 
 type HelperTestGetNodeTransactionsHandler struct {

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -99,7 +99,7 @@ func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
 
 	for _, tx := range txs {
 		b, _ := tx.Serialize()
-		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, tx, b)
+		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx, b)
 		if err = btx.Save(p.st); err != nil {
 			panic(err)
 		}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -380,7 +380,7 @@ func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *
 		tx := transactions[hash]
 		raw, _ := json.Marshal(tx)
 
-		bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, tx, raw)
+		bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx, raw)
 		if err = bt.Save(ts); err != nil {
 			ts.Discard()
 			return

--- a/lib/storage/options.go
+++ b/lib/storage/options.go
@@ -18,6 +18,7 @@ type ListOptions interface {
 	SetLimit(uint64) ListOptions
 	Template() string
 	URLValues() url.Values
+	Encode() string
 }
 
 type DefaultListOptions struct {
@@ -112,4 +113,8 @@ func (o DefaultListOptions) URLValues() url.Values {
 	}
 
 	return v
+}
+
+func (o DefaultListOptions) Encode() string {
+	return o.URLValues().Encode()
 }


### PR DESCRIPTION
### Background

The previous `block.BlockTransaction.Confirmed` set to the saving time, so it will be different between nodes

### Solution
So it is set by`block.Block.Confirmed`, instead of saving time.