### PR TITLE
Fix integration tests' instructions

### DIFF
--- a/tests/overdraft/README.md
+++ b/tests/overdraft/README.md
@@ -25,10 +25,10 @@ here is how to do it.
 ## Commands used
 
 ```sh
-docker run --network host -it sebak wallet payment ${PUBKEY3} 10_000 ${SECRET1} --endpoint=https://127.0.0.1:2821 --create --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY3} 1_000_000 ${SECRET1} --endpoint=https://127.0.0.1:2821 --create --verbose
 docker run --network host -it sebak wallet payment ${PUBKEY3} 0 ${SECRET1} --endpoint=https://127.0.0.1:2821 --verbose
 docker run --network host -it sebak wallet payment ${PUBKEY3} 1 ${SECRET1} --endpoint=https://127.0.0.1:2821 --verbose
-docker run --network host -it sebak wallet payment ${PUBKEY1} 100 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
-docker run --network host -it sebak wallet payment ${PUBKEY1} 2 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
-docker run --network host -it sebak wallet payment ${PUBKEY1} 1 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY1} 999_000 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY1} 990_002 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
+docker run --network host -it sebak wallet payment ${PUBKEY1} 990_001 ${SECRET3} --endpoint=https://127.0.0.1:2821 --verbose
 ```

--- a/tests/overdraft/request_2_2821_no_amount_tx.json
+++ b/tests/overdraft/request_2_2821_no_amount_tx.json
@@ -2,13 +2,13 @@
   "T": "transaction",
   "H": {
     "version": "",
-    "created": "2018-09-27T16:11:35.177557660+09:00",
-    "signature": "28p4QQ52UCCiioSmQv6d76f5mdcxfbfkVYtfYayzx4G2cPJDKE6j8mkiQakT5SfFDDYTzkLVvMbY69j81rKHRQRZ"
+    "created": "2018-09-19T04:26:41.304736300Z",
+    "signature": "43efdDCVdc3MrvH5cKfKn88CYV9oGnPGNzcYRtycEPvWjoZRMZkCNZ6H6kaGpGRSL7SUkuS5YaR2QYsbEbpLQYGV"
   },
   "B": {
     "source": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",
     "fee": "10000",
-    "sequenceID": 0,
+    "sequenceID": 1,
     "operations": [
       {
         "H": {

--- a/tests/overdraft/request_5_2821_overdraft_by_1.json
+++ b/tests/overdraft/request_5_2821_overdraft_by_1.json
@@ -3,12 +3,12 @@
   "H": {
     "version": "",
     "created": "2018-09-27T14:34:59.042780273+09:00",
-    "signature": "3SSWV2Mo6wrJSF5QgtLuLCPR2g6ECL73tQRoB8Pbc9LT8X57bbrMHGk66pHjd1kBY5GzuumzxDgCU2mm9patQzSp"
+    "signature": "2ruvnBdqYeiWxHW775v4SkpBr8Ds8F7PFNEKhzzrattEQxW5WDFAYDjeTvNTLuwoM28aoSwzXUU2nxevxCYJttYk"
   },
   "B": {
     "source": "GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4",
     "fee": "10000",
-    "sequenceID": 1,
+    "sequenceID": 0,
     "operations": [
       {
         "H": {
@@ -16,7 +16,7 @@
         },
         "B": {
           "target": "GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ",
-          "amount": "990001"
+          "amount": "990002"
         }
       }
     ]


### PR DESCRIPTION
The previous changes to the tests did not update the instructions.
Also included some wrong changes to the sequence ID.