### PR TITLE
Add Syncer.SetSyncTargetHeight

### DIFF
--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -13,7 +13,7 @@ const (
 	SyncPoolSize             = 300
 	FetchTimeout             = 1 * time.Minute
 	RetryInterval            = 10 * time.Second
-	CheckBlockHeightInterval = 500 * time.Millisecond
+	CheckBlockHeightInterval = 30 * time.Second
 )
 
 type Config struct {
@@ -56,5 +56,17 @@ func (c *Config) NewSyncer() *Syncer {
 		s.checkInterval = c.CheckBlockHeightInterval
 		s.logger = c.logger
 	})
+
+	c.LoggingConfig()
 	return s
+}
+
+func (c *Config) LoggingConfig() {
+	c.logger.Info("syncer config",
+		"poolSize", c.SyncPoolSize,
+		"fetchTimeout", c.FetchTimeout,
+		"retryInterval", c.RetryInterval,
+		"checkInterval", c.CheckBlockHeightInterval,
+	)
+
 }

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -26,6 +26,7 @@ func TestNewConfig(t *testing.T) {
 
 	cfg := NewConfig(networkID, node, st, nt, cm)
 	cfg.SyncPoolSize = 100
+	cfg.logger = NopLogger()
 
 	syncer := cfg.NewSyncer()
 

--- a/lib/sync/fetcher.go
+++ b/lib/sync/fetcher.go
@@ -96,7 +96,7 @@ func (f *BlockFetcher) fetch(ctx context.Context, si *SyncInfo) error {
 	f.logger.Debug("Fetch start", "height", height)
 
 	n := f.pickRandomNode()
-	f.logger.Info(fmt.Sprintf("Fetching items from node: %s", n), "fetching_node", n, "height", height)
+	f.logger.Info(fmt.Sprintf("fetching items from node: %v", n), "fetching_node", n, "height", height)
 	if n == nil {
 		return errors.New("Fetch: node not found")
 	}
@@ -133,7 +133,7 @@ func (f *BlockFetcher) fetch(ctx context.Context, si *SyncInfo) error {
 		return err
 	}
 
-	f.logger.Info("Fetch get items", "items", len(items), "height", height)
+	f.logger.Info("fetch get items", "items", len(items), "height", height)
 
 	blocks, ok := items[runner.NodeItemBlock]
 	if !ok || len(blocks) <= 0 {
@@ -185,6 +185,10 @@ func (f *BlockFetcher) pickRandomNode() node.Node {
 		if f.localNode.Address() != a {
 			addressList = append(addressList, a)
 		}
+	}
+
+	if len(addressList) <= 0 {
+		return nil
 	}
 
 	idx := rand.Intn(len(addressList))

--- a/lib/sync/pool.go
+++ b/lib/sync/pool.go
@@ -56,6 +56,15 @@ func (p *Pool) Add(ctx context.Context, f func()) error {
 	}
 }
 
+func (p *Pool) TryAdd(ctx context.Context, f func()) bool {
+	select {
+	case p.work <- f:
+		return true
+	default:
+		return false
+	}
+}
+
 func (p *Pool) Finish() {
 	select {
 	case <-p.finish:

--- a/lib/sync/syncer.go
+++ b/lib/sync/syncer.go
@@ -184,12 +184,13 @@ func (s *Syncer) sync(p *SyncProgress) {
 		}
 	)
 
-	if latestBlockHeight > p.CurrentBlock {
-		currentHeight = latestBlockHeight
+	if latestBlockHeight > currentHeight {
+		startHeight = latestBlockHeight + 1
 	}
-	if currentHeight >= highestHeight {
+	if startHeight > highestHeight {
+		p.StartingBlock = latestBlockHeight + 1
 		p.CurrentBlock = currentHeight
-		log("sync progress skip: current latest height is over than highest (requested) height")
+		log("sync progress skip: start height is over or equal than highest (requested) height")
 		return
 	}
 

--- a/lib/sync/syncer_test.go
+++ b/lib/sync/syncer_test.go
@@ -45,15 +45,17 @@ func TestSyncer(t *testing.T) {
 		return tickc
 	}
 
+	{
+		bk := block.TestMakeNewBlock([]string{})
+		bk.Height = uint64(1)
+		require.Nil(t, bk.Save(st))
+	}
+
 	go func() {
 		syncer.Start()
 	}()
 
 	{
-		bk := block.TestMakeNewBlock([]string{})
-		bk.Height = uint64(1)
-		require.Nil(t, bk.Save(st))
-
 		tickc <- time.Time{}
 		si := <-infoC
 		require.NotNil(t, si.Block)

--- a/lib/sync/syncer_test.go
+++ b/lib/sync/syncer_test.go
@@ -11,7 +11,65 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type SyncerTestContext struct {
+	t         *testing.T
+	st        *storage.LevelDBBackend
+	syncer    *Syncer
+	tickC     chan time.Time
+	syncInfoC chan *SyncInfo
+}
+
 func TestSyncer(t *testing.T) {
+	fn := func(ctx *SyncerTestContext) {
+		{
+			bk := block.TestMakeNewBlock([]string{})
+			bk.Height = uint64(1)
+			require.Nil(t, bk.Save(ctx.st))
+		}
+
+		go func() {
+			ctx.syncer.Start()
+		}()
+
+		ctx.tickC <- time.Time{}
+		si := <-ctx.syncInfoC
+		require.NotNil(t, si.Block)
+		require.Equal(t, si.BlockHeight, uint64(2))
+	}
+	SyncerTest(t, fn)
+}
+
+func TestSyncerSetSyncTarget(t *testing.T) {
+	fn := func(tctx *SyncerTestContext) {
+		ctx := context.Background()
+		syncer := tctx.syncer
+
+		{
+			bk := block.TestMakeNewBlock([]string{})
+			bk.Height = uint64(1)
+			bk.Save(tctx.st)
+		}
+
+		go func() {
+			syncer.Start()
+		}()
+
+		height := uint64(10)
+		syncer.SetSyncTargetBlock(ctx, height)
+		sp, err := syncer.SyncProgress(ctx)
+		require.Nil(t, err)
+
+		var heights []uint64
+		for i := sp.StartingBlock; i <= sp.CurrentBlock; i++ {
+			si := <-tctx.syncInfoC
+			heights = append(heights, si.BlockHeight)
+		}
+		require.Equal(t, len(heights), 9)
+	}
+	SyncerTest(t, fn)
+}
+
+func SyncerTest(t *testing.T, fn func(*SyncerTestContext)) {
 	st := storage.NewTestStorage()
 	defer st.Close()
 	_, nw, localNode := network.CreateMemoryNetwork(nil)
@@ -19,7 +77,7 @@ func TestSyncer(t *testing.T) {
 	networkID := []byte("test-network")
 
 	tickc := make(chan time.Time)
-	infoC := make(chan *SyncInfo)
+	infoc := make(chan *SyncInfo)
 
 	syncer := NewSyncer(st, nw, cm, networkID, localNode)
 	defer syncer.Stop()
@@ -37,7 +95,7 @@ func TestSyncer(t *testing.T) {
 	}
 	syncer.validator = &mockValidator{
 		validateFunc: func(ctx context.Context, si *SyncInfo) error {
-			infoC <- si
+			infoc <- si
 			return nil
 		},
 	}
@@ -45,20 +103,13 @@ func TestSyncer(t *testing.T) {
 		return tickc
 	}
 
-	{
-		bk := block.TestMakeNewBlock([]string{})
-		bk.Height = uint64(1)
-		require.Nil(t, bk.Save(st))
+	ctx := &SyncerTestContext{
+		t:         t,
+		st:        st,
+		syncer:    syncer,
+		tickC:     tickc,
+		syncInfoC: infoc,
 	}
 
-	go func() {
-		syncer.Start()
-	}()
-
-	{
-		tickc <- time.Time{}
-		si := <-infoC
-		require.NotNil(t, si.Block)
-		require.Equal(t, si.BlockHeight, uint64(2))
-	}
+	fn(ctx)
 }

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -15,6 +15,15 @@ type SyncProgress struct {
 	HighestBlock  uint64 // Highest alleged block number in the chain
 }
 
+func (s SyncProgress) Clone() *SyncProgress {
+	sp := &SyncProgress{
+		StartingBlock: s.StartingBlock,
+		CurrentBlock:  s.CurrentBlock,
+		HighestBlock:  s.HighestBlock,
+	}
+	return sp
+}
+
 type SyncController interface {
 	SetSyncTargetBlock(ctx context.Context, height uint64) error
 }

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -110,7 +110,7 @@ func (v *BlockValidator) finishBlock(ctx context.Context, syncInfo *SyncInfo) er
 		ts.Discard()
 		return err
 	}
-	v.logger.Info("Finish to sync block", "height", syncInfo.BlockHeight)
+	v.logger.Info("Finish to sync block", "height", syncInfo.BlockHeight, "hash", blk.Hash)
 
 	if err := ts.Commit(); err != nil {
 		ts.Discard()

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"boscoin.io/sebak/lib/block"
@@ -110,7 +111,7 @@ func (v *BlockValidator) finishBlock(ctx context.Context, syncInfo *SyncInfo) er
 		ts.Discard()
 		return err
 	}
-	v.logger.Info("Finish to sync block", "height", syncInfo.BlockHeight, "hash", blk.Hash)
+	v.logger.Info(fmt.Sprintf("finish to sync block height: %v", syncInfo.BlockHeight), "height", syncInfo.BlockHeight, "hash", blk.Hash)
 
 	if err := ts.Commit(); err != nil {
 		ts.Discard()


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background
- `Syncer.SetSyncTargetHeight` for setting sync target height. 
-  Consensus handles which height It need to sync talks to syncer by this function. 
- If syncer's pool is not enough to add more works , syncer just keeps this height to `SyncProgress` and then after next check time (0.5sec by default) the syncer try to add more work from current working height  to this height.

### Solution

- Add `pool.TryAdd` for unblocking add 
- Add `SyncProgress` for keeping sync progress

```
type SyncProgress struct {
    StartingBlock uint64 // Block number where sync began
    CurrentBlock  uint64 // Current block number where sync is at
    HighestBlock  uint64 // Highest alleged block number in the chain
}
```

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->
- Current, Syncer try to increase  highest height per 0.5 sec, But if Consensus handles it, This increase can be removed. :-) (Because Consensus can handle better than timer based increasing.)

