### PR TITLE
Add Sync Watcher

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -401,11 +401,18 @@ func runNode() error {
 			nr.Stop()
 		})
 	}
+	c := sync.NewConfig([]byte(flagNetworkID), localNode, st, nt, connectionManager)
+	//Place setting config
+	syncer := c.NewSyncer()
 	{
-		c := sync.NewConfig([]byte(flagNetworkID), localNode, st, nt, connectionManager)
-		//Place setting config
-		syncer := c.NewSyncer()
-
+		watcher := c.NewWatcher(syncer)
+		g.Add(func() error {
+			return watcher.Start()
+		}, func(error) {
+			watcher.Stop()
+		})
+	}
+	{
 		g.Add(func() error {
 			return syncer.Start()
 		}, func(error) {

--- a/lib/network/validator_connection_manager.go
+++ b/lib/network/validator_connection_manager.go
@@ -176,6 +176,8 @@ func (c *ValidatorConnectionManager) connectValidator(v *node.Validator) (err er
 		return
 	}
 
+	v.SetBlockHeight(validator.BlockHeight())
+
 	return
 }
 

--- a/lib/node/local_node.go
+++ b/lib/node/local_node.go
@@ -134,7 +134,7 @@ func (n *LocalNode) MarshalJSON() ([]byte, error) {
 		"endpoint":     n.Endpoint().String(),
 		"state":        n.State().String(),
 		"validators":   n.validators,
-		"block_height": n.blockHeight,
+		"block-height": n.blockHeight,
 	})
 }
 

--- a/lib/node/local_node.go
+++ b/lib/node/local_node.go
@@ -28,6 +28,7 @@ type LocalNode struct {
 	bindEndpoint    *common.Endpoint
 	publishEndpoint *common.Endpoint
 	validators      map[ /* Node.Address() */ string]*Validator
+	blockHeight     uint64
 }
 
 func NewLocalNode(kp *keypair.Full, bindEndpoint *common.Endpoint, alias string) (n *LocalNode, err error) {
@@ -128,11 +129,12 @@ func (n *LocalNode) AddValidators(validators ...*Validator) error {
 
 func (n *LocalNode) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"address":    n.Address(),
-		"alias":      n.Alias(),
-		"endpoint":   n.Endpoint().String(),
-		"state":      n.State().String(),
-		"validators": n.validators,
+		"address":      n.Address(),
+		"alias":        n.Alias(),
+		"endpoint":     n.Endpoint().String(),
+		"state":        n.State().String(),
+		"validators":   n.validators,
+		"block_height": n.blockHeight,
 	})
 }
 
