### PR TITLE
Sync 

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -402,7 +402,7 @@ func runNode() error {
 		})
 	}
 	{
-		c := sync.NewConfig(localNode, st, nt, connectionManager)
+		c := sync.NewConfig([]byte(flagNetworkID), localNode, st, nt, connectionManager)
 		//Place setting config
 		syncer := c.NewSyncer()
 

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -23,6 +23,7 @@ import (
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/node/runner"
 	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/sync"
 )
 
 const (
@@ -271,11 +272,14 @@ func parseFlagsNode() {
 		}
 	}
 
-	log.SetHandler(logging.LvlFilterHandler(logLevel, logging.CallerFileHandler(logHandler)))
+	logHandler = logging.CallerFileHandler(logHandler)
+	logHandler = logging.LvlFilterHandler(logLevel, logHandler)
+	log.SetHandler(logHandler)
 
 	runner.SetLogging(logLevel, logHandler)
 	consensus.SetLogging(logLevel, logHandler)
 	network.SetLogging(logLevel, logHandler)
+	sync.SetLogging(logLevel, logHandler)
 
 	log.Info("Starting Sebak")
 
@@ -395,6 +399,17 @@ func runNode() error {
 			return nil
 		}, func(error) {
 			nr.Stop()
+		})
+	}
+	{
+		c := sync.NewConfig(localNode, st, nt, connectionManager)
+		//Place setting config
+		syncer := c.NewSyncer()
+
+		g.Add(func() error {
+			return syncer.Start()
+		}, func(error) {
+			syncer.Stop()
 		})
 	}
 	{

--- a/lib/network/connection_manager.go
+++ b/lib/network/connection_manager.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/node"
 )
 
 type ConnectionManager interface {
@@ -15,4 +16,5 @@ type ConnectionManager interface {
 	AllConnected() []string
 	AllValidators() []string
 	CountConnected() int
+	GetNode(address string) node.Node
 }

--- a/lib/network/validator_connection_manager.go
+++ b/lib/network/validator_connection_manager.go
@@ -208,3 +208,15 @@ func (c *ValidatorConnectionManager) Broadcast(message common.Message) {
 	}
 	return
 }
+
+func (c *ValidatorConnectionManager) GetNode(address string) node.Node {
+	c.Lock()
+	defer c.Unlock()
+
+	validator, ok := c.validators[address]
+	if !ok {
+		return nil
+	}
+
+	return validator
+}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -497,3 +497,7 @@ func finishOperationPayment(st *storage.LevelDBBackend, tx transaction.Transacti
 
 	return
 }
+
+func FinishOperation(st *storage.LevelDBBackend, tx transaction.Transaction, op transaction.Operation, log logging.Logger) (err error) {
+	return finishOperation(st, tx, op, log)
+}

--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	storage           *storage.LevelDBBackend
 	network           network.Network
 	connectionManager network.ConnectionManager
+	networkID         []byte
 	logger            log15.Logger
 
 	SyncPoolSize             int
@@ -29,12 +30,13 @@ type Config struct {
 	Logger                   log15.Logger
 }
 
