### PR TITLE
Get rid of TransactionPool.Hashes

### DIFF
--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -305,8 +305,10 @@ func TestGetNodeTransactionsHandlerInTransactionPool(t *testing.T) {
 	defer p.Done()
 
 	{
-		txHashes := []string{
-			p.consensus.TransactionPool.Hashes[1],
+		var txHashes []string
+		for key, _ := range p.consensus.TransactionPool.Pool {
+			txHashes = append(txHashes, key)
+			break // Only get the first value in the pool
 		}
 
 		u := p.URL(nil)
@@ -343,12 +345,12 @@ func TestGetNodeTransactionsHandlerTooManyHashes(t *testing.T) {
 	}()
 
 	{
-		txHashes := []string{
-			p.consensus.TransactionPool.Hashes[1],
-			p.transactionHashes[0],
-			p.transactionHashes[1],
-			p.transactionHashes[2],
+		var txHashes []string
+		for key, _ := range p.consensus.TransactionPool.Pool {
+			txHashes = append(txHashes, key)
+			break // Only get the first value in the pool
 		}
+		txHashes = append(txHashes, p.transactionHashes[0], p.transactionHashes[1], p.transactionHashes[2])
 
 		query := url.Values{"hash": txHashes}
 		u := p.URL(nil)

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -307,7 +307,6 @@ func TestGetNodeTransactionsHandlerInTransactionPool(t *testing.T) {
 	{
 		txHashes := []string{
 			p.consensus.TransactionPool.Hashes[1],
-			p.consensus.TransactionPool.Hashes[len(p.consensus.TransactionPool.Hashes)-2],
 		}
 
 		u := p.URL(nil)
@@ -324,12 +323,9 @@ func TestGetNodeTransactionsHandlerInTransactionPool(t *testing.T) {
 		require.Nil(t, err)
 
 		require.Equal(t, 1, len(rbs))
-		require.Equal(t, 2, len(rbs[NodeItemTransaction]))
-
-		for i, hash := range txHashes {
-			tx := rbs[NodeItemTransaction][i].(transaction.Transaction)
-			require.Equal(t, hash, tx.GetHash())
-		}
+		require.Equal(t, 1, len(rbs[NodeItemTransaction]))
+		tx := rbs[NodeItemTransaction][0].(transaction.Transaction)
+		require.Equal(t, txHashes[0], tx.GetHash())
 	}
 }
 
@@ -349,7 +345,6 @@ func TestGetNodeTransactionsHandlerTooManyHashes(t *testing.T) {
 	{
 		txHashes := []string{
 			p.consensus.TransactionPool.Hashes[1],
-			p.consensus.TransactionPool.Hashes[len(p.consensus.TransactionPool.Hashes)-2],
 			p.transactionHashes[0],
 			p.transactionHashes[1],
 			p.transactionHashes[2],

--- a/lib/transaction/transaction_pool.go
+++ b/lib/transaction/transaction_pool.go
@@ -37,9 +37,11 @@ func (tp *TransactionPool) Get(hash string) (tx Transaction, found bool) {
 }
 
 func (tp *TransactionPool) Add(tx Transaction) bool {
+	tp.RLock()
 	if _, found := tp.Pool[tx.GetHash()]; found {
 		return false
 	}
+	tp.RUnlock()
 
 	tp.Lock()
 	defer tp.Unlock()


### PR DESCRIPTION
A small refactoring to simplify TransactionPool's code.