### PR TITLE
Operation CongressVoting

### DIFF
--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -61,4 +61,5 @@ var (
 	ErrorFrozenAccountCreationWholeUnit       = NewError(154, "frozen account balance must be a whole number of units (10k)")
 	ErrorFrozenAccountMustWithdrawEverything  = NewError(155, "frozen account can only withdraw the full amount (minus tx fee)")
 	ErrorInsufficientAmountNewAccount         = NewError(156, "insufficient amount for new account")
+	ErrorOperationBodyInsufficient            = NewError(157, "operation body insufficient")
 )

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -440,6 +440,9 @@ func finishOperation(st *storage.LevelDBBackend, tx transaction.Transaction, op 
 			return errors.ErrorUnknownOperationType
 		}
 		return finishOperationPayment(st, tx, pop, log)
+	case transaction.OperationCongressVoting, transaction.OperationCongressVotingResult:
+		//Nothing to do
+		return
 	default:
 		err = errors.ErrorUnknownOperationType
 		return

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -253,6 +253,10 @@ func ValidateOp(st *storage.LevelDBBackend, source *block.BlockAccount, op trans
 				return
 			}
 		}
+	case transaction.OperationCongressVoting, transaction.OperationCongressVotingResult:
+		// Nothing to do
+		return
+
 	default:
 		err = errors.ErrorUnknownOperationType
 		return

