### PR TITLE
Get Missing Transactions From Proposer

### DIFF
--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -66,4 +66,6 @@ var (
 	ErrorWrongBlockFound                      = NewError(159, "wrong Block found")
 	ErrorInvalidProposerTransaction           = NewError(160, "invalid proposer transaction found")
 	ErrorInvalidInflationRatio                = NewError(161, "invalid inflation ratio found")
+	ErrorNotImplemented                       = NewError(162, "not implemented")
+	ErrorHTTPProblem                          = NewError(163, "http failed to get response")
 )

--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -38,6 +38,7 @@ type NetworkClient interface {
 	GetNodeInfo() ([]byte, error)
 	SendMessage(common.Serializable) ([]byte, error)
 	SendBallot(common.Serializable) ([]byte, error)
+	GetTransactions([]string) ([]byte, error)
 }
 
 type MessageBroker interface {

--- a/lib/network/connection_manager.go
+++ b/lib/network/connection_manager.go
@@ -9,6 +9,7 @@ import (
 
 type ConnectionManager interface {
 	GetNodeAddress() string
+	GetConnection(string) NetworkClient
 	ConnectionWatcher(Network, net.Conn, http.ConnState)
 	Broadcast(common.Message)
 	Start()

--- a/lib/network/memory_client.go
+++ b/lib/network/memory_client.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/node"
 )
 
@@ -50,4 +51,8 @@ func (m *MemoryTransportClient) SendBallot(message common.Serializable) (body []
 	m.server.Send(common.BallotMessage, s)
 
 	return
+}
+
+func (m *MemoryTransportClient) GetTransactions([]string) ([]byte, error) {
+	return []byte{}, errors.ErrorNotImplemented
 }

--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -190,7 +190,7 @@ func UnmarshalNodeItemResponse(d []byte) (itemType NodeItemDataType, b interface
 	case NodeItemError:
 		var t errors.Error
 		err = unmarshal(&t)
-		b = t
+		b = &t
 	default:
 		err = errors.ErrorInvalidMessage
 	}

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -163,8 +163,8 @@ func TestGetNodeTransactionsHandlerWithUnknownHashes(t *testing.T) {
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
 		require.Equal(t, 1, len(rbs[NodeItemError]))
-		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(errors.Error).Code)
-		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(errors.Error).Data["hash"])
+		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(*errors.Error).Code)
+		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(*errors.Error).Data["hash"])
 	}
 
 	{ // unknown hash + known hash
@@ -182,8 +182,8 @@ func TestGetNodeTransactionsHandlerWithUnknownHashes(t *testing.T) {
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 		require.Nil(t, err)
 		require.Equal(t, 1, len(rbs[NodeItemError]))
-		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(errors.Error).Code)
-		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(errors.Error).Data["hash"])
+		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(*errors.Error).Code)
+		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(*errors.Error).Data["hash"])
 
 		require.Equal(t, 1, len(rbs[NodeItemTransaction]))
 

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -299,7 +299,7 @@ func getMissingTransaction(checker *BallotChecker) (err error) {
 			err = errors.ErrorTransactionNotFound
 			return
 		}