@@ -143,6 +145,14 @@ func (n *LocalNode) Serialize() ([]byte, error) {
 func (n *LocalNode) ConvertToValidator() *Validator {
 	v, _ := NewValidator(n.Address(), n.Endpoint(), n.Alias())
 	return v
+}
+
+func (n *LocalNode) BlockHeight() uint64 {
+	return n.blockHeight
+}
+
+func (n *LocalNode) SetBlockHeight(h uint64) {
+	n.blockHeight = h
 }
 
 func MakeAlias(address string) string {

--- a/lib/node/node.go
+++ b/lib/node/node.go
@@ -11,6 +11,7 @@ type Node interface {
 	Equal(Node) bool
 	Serialize() ([]byte, error)
 	State() State
+	BlockHeight() uint64
 	SetBooting()
 	SetSync()
 	SetConsensus()

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -93,7 +93,7 @@ func TestNodeMarshalJSONWithValidator(t *testing.T) {
 	tmpByte, err := localNode.MarshalJSON()
 	require.Equal(t, nil, err)
 
-	jsonStr := `"alias":"%s","block_height":%d,"endpoint":"https://localhost:%s","state":"%s"`
+	jsonStr := `"alias":"%s","block-height":%d,"endpoint":"https://localhost:%s","state":"%s"`
 
 	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "node", 0, "5000", "NONE")))
 	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v1", 0, "5001", "NONE")))

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -93,8 +93,9 @@ func TestNodeMarshalJSONWithValidator(t *testing.T) {
 	tmpByte, err := localNode.MarshalJSON()
 	require.Equal(t, nil, err)
 
-	jsonStr := `"alias":"%s","endpoint":"https://localhost:%s","state":"%s"`
-	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "node", "5000", "NONE")))
-	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v1", "5001", "NONE")))
-	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v2", "5002", "NONE")))
+	jsonStr := `"alias":"%s","block_height":%d,"endpoint":"https://localhost:%s","state":"%s"`
+
+	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "node", 0, "5000", "NONE")))
+	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v1", 0, "5001", "NONE")))
+	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v2", 0, "5002", "NONE")))
 }

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/network"
@@ -58,7 +59,13 @@ func (api NetworkHandlerNode) writeNodeItem(w http.ResponseWriter, itemType Node
 }
 
 func (api NetworkHandlerNode) NodeInfoHandler(w http.ResponseWriter, r *http.Request) {
-	b, err := NodeInfoWithRequest(api.localNode, r)
+	blk, err := block.GetLatestBlock(api.storage)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	b, err := NodeInfoWithRequest(api.localNode, &blk, r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -77,7 +84,13 @@ func (api NetworkHandlerNode) ConnectHandler(w http.ResponseWriter, r *http.Requ
 
 	api.network.MessageBroker().Receive(common.NetworkMessage{Type: common.ConnectMessage, Data: body})
 
-	b, err := NodeInfoWithRequest(api.localNode, r)
+	blk, err := block.GetLatestBlock(api.storage)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	b, err := NodeInfoWithRequest(api.localNode, &blk, r)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -123,7 +136,7 @@ func (api NetworkHandlerNode) BallotHandler(w http.ResponseWriter, r *http.Reque
 	return
 }
 
-func NodeInfoWithRequest(localNode *node.LocalNode, r *http.Request) (b []byte, err error) {
+func NodeInfoWithRequest(localNode *node.LocalNode, blk *block.Block, r *http.Request) (b []byte, err error) {
 	var endpoint string
 	if localNode.PublishEndpoint() != nil {
 		endpoint = localNode.PublishEndpoint().String()
@@ -134,12 +147,18 @@ func NodeInfoWithRequest(localNode *node.LocalNode, r *http.Request) (b []byte, 
 		endpoint = rUrl.String()
 	}
 
+	var blockHeight uint64
+	if blk != nil {
+		blockHeight = blk.Height
+	}
+
 	info := map[string]interface{}{
-		"address":    localNode.Address(),
-		"alias":      localNode.Alias(),
-		"endpoint":   endpoint,
-		"state":      localNode.State().String(),
-		"validators": localNode.GetValidators(),
+		"address":      localNode.Address(),
+		"alias":        localNode.Alias(),
+		"endpoint":     endpoint,
+		"state":        localNode.State().String(),
+		"validators":   localNode.GetValidators(),
+		"block_height": blockHeight,
 	}
 
 	b, err = json.Marshal(info)

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -158,7 +158,7 @@ func NodeInfoWithRequest(localNode *node.LocalNode, blk *block.Block, r *http.Re
 		"endpoint":     endpoint,
 		"state":        localNode.State().String(),
 		"validators":   localNode.GetValidators(),
-		"block_height": blockHeight,
+		"block-height": blockHeight,
 	}
 
 	b, err = json.Marshal(info)

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -209,7 +209,10 @@ func TestHTTP2NetworkConnect(t *testing.T) {
 	c0 := s0.GetClient(s0.Endpoint())
 	pingAndWait(t, c0)
 
-	o, _ := nodeRunner.Node().Serialize()
+	localNode := nodeRunner.Node()
+	localNode.SetBlockHeight(1)
+
+	o, _ := localNode.Serialize()
 	nodeStr := removeWhiteSpaces(string(o))
 
 	returnMsg, _ := c0.Connect(nodeRunner.Node())
@@ -246,6 +249,12 @@ func TestGetNodeInfoHandler(t *testing.T) {
 
 	server := httptest.NewServer(router)
 	defer server.Close()
+
+	{
+		bk := block.TestMakeNewBlock([]string{})
+		bk.Height = uint64(1)
+		require.Nil(t, bk.Save(st))
+	}
 
 	{ // without setting PublishEndpoint, `endpoint` of response should be requested URL
 		u, _ := url.Parse(server.URL)

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -19,10 +19,11 @@ import (
 )
 
 type ValidatorFromJSON struct {
-	Alias    string           `json:"alias"`
-	Address  string           `json:"address"`
-	Endpoint *common.Endpoint `json:"endpoint"`
-	State    State            `json:"state"`
+	Alias       string           `json:"alias"`
+	Address     string           `json:"address"`
+	Endpoint    *common.Endpoint `json:"endpoint"`
+	State       State            `json:"state"`
+	BlockHeight uint64           `json:"block_height"`
 }
 
 type Validator struct {
@@ -32,6 +33,8 @@ type Validator struct {
 	alias    string
 	address  string
 	endpoint *common.Endpoint
+
+	blockHeight uint64
 }
 
 func (v *Validator) String() string {
@@ -80,10 +83,11 @@ func (v *Validator) Endpoint() *common.Endpoint {
 
 func (v *Validator) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"address":  v.Address(),
-		"alias":    v.Alias(),
-		"endpoint": v.Endpoint().String(),
-		"state":    v.State().String(),
+		"address":      v.Address(),
+		"alias":        v.Alias(),
+		"endpoint":     v.Endpoint().String(),
+		"state":        v.State().String(),
+		"block_height": v.blockHeight,
 	})
 }
 
@@ -97,12 +101,17 @@ func (v *Validator) UnmarshalJSON(b []byte) error {
 	v.address = va.Address
 	v.endpoint = va.Endpoint
 	v.state = va.State
+	v.blockHeight = va.BlockHeight
 
 	return nil
 }
 
 func (v *Validator) Serialize() ([]byte, error) {
 	return json.Marshal(v)
+}
+
+func (v *Validator) BlockHeight() uint64 {
+	return v.blockHeight
 }
 
 func NewValidator(address string, endpoint *common.Endpoint, alias string) (v *Validator, err error) {

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -114,6 +114,10 @@ func (v *Validator) BlockHeight() uint64 {
 	return v.blockHeight
 }
 
+func (v *Validator) SetBlockHeight(h uint64) {
+	v.blockHeight = h
+}
+
 func NewValidator(address string, endpoint *common.Endpoint, alias string) (v *Validator, err error) {
 	if len(alias) < 1 {
 		alias = MakeAlias(address)

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -23,7 +23,7 @@ type ValidatorFromJSON struct {
 	Address     string           `json:"address"`
 	Endpoint    *common.Endpoint `json:"endpoint"`
 	State       State            `json:"state"`
-	BlockHeight uint64           `json:"block_height"`
+	BlockHeight uint64           `json:"block-height"`
 }
 
 type Validator struct {
@@ -87,7 +87,7 @@ func (v *Validator) MarshalJSON() ([]byte, error) {
 		"alias":        v.Alias(),
 		"endpoint":     v.Endpoint().String(),
 		"state":        v.State().String(),
-		"block_height": v.blockHeight,
+		"block-height": v.blockHeight,
 	})
 }
 

--- a/lib/node/validator_test.go
+++ b/lib/node/validator_test.go
@@ -87,8 +87,8 @@ func TestValidatorMarshalJSON(t *testing.T) {
 	tmpByte, err := validator.MarshalJSON()
 	require.Equal(t, nil, err)
 
-	jsonStr := `"alias":"%s","endpoint":"https://localhost:%s","state":"%s"`
-	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v1", "5000", "NONE")))
+	jsonStr := `"alias":"%s","block_height":%d,"endpoint":"https://localhost:%s","state":"%s"`
+	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v1", 0, "5000", "NONE")))
 }
 
 func TestValidatorNewValidatorFromString(t *testing.T) {

--- a/lib/node/validator_test.go
+++ b/lib/node/validator_test.go
@@ -87,7 +87,7 @@ func TestValidatorMarshalJSON(t *testing.T) {
 	tmpByte, err := validator.MarshalJSON()
 	require.Equal(t, nil, err)
 
-	jsonStr := `"alias":"%s","block_height":%d,"endpoint":"https://localhost:%s","state":"%s"`
+	jsonStr := `"alias":"%s","block-height":%d,"endpoint":"https://localhost:%s","state":"%s"`
 	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v1", 0, "5000", "NONE")))
 }
 

--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -61,6 +61,16 @@ func (c *Config) NewSyncer() *Syncer {
 	return s
 }
 
+func (c *Config) NewWatcher(syncer SyncController) *Watcher {
+	w := NewWatcher(
+		c.connectionManager,
+		c.storage,
+		syncer,
+	)
+	w.logger = c.logger
+	return w
+}
+
 func (c *Config) LoggingConfig() {
 	c.logger.Info("syncer config",
 		"poolSize", c.SyncPoolSize,

--- a/lib/sync/syncer.go
+++ b/lib/sync/syncer.go
@@ -145,8 +145,6 @@ func (s *Syncer) loop() {
 		HighestBlock:  height,
 	}
 
-	s.logger.Info("starting block to sync", "height", height)
-
 	for {
 		select {
 		case <-checkc:

--- a/lib/sync/syncer.go
+++ b/lib/sync/syncer.go
@@ -153,7 +153,7 @@ func (s *Syncer) loop() {
 			s.sync(syncProgress)
 			checkc = s.afterFunc(s.checkInterval)
 		case height := <-s.updateHighestBlock:
-			s.logger.Debug("update highest Height", "height", height)
+			s.logger.Info("update highest Height", "height", height)
 			if height > syncProgress.CurrentBlock {
 				syncProgress.HighestBlock = height
 				s.sync(syncProgress)

--- a/lib/sync/watcher.go
+++ b/lib/sync/watcher.go
@@ -1,0 +1,112 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/storage"
+	"github.com/inconshreveable/log15"
+)
+
+type Watcher struct {
+	cm       network.ConnectionManager
+	st       *storage.LevelDBBackend
+	syncer   SyncController
+	after    AfterFunc
+	interval time.Duration
+	stop     chan chan struct{}
+	logger   log15.Logger
+}
+
+func NewWatcher(cm network.ConnectionManager, st *storage.LevelDBBackend, syncer SyncController) *Watcher {
+	w := &Watcher{
+		cm:       cm,
+		st:       st,
+		syncer:   syncer,
+		after:    time.After,
+		interval: 5 * time.Second,
+		stop:     make(chan chan struct{}),
+		logger:   NopLogger(),
+	}
+	return w
+}
+
+func (w *Watcher) Start() error {
+	w.loop()
+	return nil
+}
+
+func (w *Watcher) Stop() error {
+	c := make(chan struct{})
+	w.stop <- c
+	<-c
+	return nil
+}
+
+func (w *Watcher) loop() {
+	var (
+		syncer        = w.syncer
+		checkc        = w.after(w.interval)
+		highestHeight uint64
+		latestHeight  uint64
+		err           error
+		ctx           = context.Background()
+	)
+	latestHeight = w.latestHeight()
+	w.logger.Info("starting sync watcher", "height", latestHeight)
+
+	for {
+		select {
+		case <-checkc:
+			highestHeight, err = w.highestHeight()
+			if err != nil {
+				w.logger.Error(err.Error(), "err", err.Error())
+				continue
+			}
+			if highestHeight > latestHeight {
+				syncer.SetSyncTargetBlock(ctx, highestHeight)
+				latestHeight = highestHeight
+			}
+			w.logger.Info("watched sync height", "high", highestHeight)
+			checkc = w.after(w.interval)
+		case c := <-w.stop:
+			close(c)
+			return
+		}
+	}
+}
+
+func (w *Watcher) highestHeight() (uint64, error) {
+	var (
+		ac            = w.cm.AllConnected()
+		nodes         []node.Node
+		highestHeight uint64
+	)
+
+	for _, a := range ac {
+		n := w.cm.GetNode(a)
+		if n == nil {
+			continue
+		}
+		nodes = append(nodes, n)
+		if n.BlockHeight() > highestHeight {
+			highestHeight = n.BlockHeight()
+			w.logger.Info(fmt.Sprintf("node %v has highestHeight %v", n, highestHeight), "height", highestHeight)
+		}
+	}
+
+	return highestHeight, nil
+}
+
+func (w *Watcher) latestHeight() uint64 {
+	blk, err := block.GetLatestBlock(w.st)
+	if err != nil {
+		w.logger.Error("block.GetLatestBlock", "err", err)
+		return 0
+	}
+	return blk.Height
+}


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

- `sync.Watcher` watches connected nodes by using `network.connectionManager` and then get highest height in the node network. 
- It can be useful watcher node mode(a node out of consensus network), because  with consensus mode, consensus can get highest height instead `sync.Watcher`
- TODO: How do interact with consensus with watcher and syncer?


### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