-func NewConfig(localNode *node.LocalNode, st *storage.LevelDBBackend, nt network.Network, cm network.ConnectionManager) *Config {
+func NewConfig(networkID []byte, localNode *node.LocalNode, st *storage.LevelDBBackend, nt network.Network, cm network.ConnectionManager) *Config {
 	c := &Config{
 		storage:           st,
 		network:           nt,
 		connectionManager: cm,
 		logger:            log.New(log15.Ctx{"node": localNode.Alias()}),
+		networkID:         networkID,
 
 		SyncPoolSize:             SyncPoolSize,
 		FetchTimeout:             FetchTimeout,
@@ -45,7 +47,7 @@ func NewConfig(localNode *node.LocalNode, st *storage.LevelDBBackend, nt network
 }
 
 func (c *Config) NewSyncer() *Syncer {
-	s := NewSyncer(c.storage, c.network, c.connectionManager, func(s *Syncer) {
+	s := NewSyncer(c.storage, c.network, c.connectionManager, c.networkID, func(s *Syncer) {
 		s.poolSize = c.SyncPoolSize
 		s.fetchTimeout = c.FetchTimeout
 		s.retryInterval = c.RetryInterval

--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -1,0 +1,56 @@
+package sync
+
+import (
+	"time"
+
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/inconshreveable/log15"
+)
+
+const (
+	SyncPoolSize             = 300
+	FetchTimeout             = 1 * time.Minute
+	RetryInterval            = 10 * time.Second
+	CheckBlockHeightInterval = 500 * time.Millisecond
+)
+
+type Config struct {
+	storage           *storage.LevelDBBackend
+	network           network.Network
+	connectionManager network.ConnectionManager
+	logger            log15.Logger
+
+	SyncPoolSize             int
+	FetchTimeout             time.Duration
+	RetryInterval            time.Duration
+	CheckBlockHeightInterval time.Duration
+	Logger                   log15.Logger
+}
+
+func NewConfig(localNode *node.LocalNode, st *storage.LevelDBBackend, nt network.Network, cm network.ConnectionManager) *Config {
+	c := &Config{
+		storage:           st,
+		network:           nt,
+		connectionManager: cm,
+		logger:            log.New(log15.Ctx{"node": localNode.Alias()}),
+
+		SyncPoolSize:             SyncPoolSize,
+		FetchTimeout:             FetchTimeout,
+		RetryInterval:            RetryInterval,
+		CheckBlockHeightInterval: CheckBlockHeightInterval,
+	}
+	return c
+}
+
+func (c *Config) NewSyncer() *Syncer {
+	s := NewSyncer(c.storage, c.network, c.connectionManager, func(s *Syncer) {
+		s.poolSize = c.SyncPoolSize
+		s.fetchTimeout = c.FetchTimeout
+		s.retryInterval = c.RetryInterval
+		s.checkInterval = c.CheckBlockHeightInterval
+		s.logger = c.logger
+	})
+	return s
+}

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -1,0 +1,33 @@
+package sync
+
+import (
+	"fmt"
+	"testing"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewConfig(t *testing.T) {
+	st := storage.NewTestStorage()
+	_, nt, _ := network.CreateMemoryNetwork(nil)
+	cm := &mockConnectionManager{}
+
+	kp, _ := keypair.Random()
+	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
+	require.Equal(t, nil, err)
+
+	node, _ := node.NewLocalNode(kp, endpoint, "")
+
+	cfg := NewConfig(node, st, nt, cm)
+	cfg.SyncPoolSize = 100
+
+	syncer := cfg.NewSyncer()
+
+	require.NotNil(t, syncer)
+	require.Equal(t, syncer.poolSize, cfg.SyncPoolSize)
+}

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -22,8 +22,9 @@ func TestNewConfig(t *testing.T) {
 	require.Equal(t, nil, err)
 
 	node, _ := node.NewLocalNode(kp, endpoint, "")
+	networkID := []byte("test-network")
 
-	cfg := NewConfig(node, st, nt, cm)
+	cfg := NewConfig(networkID, node, st, nt, cm)
 	cfg.SyncPoolSize = 100
 
 	syncer := cfg.NewSyncer()

--- a/lib/sync/fetcher.go
+++ b/lib/sync/fetcher.go
@@ -1,0 +1,199 @@
+package sync
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"time"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/node/runner"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/inconshreveable/log15"
+)
+
+type BlockFetcher struct {
+	network           network.Network
+	connectionManager network.ConnectionManager
+	apiClient         Doer
+	storage           *storage.LevelDBBackend
+
+	fetchTimeout  time.Duration
+	retryInterval time.Duration
+
+	logger log15.Logger
+}
+
+type BlockFetcherOption = func(f *BlockFetcher)
+
+func NewBlockFetcher(nw network.Network, cManager network.ConnectionManager, st *storage.LevelDBBackend, opts ...BlockFetcherOption) *BlockFetcher {
+
+	f := &BlockFetcher{
+		network:           nw,
+		connectionManager: cManager,
+		apiClient:         &http.Client{},
+		storage:           st,
+		logger:            NopLogger(),
+
+		fetchTimeout:  1 * time.Minute,
+		retryInterval: 30 * time.Second,
+	}
+
+	for _, opt := range opts {
+		opt(f)
+	}
+
+	return f
+}
+
+func (f *BlockFetcher) Fetch(ctx context.Context, height uint64) (*BlockInfo, error) {
+	var (
+		result *BlockInfo
+		err    error
+	)
+
+	TryForever(func(attempt int) (bool, error) {
+		select {
+		case <-ctx.Done():
+			return false, ctx.Err()
+		default:
+			f.logger.Debug("Try to fetch", "height", height, "attempt", attempt)
+			result, err = f.fetch(ctx, height)
+			if err != nil {
+				f.logger.Error(err.Error(), "err", err)
+				c := time.After(f.retryInterval) //afterFunc?
+				select {
+				case <-ctx.Done():
+					return false, ctx.Err()
+				case <-c:
+				}
+			}
+		}
+		return true, err
+	})
+
+	return result, err
+}
+
+func (f *BlockFetcher) fetch(ctx context.Context, height uint64) (*BlockInfo, error) {
+	f.logger.Debug("Fetch start", "height", height)
+
+	n := f.pickRandomNode()
+	f.logger.Info("Fetching items from node", "node", n, "height", height)
+	if n == nil {
+		return nil, errors.New("Fetch: node not found")
+	}
+
+	ep := n.Endpoint()
+	apiURL := url.URL(*ep)
+	apiURL.Path = network.UrlPathPrefixNode + runner.GetBlocksPattern
+	q := apiURL.Query()
+	q.Set("height-range", fmt.Sprintf("%d-%d", height, height+1))
+	q.Set("mode", "full")
+	apiURL.RawQuery = q.Encode()
+	f.logger.Debug("apiClient", "url", apiURL.String())
+
+	req, err := http.NewRequest("GET", apiURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancelF := context.WithTimeout(ctx, f.fetchTimeout)
+	defer cancelF()
+
+	resp, err := f.apiClient.Do(req)
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		//TODO:
+		err := errors.New("Fetch: block not found")
+		return nil, err
+	}
+
+	items, err := f.unmarshalResp(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	f.logger.Info("Fetch get items", "items", len(items), "height", height)
+
+	blocks, ok := items[runner.NodeItemBlock]
+	if !ok || len(blocks) <= 0 {
+		err := errors.New("Fetch: block not found in resp")
+		return nil, err
+	}
+
+	//TODO(anarcher): check items
+	txs, ok := items[runner.NodeItemBlockTransaction]
+	ops, ok := items[runner.NodeItemBlockOperation]
+
+	blk := blocks[0].(block.Block)
+
+	info := &BlockInfo{
+		BlockHeight: height,
+		Block:       &blk,
+	}
+
+	for _, tx := range txs {
+		bt := tx.(block.BlockTransaction)
+		info.Txs = append(info.Txs, &bt)
+	}
+	for _, op := range ops {
+		op := op.(block.BlockOperation)
+		info.Ops = append(info.Ops, &op)
+	}
+
+	return info, nil
+}
+
+// pickRandomNode choose one node by random. It is very protype for choosing fetching which node
+func (f *BlockFetcher) pickRandomNode() node.Node {
+	ac := f.connectionManager.AllConnected()
+	if len(ac) <= 0 {
+		return nil
+	}
+	idx := rand.Intn(len(ac))
+	node := f.connectionManager.GetNode(ac[idx])
+	return node
+}
+
+func (f *BlockFetcher) existsBlockHeight(height uint64) bool {
+	exists, err := block.ExistsBlockByHeight(f.storage, height)
+	if err != nil {
+		f.logger.Error("block.ExistsBlockByHeight", "err", err)
+		return false
+	}
+	return exists
+}
+
+func (f *BlockFetcher) unmarshalResp(body io.ReadCloser) (map[runner.NodeItemDataType][]interface{}, error) {
+	items := map[runner.NodeItemDataType][]interface{}{}
+
+	sc := bufio.NewScanner(body)
+	for sc.Scan() {
+		itemType, b, err := runner.UnmarshalNodeItemResponse(sc.Bytes())
+		if err != nil {
+			return nil, err
+		}
+		items[itemType] = append(items[itemType], b)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+
+	return items, nil
+}

--- a/lib/sync/fetcher_test.go
+++ b/lib/sync/fetcher_test.go
@@ -1,0 +1,72 @@
+package sync
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/node/runner"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+)
+
+func renderNodeItem(w http.ResponseWriter, itemType runner.NodeItemDataType, o interface{}) {
+	s, err := json.Marshal(o)
+	if err != nil {
+		itemType = runner.NodeItemError
+		s = []byte(err.Error())
+	}
+
+	writeNodeItem(w, itemType, s)
+}
+
+func writeNodeItem(w http.ResponseWriter, itemType runner.NodeItemDataType, s []byte) {
+	w.Write(append([]byte(itemType+" "), append(s, '\n')...))
+}
+
+func TestBlockFetcher(t *testing.T) {
+	st := storage.NewTestStorage()
+	defer st.Close()
+
+	kp, _ := keypair.Random()
+	_, nw, _ := network.CreateMemoryNetwork(nil)
+	cm := &mockConnectionManager{
+		allConnected: []string{kp.Address()},
+		getNodeFunc: func(addr string) node.Node {
+			ep, err := common.NewEndpointFromString("https://node1?NodeName=n1")
+			require.Nil(t, err)
+			v, err := node.NewValidator(kp.Address(), ep, "n1")
+			require.Nil(t, err)
+			return v
+		},
+	}
+
+	bk := block.TestMakeNewBlock([]string{})
+	bk.Height = uint64(1)
+
+	apiHandlerFunc := func(req *http.Request) (*http.Response, error) {
+		w := httptest.NewRecorder()
+		renderNodeItem(w, runner.NodeItemBlock, bk)
+		resp := w.Result()
+		return resp, nil
+	}
+
+	f := NewBlockFetcher(nw, cm, st, func(f *BlockFetcher) {
+		f.apiClient = mockDoer{
+			handleFunc: apiHandlerFunc,
+		}
+	})
+
+	ctx := context.Background()
+	bi, err := f.Fetch(ctx, 1)
+	require.Nil(t, err)
+	require.Equal(t, bk.Hash, bi.Block.Hash)
+	require.Equal(t, bk.TransactionsRoot, bi.Block.TransactionsRoot)
+}

--- a/lib/sync/fetcher_test.go
+++ b/lib/sync/fetcher_test.go
@@ -65,8 +65,8 @@ func TestBlockFetcher(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	bi, err := f.Fetch(ctx, 1)
+	si, err := f.Fetch(ctx, &SyncInfo{BlockHeight: 1})
 	require.Nil(t, err)
-	require.Equal(t, bk.Hash, bi.Block.Hash)
-	require.Equal(t, bk.TransactionsRoot, bi.Block.TransactionsRoot)
+	require.Equal(t, bk.Hash, si.Block.Hash)
+	require.Equal(t, bk.TransactionsRoot, si.Block.TransactionsRoot)
 }

--- a/lib/sync/init.go
+++ b/lib/sync/init.go
@@ -1,0 +1,17 @@
+package sync
+
+import (
+	logging "github.com/inconshreveable/log15"
+
+	"boscoin.io/sebak/lib/common"
+)
+
+var log logging.Logger = logging.New("module", "sync")
+
+func init() {
+	SetLogging(common.DefaultLogLevel, common.DefaultLogHandler)
+}
+
+func SetLogging(level logging.Lvl, handler logging.Handler) {
+	log.SetHandler(logging.LvlFilterHandler(level, handler))
+}

--- a/lib/sync/logger.go
+++ b/lib/sync/logger.go
@@ -1,0 +1,25 @@
+package sync
+
+import "github.com/inconshreveable/log15"
+
+// NopLogger returns a Logger with a no-op (nil) Logger
+func NopLogger() log15.Logger {
+	return &nopLogger{}
+}
+
+type nopLogger struct{}
+
+func (l *nopLogger) New(ctx ...interface{}) log15.Logger {
+	return l
+}
+
+func (l nopLogger) GetHandler() log15.Handler {
+	return nil
+}
+
+func (l nopLogger) SetHandler(log15.Handler)             {}
+func (l nopLogger) Debug(msg string, ctx ...interface{}) {}
+func (l nopLogger) Info(msg string, ctx ...interface{})  {}
+func (l nopLogger) Warn(msg string, ctx ...interface{})  {}
+func (l nopLogger) Error(msg string, ctx ...interface{}) {}
+func (l nopLogger) Crit(msg string, ctx ...interface{})  {}

--- a/lib/sync/mock_test.go
+++ b/lib/sync/mock_test.go
@@ -1,0 +1,69 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+)
+
+type mockConnectionManager struct {
+	allConnected  []string
+	allValidators []string
+	getNodeFunc   func(addr string) node.Node
+}
+
+func (m *mockConnectionManager) GetNodeAddress() string {
+	return ""
+}
+
+func (m *mockConnectionManager) ConnectionWatcher(network.Network, net.Conn, http.ConnState) {}
+func (m *mockConnectionManager) Broadcast(common.Message)                                    {}
+func (m *mockConnectionManager) Start()                                                      {}
+
+func (m *mockConnectionManager) AllConnected() []string {
+	return m.allConnected
+}
+
+func (m *mockConnectionManager) AllValidators() []string {
+	return m.allValidators
+}
+
+func (m *mockConnectionManager) CountConnected() int {
+	return len(m.allConnected)
+}
+
+func (m *mockConnectionManager) GetNode(addr string) node.Node {
+	return m.getNodeFunc(addr)
+}
+
+type mockDoer struct {
+	handleFunc func(*http.Request) (*http.Response, error)
+}
+
+func (d mockDoer) Do(req *http.Request) (*http.Response, error) {
+	if d.handleFunc == nil {
+		return nil, errors.New("not implemented")
+	}
+	return d.handleFunc(req)
+}
+
+type mockFetcher struct {
+	fetchFunc func(context.Context, uint64) (*BlockInfo, error)
+}
+
+func (f mockFetcher) Fetch(ctx context.Context, height uint64) (*BlockInfo, error) {
+	return f.fetchFunc(ctx, height)
+}
+
+type mockValidator struct {
+	validateFunc func(context.Context, *BlockInfo) error
+}
+
+func (v mockValidator) Validate(ctx context.Context, bi *BlockInfo) error {
+	return v.validateFunc(ctx, bi)
+}

--- a/lib/sync/mock_test.go
+++ b/lib/sync/mock_test.go
@@ -53,17 +53,17 @@ func (d mockDoer) Do(req *http.Request) (*http.Response, error) {
 }
 
 type mockFetcher struct {
-	fetchFunc func(context.Context, uint64) (*BlockInfo, error)
+	fetchFunc func(context.Context, *SyncInfo) (*SyncInfo, error)
 }
 
-func (f mockFetcher) Fetch(ctx context.Context, height uint64) (*BlockInfo, error) {
-	return f.fetchFunc(ctx, height)
+func (f mockFetcher) Fetch(ctx context.Context, si *SyncInfo) (*SyncInfo, error) {
+	return f.fetchFunc(ctx, si)
 }
 
 type mockValidator struct {
-	validateFunc func(context.Context, *BlockInfo) error
+	validateFunc func(context.Context, *SyncInfo) error
 }
 
-func (v mockValidator) Validate(ctx context.Context, bi *BlockInfo) error {
-	return v.validateFunc(ctx, bi)
+func (v mockValidator) Validate(ctx context.Context, si *SyncInfo) error {
+	return v.validateFunc(ctx, si)
 }

--- a/lib/sync/pool.go
+++ b/lib/sync/pool.go
@@ -1,0 +1,66 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type Pool struct {
+	finish chan struct{}
+	work   chan<- func()
+	wg     sync.WaitGroup
+}
+
+var ErrFinished = errors.New("Add: Pool is finished")
+
+func NewPool(n int) *Pool {
+	work := make(chan func())
+	finish := make(chan struct{})
+	p := &Pool{
+		work:   work,
+		finish: finish,
+	}
+
+	for ; n > 0; n-- {
+		p.wg.Add(1)
+		go func() {
+			for {
+				select {
+				case f := <-work:
+					f()
+				case <-p.finish:
+					p.wg.Done()
+					return
+				}
+			}
+		}()
+	}
+	return p
+}
+
+func (p *Pool) Add(ctx context.Context, f func()) error {
+	select {
+	case <-p.finish:
+		return ErrFinished
+	default:
+	}
+
+	select {
+	case <-p.finish:
+		return ErrFinished
+	case p.work <- f:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *Pool) Finish() {
+	select {
+	case <-p.finish:
+	default:
+		close(p.finish)
+	}
+	p.wg.Wait()
+}

--- a/lib/sync/pool_test.go
+++ b/lib/sync/pool_test.go
@@ -1,0 +1,25 @@
+package sync
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestPool(t *testing.T) {
+	size := 2
+	ctx := context.Background()
+	pool := NewPool(size)
+	var wg sync.WaitGroup
+
+	wg.Add(size)
+
+	for i := 0; i < size; i++ {
+		pool.Add(ctx, func() {
+			wg.Done()
+		})
+	}
+
+	wg.Wait()
+	pool.Finish()
+}

--- a/lib/sync/syncer.go
+++ b/lib/sync/syncer.go
@@ -1,0 +1,158 @@
+package sync
+
+import (
+	"context"
+	"time"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/inconshreveable/log15"
+)
+
+type Syncer struct {
+	poolSize      int
+	fetchTimeout  time.Duration
+	retryInterval time.Duration
+	checkInterval time.Duration
+
+	afterFunc AfterFunc
+
+	storage           *storage.LevelDBBackend
+	network           network.Network
+	connectionManager network.ConnectionManager
+
+	fetcher   Fetcher
+	validator Validator
+
+	workPool   *Pool
+	stop       chan chan struct{}
+	ctx        context.Context
+	cancelFunc context.CancelFunc
+
+	logger log15.Logger
+}
+
+type SyncerOption func(s *Syncer)
+
+func NewSyncer(st *storage.LevelDBBackend, nw network.Network, cm network.ConnectionManager, opts ...SyncerOption) *Syncer {
+	ctx, cancelFunc := context.WithCancel(context.Background())
+
+	s := &Syncer{
+		storage:           st,
+		network:           nw,
+		connectionManager: cm,
+
+		poolSize:      SyncPoolSize,
+		fetchTimeout:  FetchTimeout,
+		retryInterval: RetryInterval,
+		checkInterval: CheckBlockHeightInterval,
+
+		afterFunc: time.After,
+
+		stop:       make(chan chan struct{}),
+		ctx:        ctx,
+		cancelFunc: cancelFunc,
+
+		logger: NopLogger(),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	fetcher := NewBlockFetcher(nw, cm, st, func(f *BlockFetcher) {
+		f.fetchTimeout = s.fetchTimeout
+		f.logger = s.logger
+	})
+	s.fetcher = fetcher
+
+	validator := NewBlockValidator(nw, st, func(v *BlockValidator) {
+		v.logger = s.logger
+	})
+	s.validator = validator
+
+	return s
+}
+
+func (s *Syncer) Stop() error {
+	s.cancelFunc()
+	c := make(chan struct{})
+	s.stop <- c
+	<-c
+	s.workPool.Finish()
+	s.logger.Info("Stopped syncer")
+	return nil
+}
+
+func (s *Syncer) Start() error {
+	s.logger.Info("Starting syncer")
+	s.workPool = NewPool(s.poolSize)
+	s.loop()
+	return nil
+}
+
+func (s *Syncer) loop() {
+	checkc := s.afterFunc(s.checkInterval)
+	blockHeight := uint64(1)
+	for {
+		select {
+		case <-checkc:
+			blockHeight = s.syncBlockHeight(blockHeight)
+			checkc = s.afterFunc(s.checkInterval)
+		case c := <-s.stop:
+			close(c)
+			return
+		}
+	}
+}
+
+func (s *Syncer) syncBlockHeight(height uint64) uint64 {
+	blk, err := block.GetLatestBlock(s.storage)
+	if err != nil {
+		s.logger.Error("checkBlockHeight", "err", err)
+	}
+	newHeight := blk.Height + 1
+	if newHeight > height {
+		s.work(newHeight)
+		s.logger.Info("Starting sync", "height", newHeight)
+		return newHeight
+	}
+	return height
+}
+
+func (s *Syncer) work(height uint64) {
+	ctx := s.ctx
+	work := func() {
+	L:
+		for {
+			select {
+			case <-ctx.Done():
+				break L
+			default:
+				currHeight := s.currBlockHeight()
+				if currHeight > 0 && height <= currHeight {
+					s.logger.Info("This height has already synced", "height", height)
+					break L
+				}
+				blockInfo, _ := s.fetcher.Fetch(ctx, height)
+				if err := s.validator.Validate(ctx, blockInfo); err != nil {
+					s.logger.Error("validate failure", "err", err)
+					continue
+				}
+				break L
+			}
+		}
+		s.logger.Info("Done sync", "height", height)
+	}
+	s.workPool.Add(ctx, work)
+}
+
+func (s *Syncer) currBlockHeight() uint64 {
+	blk, err := block.GetLatestBlock(s.storage)
+	if err != nil {
+		s.logger.Error("block.GetLatestBlock", "err", err)
+		return 0
+	}
+	return blk.Height
+}

--- a/lib/sync/syncer.go
+++ b/lib/sync/syncer.go
@@ -21,6 +21,7 @@ type Syncer struct {
 	storage           *storage.LevelDBBackend
 	network           network.Network
 	connectionManager network.ConnectionManager
+	networkID         []byte
 
 	fetcher   Fetcher
 	validator Validator
@@ -35,13 +36,14 @@ type Syncer struct {
 
 type SyncerOption func(s *Syncer)
 
-func NewSyncer(st *storage.LevelDBBackend, nw network.Network, cm network.ConnectionManager, opts ...SyncerOption) *Syncer {
+func NewSyncer(st *storage.LevelDBBackend, nw network.Network, cm network.ConnectionManager, networkID []byte, opts ...SyncerOption) *Syncer {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	s := &Syncer{
 		storage:           st,
 		network:           nw,
 		connectionManager: cm,
+		networkID:         networkID,
 
 		poolSize:      SyncPoolSize,
 		fetchTimeout:  FetchTimeout,
@@ -67,7 +69,7 @@ func NewSyncer(st *storage.LevelDBBackend, nw network.Network, cm network.Connec
 	})
 	s.fetcher = fetcher
 
-	validator := NewBlockValidator(nw, st, func(v *BlockValidator) {
+	validator := NewBlockValidator(nw, st, networkID, func(v *BlockValidator) {
 		v.logger = s.logger
 	})
 	s.validator = validator

--- a/lib/sync/syncer_test.go
+++ b/lib/sync/syncer_test.go
@@ -1,0 +1,61 @@
+package sync
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncer(t *testing.T) {
+	st := storage.NewTestStorage()
+	defer st.Close()
+	_, nw, _ := network.CreateMemoryNetwork(nil)
+	cm := &mockConnectionManager{}
+
+	tickc := make(chan time.Time)
+	blockInfoC := make(chan *BlockInfo)
+
+	syncer := NewSyncer(st, nw, cm)
+	defer syncer.Stop()
+
+	syncer.fetcher = &mockFetcher{
+		fetchFunc: func(ctx context.Context, height uint64) (*BlockInfo, error) {
+			bk := block.TestMakeNewBlock([]string{})
+			bk.Height = height
+			bi := &BlockInfo{
+				BlockHeight: height,
+				Block:       &bk,
+			}
+			return bi, nil
+		},
+	}
+	syncer.validator = &mockValidator{
+		validateFunc: func(ctx context.Context, bi *BlockInfo) error {
+			blockInfoC <- bi
+			return nil
+		},
+	}
+	syncer.afterFunc = func(d time.Duration) <-chan time.Time {
+		return tickc
+	}
+
+	go func() {
+		syncer.Start()
+	}()
+
+	{
+		bk := block.TestMakeNewBlock([]string{})
+		bk.Height = uint64(1)
+		require.Nil(t, bk.Save(st))
+
+		tickc <- time.Time{}
+		bi := <-blockInfoC
+		require.NotNil(t, bi.Block)
+		require.Equal(t, bi.BlockHeight, uint64(2))
+	}
+}

--- a/lib/sync/syncer_test.go
+++ b/lib/sync/syncer_test.go
@@ -16,11 +16,12 @@ func TestSyncer(t *testing.T) {
 	defer st.Close()
 	_, nw, _ := network.CreateMemoryNetwork(nil)
 	cm := &mockConnectionManager{}
+	networkID := []byte("test-network")
 
 	tickc := make(chan time.Time)
 	infoC := make(chan *SyncInfo)
 
-	syncer := NewSyncer(st, nw, cm)
+	syncer := NewSyncer(st, nw, cm, networkID)
 	defer syncer.Stop()
 
 	syncer.fetcher = &mockFetcher{

--- a/lib/sync/try.go
+++ b/lib/sync/try.go
@@ -1,0 +1,31 @@
+package sync
+
+import "errors"
+
+type TryFunc func(attempt int) (retry bool, err error)
+
+const MaxRetries = 10
+
+var errMaxRetriesReached = errors.New("exceeded retry limit")
+
+func Try(maxRetries int, fn TryFunc) error {
+	var err error
+	var cont bool
+	attempt := 1
+	for {
+		cont, err = fn(attempt)
+		if !cont || err == nil {
+			break
+		}
+		attempt++
+		// if maxRetries < 0 , infinite retries.
+		if maxRetries > 0 && attempt > maxRetries {
+			return errMaxRetriesReached
+		}
+	}
+	return err
+}
+
+func TryForever(fn TryFunc) error {
+	return Try(-1, fn)
+}

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -9,6 +9,16 @@ import (
 	"boscoin.io/sebak/lib/transaction"
 )
 
+type SyncProgress struct {
+	StartingBlock uint64 // Block number where sync began
+	CurrentBlock  uint64 // Current block number where sync is at
+	HighestBlock  uint64 // Highest alleged block number in the chain
+}
+
+type SyncController interface {
+	SetSyncTargetBlock(ctx context.Context, height uint64) error
+}
+
 type SyncInfo struct {
 	BlockHeight uint64
 	Block       *block.Block

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -1,0 +1,30 @@
+package sync
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"boscoin.io/sebak/lib/block"
+)
+
+type BlockInfo struct {
+	BlockHeight uint64
+	Block       *block.Block
+	Txs         []*block.BlockTransaction
+	Ops         []*block.BlockOperation
+}
+
+type Doer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type AfterFunc = func(time.Duration) <-chan time.Time
+
+type Fetcher interface {
+	Fetch(ctx context.Context, height uint64) (*BlockInfo, error)
+}
+
+type Validator interface {
+	Validate(context.Context, *BlockInfo) error
+}

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -6,13 +6,16 @@ import (
 	"time"
 
 	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/transaction"
 )
 
 type SyncInfo struct {
 	BlockHeight uint64
 	Block       *block.Block
-	Txs         []*block.BlockTransaction
-	Ops         []*block.BlockOperation
+	Txs         []*transaction.Transaction
+
+	BlockTxs []*block.BlockTransaction
+	BlockOps []*block.BlockOperation
 }
 
 type Doer interface {

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -8,7 +8,7 @@ import (
 	"boscoin.io/sebak/lib/block"
 )
 
-type BlockInfo struct {
+type SyncInfo struct {
 	BlockHeight uint64
 	Block       *block.Block
 	Txs         []*block.BlockTransaction
@@ -22,9 +22,9 @@ type Doer interface {
 type AfterFunc = func(time.Duration) <-chan time.Time
 
 type Fetcher interface {
-	Fetch(ctx context.Context, height uint64) (*BlockInfo, error)
+	Fetch(ctx context.Context, syncInfo *SyncInfo) (*SyncInfo, error)
 }
 
 type Validator interface {
-	Validate(context.Context, *BlockInfo) error
+	Validate(context.Context, *SyncInfo) error
 }

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -1,0 +1,102 @@
+package sync
+
+import (
+	"context"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/storage"
+
+	"github.com/inconshreveable/log15"
+)
+
+type BlockValidator struct {
+	network network.Network
+	storage *storage.LevelDBBackend
+
+	logger log15.Logger
+}
+
+type BlockValidatorOption func(*BlockValidator)
+
+func NewBlockValidator(nw network.Network, ldb *storage.LevelDBBackend, opts ...BlockValidatorOption) *BlockValidator {
+	v := &BlockValidator{
+		network: nw,
+		storage: ldb,
+
+		logger: NopLogger(),
+	}
+
+	for _, opt := range opts {
+		opt(v)
+	}
+
+	return v
+}
+
+func (v *BlockValidator) Validate(ctx context.Context, blockInfo *BlockInfo) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		err := v.validate(ctx, blockInfo)
+		if err != nil {
+			return err
+		}
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return v.save(ctx, blockInfo)
+	}
+}
+
+func (v *BlockValidator) validate(ctx context.Context, blockInfo *BlockInfo) error {
+	//TODO: validate
+	return nil
+}
+
+func (v *BlockValidator) save(ctx context.Context, blockInfo *BlockInfo) error {
+	//TODO(anarcher): using leveldb.Tx or leveldb.Batch?
+	height := blockInfo.BlockHeight
+	exists, err := block.ExistsBlockByHeight(v.storage, height)
+	if err != nil {
+		return err
+	}
+	if exists == true {
+		v.logger.Info("This block exists", "height", height)
+		return nil
+	}
+
+	for _, op := range blockInfo.Ops {
+		if err := op.Save(v.storage); err != nil {
+			if err == errors.ErrorBlockAlreadyExists {
+				return nil
+			}
+			return err
+		}
+	}
+
+	for _, tx := range blockInfo.Txs {
+		if err := tx.Save(v.storage); err != nil {
+			if err == errors.ErrorBlockAlreadyExists {
+				return nil
+			}
+			return err
+		}
+	}
+
+	blk := *blockInfo.Block
+	if err := blk.Save(v.storage); err != nil {
+		if err == errors.ErrorBlockAlreadyExists {
+			return nil
+		}
+		return err
+	}
+
+	v.logger.Info("Save block", "height", height)
+	return nil
+
+}

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -18,15 +18,18 @@ type BlockValidator struct {
 	network network.Network
 	storage *storage.LevelDBBackend
 
+	networkID []byte
+
 	logger log15.Logger
 }
 
 type BlockValidatorOption func(*BlockValidator)
 
-func NewBlockValidator(nw network.Network, ldb *storage.LevelDBBackend, opts ...BlockValidatorOption) *BlockValidator {
+func NewBlockValidator(nw network.Network, ldb *storage.LevelDBBackend, networkID []byte, opts ...BlockValidatorOption) *BlockValidator {
 	v := &BlockValidator{
-		network: nw,
-		storage: ldb,
+		network:   nw,
+		storage:   ldb,
+		networkID: networkID,
 
 		logger: NopLogger(),
 	}
@@ -166,6 +169,10 @@ func (v *BlockValidator) validateTxs(ctx context.Context, si *SyncInfo) error {
 		hash := tx.B.MakeHashString()
 		if hash != tx.H.Hash {
 			err := errors.ErrorHashDoesNotMatch
+			return err
+		}
+
+		if err := tx.IsWellFormed(v.networkID); err != nil {
 			return err
 		}
 	}

--- a/lib/sync/validator_test.go
+++ b/lib/sync/validator_test.go
@@ -14,9 +14,10 @@ func TestValidator(t *testing.T) {
 	st := storage.NewTestStorage()
 	defer st.Close()
 
+	networkID := []byte("test-network")
 	_, nw, _ := network.CreateMemoryNetwork(nil)
 
-	v := NewBlockValidator(nw, st)
+	v := NewBlockValidator(nw, st, networkID)
 
 	ctx := context.Background()
 

--- a/lib/sync/validator_test.go
+++ b/lib/sync/validator_test.go
@@ -1,0 +1,32 @@
+package sync
+
+import (
+	"context"
+	"testing"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidator(t *testing.T) {
+	st := storage.NewTestStorage()
+	defer st.Close()
+
+	_, nw, _ := network.CreateMemoryNetwork(nil)
+
+	v := NewBlockValidator(nw, st)
+
+	ctx := context.Background()
+
+	bk := block.TestMakeNewBlock(nil)
+	bi := &BlockInfo{
+		BlockHeight: uint64(1),
+		Block:       &bk,
+	}
+
+	err := v.Validate(ctx, bi)
+	require.Nil(t, err)
+
+}

--- a/lib/sync/validator_test.go
+++ b/lib/sync/validator_test.go
@@ -21,12 +21,12 @@ func TestValidator(t *testing.T) {
 	ctx := context.Background()
 
 	bk := block.TestMakeNewBlock(nil)
-	bi := &BlockInfo{
+	si := &SyncInfo{
 		BlockHeight: uint64(1),
 		Block:       &bk,
 	}
 
-	err := v.Validate(ctx, bi)
+	err := v.Validate(ctx, si)
 	require.Nil(t, err)
 
 }


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->
Related: #302

### Background

IMHO, This is a much more`* N` simple version of sync than #448  `~_~`

### Solution

- Just use `WorkerPool` for syncing. (default pool size is 300)

```
func (s *Syncer) work(height uint64) {
	ctx := s.ctx
	work := func() {
	L:
		for {
			select {
			case <-ctx.Done():
				break L
			default:
				currHeight := s.currBlockHeight()
				if currHeight > 0 && height <= currHeight {
					s.logger.Info("This height has already synced", "height", height)
					break L
				}
				blockInfo, _ := s.fetcher.Fetch(ctx, height)
				if err := s.validator.Validate(ctx, blockInfo); err != nil {
					s.logger.Error("validate failure", "err", err)
					continue
				}
				break L
			}
		}
		s.logger.Info("Done sync", "height", height)
	}
	s.workPool.Add(ctx, work)
}
```

- If Fetcher and Validator need to do work concurrently, They can have their own `WorkerPool` too. `'ㅅ'`

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->