-		if err = tx.IsWellFormed(checker.NetworkID); err != nil {
+		if err = tx.IsWellFormed(checker.NetworkID, checker.NodeRunner.Conf); err != nil {
 			return
 		}
 

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -465,6 +465,11 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 	if checker.FinishedVotingHole == ballot.VotingYES {
+		if err = getMissingTransaction(checker); err != nil {
+			checker.Log.Debug("failed to get the missing transactions of ballot", "error", err)
+			return
+		}
+
 		var theBlock block.Block
 		theBlock, err = finishBallot(
 			checker.NodeRunner.Storage(),

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -242,12 +242,13 @@ func BallotCheckResult(c common.Checker, args ...interface{}) (err error) {
 	return
 }
 
-var handleBallotTransactionCheckerFuncs = []common.CheckerFunc{
+var INITBallotTransactionCheckerFuncs = []common.CheckerFunc{
 	IsNew,
 	GetMissingTransaction,
 	BallotTransactionsSameSource,
 	BallotTransactionsSourceCheck,
 	BallotTransactionsOperationBodyCollectTxFee,
+	BallotTransactionsAllValid,
 }
 
 // INITBallotValidateTransactions validates the
@@ -270,7 +271,7 @@ func INITBallotValidateTransactions(c common.Checker, args ...interface{}) (err 
 	}
 
 	transactionsChecker := &BallotTransactionChecker{
-		DefaultChecker: common.DefaultChecker{Funcs: handleBallotTransactionCheckerFuncs},
+		DefaultChecker: common.DefaultChecker{Funcs: INITBallotTransactionCheckerFuncs},
 		NodeRunner:     checker.NodeRunner,
 		LocalNode:      checker.LocalNode,
 		NetworkID:      checker.NetworkID,

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -1,7 +1,10 @@
 package runner
 
 import (
+	"bufio"
+	"bytes"
 	"encoding/json"
+	"io"
 
 	logging "github.com/inconshreveable/log15"
 
@@ -242,9 +245,93 @@ func BallotCheckResult(c common.Checker, args ...interface{}) (err error) {
 	return
 }
 
+// getMissingTransaction will get the missing tranactions, that is, not in
+// `TransactionPool` from proposer.
+func getMissingTransaction(checker *BallotChecker) (err error) {
+	// get missing transactions
+	var unknown []string
+	for _, hash := range checker.Ballot.Transactions() {
+		if checker.NodeRunner.Consensus().TransactionPool.Has(hash) {
+			continue
+		}
+		unknown = append(unknown, hash)
+	}
+
+	if len(unknown) < 1 {
+		return
+	}
+
+	client := checker.NodeRunner.ConnectionManager().GetConnection(checker.Ballot.Proposer())
+	if client == nil {
+		err = errors.ErrorBallotFromUnknownValidator
+		return
+	}
+	var body []byte
+	// TODO check error
+	if body, err = client.GetTransactions(unknown); err != nil {
+		return
+	}
+
+	var receivedTransaction []transaction.Transaction
+	bf := bufio.NewReader(bytes.NewReader(body))
+	for {
+		var l []byte
+		l, err = bf.ReadBytes('\n')
+		if err == io.EOF {
+			err = nil
+			break
+		} else if err != nil {
+			return
+		}
+		var itemType NodeItemDataType
+		var d interface{}
+		if itemType, d, err = UnmarshalNodeItemResponse(l); err != nil {
+			return
+		}
+		if itemType == NodeItemError {
+			err = d.(*errors.Error)
+			return
+		}
+
+		var tx transaction.Transaction
+		var ok bool
+		if tx, ok = d.(transaction.Transaction); !ok {
+			err = errors.ErrorTransactionNotFound
+			return
+		}
+		if err = tx.IsWellFormed(checker.NetworkID); err != nil {
+			return
+		}
+
+		receivedTransaction = append(receivedTransaction, tx)
+	}
+
+	for _, tx := range receivedTransaction {
+		checker.NodeRunner.Consensus().TransactionPool.Add(tx)
+	}
+
+	return
+}
+
+func BallotGetMissingTransaction(c common.Checker, args ...interface{}) (err error) {
+	checker := c.(*BallotChecker)
+
+	if checker.VotingHole != ballot.VotingNOTYET {
+		return
+	}
+
+	if err = getMissingTransaction(checker); err != nil {
+		checker.VotingHole = ballot.VotingNO
+		err = nil
+		checker.Log.Debug("failed to get the missing transactions of ballot", "error", err)
+	}
+
+	return
+}
+
 var INITBallotTransactionCheckerFuncs = []common.CheckerFunc{
 	IsNew,
-	GetMissingTransaction,
+	CheckMissingTransaction,
 	BallotTransactionsSameSource,
 	BallotTransactionsSourceCheck,
 	BallotTransactionsOperationBodyCollectTxFee,

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -1,6 +1,10 @@
 package runner
 
 import (
+	"bufio"
+	"bytes"
+	"io"
+
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
@@ -79,11 +83,69 @@ func IsNew(c common.Checker, args ...interface{}) (err error) {
 func GetMissingTransaction(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
 
+	// get missing transactions
+	var unknown []string
+	for _, hash := range checker.ValidTransactions {
+		if checker.NodeRunner.Consensus().TransactionPool.Has(hash) {
+			continue
+		}
+		unknown = append(unknown, hash)
+	}
+
+	if len(unknown) > 0 {
+		client := checker.NodeRunner.ConnectionManager().GetConnection(checker.Ballot.Proposer())
+		if client == nil {
+			err = errors.ErrorBallotFromUnknownValidator
+			return
+		}
+		var body []byte
+		// TODO check error
+		if body, err = client.GetTransactions(unknown); err != nil {
+			return
+		}
+
+		var receivedTransaction []transaction.Transaction
+		bf := bufio.NewReader(bytes.NewReader(body))
+		for {
+			var l []byte
+			l, err = bf.ReadBytes('\n')
+			if err == io.EOF {
+				err = nil
+				break
+			} else if err != nil {
+				return
+			}
+			var itemType NodeItemDataType
+			var d interface{}
+			if itemType, d, err = UnmarshalNodeItemResponse(l); err != nil {
+				return
+			}
+			if itemType == NodeItemError {
+				err = d.(*errors.Error)
+				return
+			}
+
+			var tx transaction.Transaction
+			var ok bool
+			if tx, ok = d.(transaction.Transaction); !ok {
+				err = errors.ErrorTransactionNotFound
+				return
+			}
+			if err = tx.IsWellFormed(checker.NetworkID); err != nil {
+				return
+			}
+
+			receivedTransaction = append(receivedTransaction, tx)
+		}
+
+		for _, tx := range receivedTransaction {
+			checker.NodeRunner.Consensus().TransactionPool.Add(tx)
+		}
+	}
+
 	var validTransactions []string
 	for _, hash := range checker.ValidTransactions {
 		if !checker.NodeRunner.Consensus().TransactionPool.Has(hash) {
-			// TODO get transaction from proposer and check
-			// `Transaction.IsWellFormed()`
 			continue
 		}
 		validTransactions = append(validTransactions, hash)
@@ -94,7 +156,7 @@ func GetMissingTransaction(c common.Checker, args ...interface{}) (err error) {
 	return
 }
 
-// BallotTransactionsSourceCheck checks there are transactions which has same
+// BallotTransactionsSameSource checks there are transactions which has same
 // source in the `Transactions`.
 func BallotTransactionsSameSource(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
@@ -175,6 +237,19 @@ func BallotTransactionsOperationBodyCollectTxFee(c common.Checker, args ...inter
 			err = errors.ErrorInvalidFee
 			return
 		}
+	}
+
+	return
+}
+
+// BallotTransactionsAllValid checks all the transactions are valid or not.
+func BallotTransactionsAllValid(c common.Checker, args ...interface{}) (err error) {
+	checker := c.(*BallotTransactionChecker)
+
+	if len(checker.InvalidTransactions()) > 0 {
+		checker.VotingHole = ballot.VotingNO
+	} else {
+		checker.VotingHole = ballot.VotingYES
 	}
 
 	return

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -74,8 +74,9 @@ func IsNew(c common.Checker, args ...interface{}) (err error) {
 	return
 }
 
-// GetMissingTransaction will get the missing
-// tranactions, that is, not in `Pool` from proposer.
+// CheckMissingTransaction will get the missing tranactions, that is, not in
+// `Pool` from proposer.
+func CheckMissingTransaction(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
 
 	var validTransactions []string

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -2,12 +2,15 @@ package runner
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
+	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus/round"
 	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/transaction"
 )
@@ -112,4 +115,218 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 			"invalid transaction must be in `Pool`: target account does not exists",
 		)
 	}
+}
+
+type getMissingTransactionTesting struct {
+	nodeRunners   []*NodeRunner
+	proposerNR    *NodeRunner
+	consensusNR   *NodeRunner
+	genesisBlock  block.Block
+	commonAccount *block.BlockAccount
+}
+
+func (g *getMissingTransactionTesting) Prepare() {
+	g.nodeRunners, _ = createTestNodeRunnersHTTP2Network(2)
+
+	g.proposerNR = g.nodeRunners[0]
+
+	for _, nr := range g.nodeRunners {
+		nr.Ready()
+		go nr.ConnectValidators()
+		go func(n *NodeRunner) {
+			panic(n.Network().Start())
+		}(nr)
+	}
+
+	T := time.NewTicker(100 * time.Millisecond)
+	stopTimer := make(chan bool)
+
+	go func() {
+		time.Sleep(5 * time.Second)
+		stopTimer <- true
+	}()
+
+	go func() {
+		for _ = range T.C {
+			var notyet bool
+			for _, nr := range g.nodeRunners {
+				if nr.ConnectionManager().CountConnected() != 1 {
+					notyet = true
+					break
+				}
+			}
+			if notyet {
+				continue
+			}
+			stopTimer <- true
+		}
+	}()
+	select {
+	case <-stopTimer:
+		T.Stop()
+	}
+
+	for _, nr := range g.nodeRunners {
+		nr.Consensus().SetProposerSelector(FixedSelector{g.proposerNR.Node().Address()})
+	}
+
+	g.consensusNR = g.nodeRunners[1]
+
+	g.genesisBlock, _ = block.GetBlockByHeight(g.proposerNR.Storage(), 1)
+	g.commonAccount, _ = GetCommonAccount(g.proposerNR.Storage())
+}
+
+func (g *getMissingTransactionTesting) MakeBallot(numberOfTxs int) (blt *ballot.Ballot) {
+	rd := round.Round{
+		Number:      0,
+		BlockHeight: g.genesisBlock.Height,
+		BlockHash:   g.genesisBlock.Hash,
+		TotalTxs:    g.genesisBlock.TotalTxs,
+	}
+
+	keys := map[string]*keypair.Full{}
+	var txHashes []string
+	var txs []transaction.Transaction
+	for i := 0; i < numberOfTxs; i++ {
+		kpA, _ := keypair.Random()
+		accountA := block.NewBlockAccount(kpA.Address(), common.Amount(common.BaseReserve)*2)
+		accountA.Save(g.proposerNR.Storage())
+
+		kpB, _ := keypair.Random()
+
+		tx := transaction.MakeTransactionCreateAccount(kpA, kpB.Address(), common.BaseReserve)
+		tx.B.SequenceID = accountA.SequenceID
+		tx.Sign(kpA, networkID)
+
+		keys[kpA.Address()] = kpA
+		txHashes = append(txHashes, tx.GetHash())
+		txs = append(txs, tx)
+
+		// inject txs to `TransactionPool`
+		g.proposerNR.Consensus().TransactionPool.Add(tx)
+	}
+
+	blt = ballot.NewBallot(g.proposerNR.Node().Address(), rd, txHashes)
+
+	ptx, _ := ballot.NewProposerTransactionFromBallot(*blt, g.commonAccount.Address, txs...)
+	blt.SetProposerTransaction(ptx)
+	blt.SetVote(ballot.StateINIT, ballot.VotingYES)
+	blt.Sign(g.proposerNR.Node().Keypair(), networkID)
+
+	return blt
+}
+
+// TestGetMissingTransactionAllMissing assumes,
+// * 2 NodeRunners
+// * first NodeRunner proposes Ballot
+// * 2nd NodeRunner does not have the transactions of the proposed Ballot
+// TestGetMissingTransactionAllMissing checks 2nd NodeRunner must have all the
+// transactions after `BallotTransactionChecker`.
+func TestGetMissingTransactionAllMissing(t *testing.T) {
+	g := &getMissingTransactionTesting{}
+	g.Prepare()
+
+	blt := g.MakeBallot(3)
+
+	var ballotMessage common.NetworkMessage
+	{
+		b, _ := blt.Serialize()
+		ballotMessage = common.NetworkMessage{
+			Type: common.BallotMessage,
+			Data: b,
+		}
+	}
+
+	baseChecker := &BallotChecker{
+		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleBaseBallotCheckerFuncs},
+		NodeRunner:     g.consensusNR,
+		LocalNode:      g.consensusNR.Node(),
+		NetworkID:      g.consensusNR.NetworkID(),
+		Message:        ballotMessage,
+		Log:            g.consensusNR.Log(),
+		VotingHole:     ballot.VotingNOTYET,
+	}
+	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
+	require.Nil(t, err)
+
+	var checkerFuncs = []common.CheckerFunc{
+		IsNew,
+		GetMissingTransaction,
+	}
+
+	transactionsChecker := &BallotTransactionChecker{
+		DefaultChecker: common.DefaultChecker{Funcs: checkerFuncs},
+		NodeRunner:     baseChecker.NodeRunner,
+		LocalNode:      baseChecker.LocalNode,
+		NetworkID:      baseChecker.NetworkID,
+		Ballot:         baseChecker.Ballot,
+		Transactions:   baseChecker.Ballot.Transactions(),
+		VotingHole:     ballot.VotingNOTYET,
+	}
+
+	err = common.RunChecker(transactionsChecker, common.DefaultDeferFunc)
+	require.Nil(t, err)
+
+	// check consensus node runner has all missing transactions.
+	for _, hash := range blt.Transactions() {
+		require.True(t, g.consensusNR.Consensus().TransactionPool.Has(hash))
+	}
+}
+
+// TestGetMissingTransactionProposerAlsoMissing assumes,
+// * 2 NodeRunners
+// * first NodeRunner proposes Ballot
+// * 2nd NodeRunner does not have the transactions of the proposed Ballot
+// * remove one transaction from first NodeRunner
+// * 2nd NodeRunner fail to get that transaction from proposer
+func TestGetMissingTransactionProposerAlsoMissing(t *testing.T) {
+	g := &getMissingTransactionTesting{}
+	g.Prepare()
+
+	blt := g.MakeBallot(3)
+
+	// remove 1st tx from `TransactionPool` of proposer NodeRunner
+	removedHash := blt.Transactions()[0]
+	g.proposerNR.Consensus().TransactionPool.Remove(removedHash)
+
+	var ballotMessage common.NetworkMessage
+	{
+		b, _ := blt.Serialize()
+		ballotMessage = common.NetworkMessage{
+			Type: common.BallotMessage,
+			Data: b,
+		}
+	}
+
+	baseChecker := &BallotChecker{
+		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleBaseBallotCheckerFuncs},
+		NodeRunner:     g.consensusNR,
+		LocalNode:      g.consensusNR.Node(),
+		NetworkID:      g.consensusNR.NetworkID(),
+		Message:        ballotMessage,
+		Log:            g.consensusNR.Log(),
+		VotingHole:     ballot.VotingNOTYET,
+	}
+	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
+	require.Nil(t, err)
+
+	var checkerFuncs = []common.CheckerFunc{
+		IsNew,
+		GetMissingTransaction,
+	}
+
+	transactionsChecker := &BallotTransactionChecker{
+		DefaultChecker: common.DefaultChecker{Funcs: checkerFuncs},
+		NodeRunner:     baseChecker.NodeRunner,
+		LocalNode:      baseChecker.LocalNode,
+		NetworkID:      baseChecker.NetworkID,
+		Ballot:         baseChecker.Ballot,
+		Transactions:   baseChecker.Ballot.Transactions(),
+		VotingHole:     ballot.VotingNOTYET,
+	}
+
+	err = common.RunChecker(transactionsChecker, common.DefaultDeferFunc)
+	require.Equal(t, errors.ErrorTransactionNotFound.Code, err.(*errors.Error).Code)
+	require.Equal(t, removedHash, err.(*errors.Error).Data["hash"].(string))
+	require.Equal(t, 0, g.consensusNR.Consensus().TransactionPool.Len())
 }

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -210,8 +210,8 @@ func (g *getMissingTransactionTesting) MakeBallot(numberOfTxs int) (blt *ballot.
 
 	blt = ballot.NewBallot(g.proposerNR.Node().Address(), rd, txHashes)
 
-	opc, _ := ballot.NewOperationCollectTxFeeFromBallot(*blt, g.commonAccount.Address, txs...)
-	opi, _ := ballot.NewOperationInflationFromBallot(*blt, g.commonAccount.Address, g.initialBalance)
+	opc, _ := ballot.NewCollectTxFeeFromBallot(*blt, g.commonAccount.Address, txs...)
+	opi, _ := ballot.NewInflationFromBallot(*blt, g.commonAccount.Address, g.initialBalance)
 
 	ptx, _ := ballot.NewProposerTransactionFromBallot(*blt, opc, opi)
 	blt.SetProposerTransaction(ptx)

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -250,21 +250,24 @@ func TestGetMissingTransactionAllMissing(t *testing.T) {
 	require.Nil(t, err)
 
 	var checkerFuncs = []common.CheckerFunc{
-		IsNew,
-		GetMissingTransaction,
+		BallotAlreadyVoted,
+		BallotVote,
+		BallotIsSameProposer,
+		BallotGetMissingTransaction,
 	}
 
-	transactionsChecker := &BallotTransactionChecker{
+	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: checkerFuncs},
 		NodeRunner:     baseChecker.NodeRunner,
 		LocalNode:      baseChecker.LocalNode,
 		NetworkID:      baseChecker.NetworkID,
+		Message:        ballotMessage,
 		Ballot:         baseChecker.Ballot,
-		Transactions:   baseChecker.Ballot.Transactions(),
 		VotingHole:     ballot.VotingNOTYET,
+		Log:            baseChecker.Log,
 	}
 
-	err = common.RunChecker(transactionsChecker, common.DefaultDeferFunc)
+	err = common.RunChecker(checker, common.DefaultDeferFunc)
 	require.Nil(t, err)
 
 	// check consensus node runner has all missing transactions.
@@ -311,22 +314,24 @@ func TestGetMissingTransactionProposerAlsoMissing(t *testing.T) {
 	require.Nil(t, err)
 
 	var checkerFuncs = []common.CheckerFunc{
-		IsNew,
-		GetMissingTransaction,
+		BallotAlreadyVoted,
+		BallotVote,
+		BallotIsSameProposer,
+		BallotGetMissingTransaction,
 	}
 
-	transactionsChecker := &BallotTransactionChecker{
+	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: checkerFuncs},
 		NodeRunner:     baseChecker.NodeRunner,
 		LocalNode:      baseChecker.LocalNode,
 		NetworkID:      baseChecker.NetworkID,
+		Message:        ballotMessage,
 		Ballot:         baseChecker.Ballot,
-		Transactions:   baseChecker.Ballot.Transactions(),
 		VotingHole:     ballot.VotingNOTYET,
+		Log:            baseChecker.Log,
 	}
+	err = common.RunChecker(checker, common.DefaultDeferFunc)
 
-	err = common.RunChecker(transactionsChecker, common.DefaultDeferFunc)
-	require.Equal(t, errors.ErrorTransactionNotFound.Code, err.(*errors.Error).Code)
-	require.Equal(t, removedHash, err.(*errors.Error).Data["hash"].(string))
+	require.Equal(t, ballot.VotingNO, checker.VotingHole)
 	require.Equal(t, 0, g.consensusNR.Consensus().TransactionPool.Len())
 }

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -494,7 +494,6 @@ func (nr *NodeRunner) TransitISAACState(round round.Round, ballotState ballot.St
 
 var NewBallotTransactionCheckerFuncs = []common.CheckerFunc{
 	IsNew,
-	GetMissingTransaction,
 	BallotTransactionsSameSource,
 	BallotTransactionsSourceCheck,
 }

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -48,6 +48,7 @@ var DefaultHandleINITBallotCheckerFuncs = []common.CheckerFunc{
 	BallotIsSameProposer,
 	BallotValidateOperationBodyCollectTxFee,
 	BallotValidateOperationBodyInflation,
+	BallotGetMissingTransaction,
 	INITBallotValidateTransactions,
 	SIGNBallotBroadcast,
 	TransitStateToSIGN,
@@ -67,6 +68,7 @@ var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
 	BallotVote,
 	BallotIsSameProposer,
 	BallotCheckResult,
+	BallotGetMissingTransaction,
 	FinishedBallotStore,
 }
 

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -68,7 +68,6 @@ var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
 	BallotVote,
 	BallotIsSameProposer,
 	BallotCheckResult,
-	BallotGetMissingTransaction,
 	FinishedBallotStore,
 }
 


### PR DESCRIPTION
### Github Issue
resolves #479 

### Background

Under current new designed ISAAC, the incoming transactions can not sure to be broadcasted to the entire nodes, so some node maybe receives the proposed ballot before getting some transactions of ballot.

### Solution

The `runner.GetMissingTransactions()` will get the missing transactions from proposer thru node api, `/node/transactions`(the proposer must know the transactions of ballot.)

### Changes

* `NetworkClient` will have new method, `GetTransactions`.
* `checker.BallotGetMissingTransaction()` will get the missing transaction `checker.BallotChecker` in `INIT` state.
* To get the missing `Transactions` will be processed in 2 state, `INIT` and `ACCEPT`.
    * `INIT`: node validates the incoming Ballot with the `Transactions` of `Ballot`
    * `ACCEPT`: node needs to know the all the `Transactions` of `Ballot` to store it.
* If `checker.BallotGetMissingTransaction()` fail to get the transactions from proposer in `INIT`, it will vote `Ballot.VotingNO` in `Ballot`.
* If `checker.FinishedBallotStore()` fails to get the transactions from proposer in `ACCEPT`, it will not save the new block.