--- a/lib/transaction/operation.go
+++ b/lib/transaction/operation.go
@@ -14,8 +14,8 @@ type OperationType string
 const (
 	OperationCreateAccount        OperationType = "create-account"
 	OperationPayment                            = "payment"
-	OperationCongressVoting                     = "cv"
-	OperationCongressVotingResult               = "cvr"
+	OperationCongressVoting                     = "congress-voting"
+	OperationCongressVotingResult               = "congress-voting-result"
 )
 
 type Operation struct {

--- a/lib/transaction/operation.go
+++ b/lib/transaction/operation.go
@@ -112,13 +112,13 @@ func UnmarshalOperationBodyJSON(t OperationType, b []byte) (body OperationBody, 
 		body = ob
 	case OperationCongressVoting:
 		var ob OperationBodyCongressVoting
-		if err = json.Unmarshal(envelop, &body); err != nil {
+		if err = json.Unmarshal(b, &ob); err != nil {
 			return
 		}
 		body = ob
 	case OperationCongressVotingResult:
 		var ob OperationBodyCongressVotingResult
-		if err = json.Unmarshal(envelop, &body); err != nil {
+		if err = json.Unmarshal(b, &ob); err != nil {
 			return
 		}
 		body = ob

--- a/lib/transaction/operation.go
+++ b/lib/transaction/operation.go
@@ -12,8 +12,10 @@ import (
 type OperationType string
 
 const (
-	OperationCreateAccount OperationType = "create-account"
-	OperationPayment                     = "payment"
+	OperationCreateAccount        OperationType = "create-account"
+	OperationPayment                            = "payment"
+	OperationCongressVoting                     = "cv"
+	OperationCongressVotingResult               = "cvr"
 )
 
 type Operation struct {
@@ -105,6 +107,18 @@ func UnmarshalOperationBodyJSON(t OperationType, b []byte) (body OperationBody, 
 	case OperationPayment:
 		var ob OperationBodyPayment
 		if err = json.Unmarshal(b, &ob); err != nil {
+			return
+		}
+		body = ob
+	case OperationCongressVoting:
+		var ob OperationBodyCongressVoting
+		if err = json.Unmarshal(envelop, &body); err != nil {
+			return
+		}
+		body = ob
+	case OperationCongressVotingResult:
+		var ob OperationBodyCongressVotingResult
+		if err = json.Unmarshal(envelop, &body); err != nil {
 			return
 		}
 		body = ob

--- a/lib/transaction/operation_congress_voting.go
+++ b/lib/transaction/operation_congress_voting.go
@@ -3,14 +3,13 @@ package transaction
 import (
 	"boscoin.io/sebak/lib/error"
 	"encoding/json"
-	"time"
 )
 
 type OperationBodyCongressVoting struct {
-	Contract string
+	Contract []byte
 	Voting   struct {
-		Start string
-		End   string
+		Start uint64
+		End   uint64
 	}
 }
 
@@ -22,11 +21,8 @@ func (o OperationBodyCongressVoting) IsWellFormed([]byte) (err error) {
 	if len(o.Contract) == 0 {
 		return errors.ErrorOperationBodyInsufficient
 	}
-	if _, err := time.Parse(time.RFC3339Nano, o.Voting.Start); err != nil {
-		return errors.ErrorInvalidOperation
-	}
 
-	if _, err := time.Parse(time.RFC3339Nano, o.Voting.End); err != nil {
+	if o.Voting.End < o.Voting.Start {
 		return errors.ErrorInvalidOperation
 	}
 	return

--- a/lib/transaction/operation_congress_voting.go
+++ b/lib/transaction/operation_congress_voting.go
@@ -1,0 +1,33 @@
+package transaction
+
+import (
+	"boscoin.io/sebak/lib/error"
+	"encoding/json"
+	"time"
+)
+
+type OperationBodyCongressVoting struct {
+	Contract string
+	Voting   struct {
+		Start string
+		End   string
+	}
+}
+
+func (o OperationBodyCongressVoting) Serialize() (encoded []byte, err error) {
+	encoded, err = json.Marshal(o)
+	return
+}
+func (o OperationBodyCongressVoting) IsWellFormed([]byte) (err error) {
+	if len(o.Contract) == 0 {
+		return errors.ErrorOperationBodyInsufficient
+	}
+	if _, err := time.Parse(time.RFC3339Nano, o.Voting.Start); err != nil {
+		return errors.ErrorInvalidOperation
+	}
+
+	if _, err := time.Parse(time.RFC3339Nano, o.Voting.End); err != nil {
+		return errors.ErrorInvalidOperation
+	}
+	return
+}

--- a/lib/transaction/operation_congress_voting_result.go
+++ b/lib/transaction/operation_congress_voting_result.go
@@ -1,7 +1,6 @@
 package transaction
 
 import (
-	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
 	"encoding/json"
 	"net/url"
@@ -32,34 +31,20 @@ func (o OperationBodyCongressVotingResult) IsWellFormed([]byte) (err error) {
 		return errors.ErrorOperationBodyInsufficient
 	}
 
-	var tobeHash = ""
 	for _, u := range o.BallotStamps.Urls {
 		if _, err := url.Parse(u); err != nil {
 			return errors.ErrorInvalidOperation
 		}
-		tobeHash += u
-	}
-
-	hash := common.MakeHash([]byte(tobeHash))
-	if string(hash) != o.BallotStamps.Hash {
-		return errors.ErrorInvalidOperation
 	}
 
 	if len(o.Voters.Hash) == 0 {
 		return errors.ErrorOperationBodyInsufficient
 	}
 
-	tobeHash = ""
 	for _, u := range o.Voters.Urls {
 		if _, err := url.Parse(u); err != nil {
 			return errors.ErrorInvalidOperation
 		}
-		tobeHash += u
-	}
-
-	hash = common.MakeHash([]byte(tobeHash))
-	if string(hash) != o.Voters.Hash {
-		return errors.ErrorInvalidOperation
 	}
 
 	if o.Result.Count != o.Result.Yes+o.Result.No+o.Result.ABS {

--- a/lib/transaction/operation_congress_voting_result.go
+++ b/lib/transaction/operation_congress_voting_result.go
@@ -1,0 +1,70 @@
+package transaction
+
+import (
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"encoding/json"
+	"net/url"
+)
+
+type OperationBodyCongressVotingResult struct {
+	BallotStamps struct {
+		Hash string
+		Urls []string
+	}
+	Voters struct {
+		Hash string
+		Urls []string
+	}
+	Result struct {
+		Count uint64
+		Yes   uint64
+		No    uint64
+		ABS   uint64
+	}
+}
+
+func (o OperationBodyCongressVotingResult) Serialize() (encoded []byte, err error) {
+	return json.Marshal(o)
+}
+func (o OperationBodyCongressVotingResult) IsWellFormed([]byte) (err error) {
+	if len(o.BallotStamps.Hash) == 0 {
+		return errors.ErrorOperationBodyInsufficient
+	}
+
+	var tobeHash = ""
+	for _, u := range o.BallotStamps.Urls {
+		if _, err := url.Parse(u); err != nil {
+			return errors.ErrorInvalidOperation
+		}
+		tobeHash += u
+	}
+
+	hash := common.MakeHash([]byte(tobeHash))
+	if string(hash) != o.BallotStamps.Hash {
+		return errors.ErrorInvalidOperation
+	}
+
+	if len(o.Voters.Hash) == 0 {
+		return errors.ErrorOperationBodyInsufficient
+	}
+
+	tobeHash = ""
+	for _, u := range o.Voters.Urls {
+		if _, err := url.Parse(u); err != nil {
+			return errors.ErrorInvalidOperation
+		}
+		tobeHash += u
+	}
+
+	hash = common.MakeHash([]byte(tobeHash))
+	if string(hash) != o.Voters.Hash {
+		return errors.ErrorInvalidOperation
+	}
+
+	if o.Result.Count != o.Result.Yes+o.Result.No+o.Result.ABS {
+		return errors.ErrorInvalidOperation
+	}
+
+	return
+}

--- a/lib/transaction/operation_test.go
+++ b/lib/transaction/operation_test.go
@@ -52,13 +52,13 @@ func TestSerializeOperation(t *testing.T) {
 
 func TestOperationBodyCongressVoting(t *testing.T) {
 	opb := OperationBodyCongressVoting{
-		Contract: "dummy contract",
+		Contract: []byte("dummy contract"),
 		Voting: struct {
-			Start string
-			End   string
+			Start uint64
+			End   uint64
 		}{
-			Start: "2006-01-02T15:04:05.999999999Z",
-			End:   "2006-01-02T15:04:05.999999999Z",
+			Start: 1,
+			End:   100,
 		},
 	}
 	op := Operation{
@@ -67,7 +67,7 @@ func TestOperationBodyCongressVoting(t *testing.T) {
 	}
 	hashed := op.MakeHashString()
 
-	expected := "6pGRgBRMFTyuJGUtiheEboibCNfYEAyqFtq4FgcAgfGC"
+	expected := "4DDgT1txmCrge9eS1QqHhThTu3f97NkHos8t8ueD94sA"
 	require.Equal(t, hashed, expected)
 
 	err := op.IsWellFormed(networkID)
@@ -81,14 +81,14 @@ func TestOperationBodyCongressVotingResult(t *testing.T) {
 			Hash string
 			Urls []string
 		}{
-			Hash: string(common.MakeHash([]byte("http://www.boscoin.io/1http://www.boscoin.io/2"))),
+			Hash: string(common.MakeHash([]byte("dummydummy"))),
 			Urls: []string{"http://www.boscoin.io/1", "http://www.boscoin.io/2"},
 		},
 		Voters: struct {
 			Hash string
 			Urls []string
 		}{
-			Hash: string(common.MakeHash([]byte("http://www.boscoin.io/3http://www.boscoin.io/4"))),
+			Hash: string(common.MakeHash([]byte("dummydummy"))),
 			Urls: []string{"http://www.boscoin.io/3", "http://www.boscoin.io/4"},
 		},
 		Result: struct {
@@ -109,7 +109,7 @@ func TestOperationBodyCongressVotingResult(t *testing.T) {
 	}
 	hashed := op.MakeHashString()
 
-	expected := "q9QygfM7r9W7hm3hekWkpoye8dyYDXnzapja8CiFSem"
+	expected := "F4HQBdWPiMJHFtgbgbxp2ykESppD9vGAewUnmA5B9Agg"
 	require.Equal(t, hashed, expected)
 
 	err := op.IsWellFormed(networkID)

--- a/lib/transaction/operation_test.go
+++ b/lib/transaction/operation_test.go
@@ -67,7 +67,7 @@ func TestOperationBodyCongressVoting(t *testing.T) {
 	}
 	hashed := op.MakeHashString()
 
-	expected := "4DDgT1txmCrge9eS1QqHhThTu3f97NkHos8t8ueD94sA"
+	expected := "2skQu73zDSRvBF5CYhKkJLuK2QBqBkPDTcp3qAx7XvgA"
 	require.Equal(t, hashed, expected)
 
 	err := op.IsWellFormed(networkID)
@@ -109,7 +109,7 @@ func TestOperationBodyCongressVotingResult(t *testing.T) {
 	}
 	hashed := op.MakeHashString()
 
-	expected := "F4HQBdWPiMJHFtgbgbxp2ykESppD9vGAewUnmA5B9Agg"
+	expected := "HHEKRf4Q4Hzvaz8NMvvsKV57neTvgkppYBg5Up39JB8k"
 	require.Equal(t, hashed, expected)
 
 	err := op.IsWellFormed(networkID)

--- a/lib/transaction/operation_test.go
+++ b/lib/transaction/operation_test.go
@@ -49,3 +49,70 @@ func TestSerializeOperation(t *testing.T) {
 	err = json.Unmarshal(b, &o)
 	require.Nil(t, err)
 }
+
+func TestOperationBodyCongressVoting(t *testing.T) {
+	opb := OperationBodyCongressVoting{
+		Contract: "dummy contract",
+		Voting: struct {
+			Start string
+			End   string
+		}{
+			Start: "2006-01-02T15:04:05.999999999Z",
+			End:   "2006-01-02T15:04:05.999999999Z",
+		},
+	}
+	op := Operation{
+		H: OperationHeader{Type: OperationCongressVoting},
+		B: opb,
+	}
+	hashed := op.MakeHashString()
+
+	expected := "6pGRgBRMFTyuJGUtiheEboibCNfYEAyqFtq4FgcAgfGC"
+	require.Equal(t, hashed, expected)
+
+	err := op.IsWellFormed(networkID)
+	require.Nil(t, err)
+
+}
+
+func TestOperationBodyCongressVotingResult(t *testing.T) {
+	opb := OperationBodyCongressVotingResult{
+		BallotStamps: struct {
+			Hash string
+			Urls []string
+		}{
+			Hash: string(common.MakeHash([]byte("http://www.boscoin.io/1http://www.boscoin.io/2"))),
+			Urls: []string{"http://www.boscoin.io/1", "http://www.boscoin.io/2"},
+		},
+		Voters: struct {
+			Hash string
+			Urls []string
+		}{
+			Hash: string(common.MakeHash([]byte("http://www.boscoin.io/3http://www.boscoin.io/4"))),
+			Urls: []string{"http://www.boscoin.io/3", "http://www.boscoin.io/4"},
+		},
+		Result: struct {
+			Count uint64
+			Yes   uint64
+			No    uint64
+			ABS   uint64
+		}{
+			Count: 9,
+			Yes:   2,
+			No:    3,
+			ABS:   4,
+		},
+	}
+	op := Operation{
+		H: OperationHeader{Type: OperationCongressVotingResult},
+		B: opb,
+	}
+	hashed := op.MakeHashString()
+
+	expected := "q9QygfM7r9W7hm3hekWkpoye8dyYDXnzapja8CiFSem"
+	require.Equal(t, hashed, expected)
+
+	err := op.IsWellFormed(networkID)
+	require.Nil(t, err)
+
+}


### PR DESCRIPTION
### Github Issue
Resolves #311 

### Background
To store proposal/result of congress voting to blockchain, new operations needed

### Solution
New 2 operations

### Possible Drawbacks
Operations are just stored in the blockchain with its transaction but no affect to account.

