### PR TITLE
Changes SetSyncTargetBlock(ctx,height,nodeAddrs)

### DIFF
--- a/lib/sync/fetcher.go
+++ b/lib/sync/fetcher.go
@@ -92,10 +92,13 @@ func (f *BlockFetcher) Fetch(ctx context.Context, syncInfo *SyncInfo) (*SyncInfo
 }
 
 func (f *BlockFetcher) fetch(ctx context.Context, si *SyncInfo) error {
-	var height = si.BlockHeight
+	var (
+		height    = si.BlockHeight
+		nodeAddrs = si.NodeAddrs
+	)
 	f.logger.Debug("Fetch start", "height", height)
 
-	n := f.pickRandomNode()
+	n := f.pickRandomNode(nodeAddrs)
 	f.logger.Info(fmt.Sprintf("fetching items from node: %v", n), "fetching_node", n, "height", height)
 	if n == nil {
 		return errors.New("Fetch: node not found")
@@ -174,15 +177,27 @@ func (f *BlockFetcher) fetch(ctx context.Context, si *SyncInfo) error {
 }
 
 // pickRandomNode choose one node by random. It is very protype for choosing fetching which node
-func (f *BlockFetcher) pickRandomNode() node.Node {
+func (f *BlockFetcher) pickRandomNode(nodeAddrs []string) node.Node {
 	ac := f.connectionManager.AllConnected()
 	if len(ac) <= 0 {
 		return nil
 	}
 
+	var nodeMap = make(map[string]struct{})
+	for _, addr := range nodeAddrs {
+		nodeMap[addr] = struct{}{}
+	}
+
 	var addressList []string
 	for _, a := range ac {
-		if f.localNode.Address() != a {
+		if f.localNode.Address() == a {
+			continue
+		}
+		if len(nodeAddrs) > 0 {
+			if _, ok := nodeMap[a]; ok {
+				addressList = append(addressList, a)
+			}
+		} else {
 			addressList = append(addressList, a)
 		}
 	}

--- a/lib/sync/syncer.go
+++ b/lib/sync/syncer.go
@@ -12,6 +12,11 @@ import (
 	"github.com/inconshreveable/log15"
 )
 
+type requestHighestBlock struct {
+	height    uint64
+	nodeAddrs []string
+}
+
 type Syncer struct {
 	poolSize      int
 	fetchTimeout  time.Duration
@@ -34,8 +39,8 @@ type Syncer struct {
 	ctx        context.Context
 	cancelFunc context.CancelFunc
 
-	updateHighestBlock chan uint64
-	getSyncProgress    chan chan *SyncProgress
+	requestHighestBlock chan *requestHighestBlock
+	getSyncProgress     chan chan *SyncProgress
 
 	logger log15.Logger
 }
@@ -68,8 +73,8 @@ func NewSyncer(st *storage.LevelDBBackend,
 		ctx:        ctx,
 		cancelFunc: cancelFunc,
 
-		updateHighestBlock: make(chan uint64),
-		getSyncProgress:    make(chan chan *SyncProgress),
+		requestHighestBlock: make(chan *requestHighestBlock),
+		getSyncProgress:     make(chan chan *SyncProgress),
 
 		logger: NopLogger(),
 	}
@@ -109,9 +114,15 @@ func (s *Syncer) Start() error {
 	return nil
 }
 
-func (s *Syncer) SetSyncTargetBlock(ctx context.Context, height uint64) error {
+func (s *Syncer) SetSyncTargetBlock(ctx context.Context, height uint64, nodeAddrs []string) error {
+	nas := make([]string, len(nodeAddrs))
+	copy(nas, nodeAddrs) // preventing data race
+	req := &requestHighestBlock{
+		height:    height,
+		nodeAddrs: nas,
+	}
 	select {
-	case s.updateHighestBlock <- height:
+	case s.requestHighestBlock <- req:
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -136,29 +147,31 @@ func (s *Syncer) SyncProgress(ctx context.Context) (*SyncProgress, error) {
 }
 
 func (s *Syncer) loop() {
-	checkc := s.afterFunc(s.checkInterval)
-
-	height := s.latestBlockHeight()
-	syncProgress := &SyncProgress{
-		StartingBlock: height,
-		CurrentBlock:  height,
-		HighestBlock:  height,
-	}
-
-	s.logger.Info("starting block to sync", "height", height)
+	var (
+		checkc       = s.afterFunc(s.checkInterval)
+		height       = s.latestBlockHeight()
+		syncProgress = &SyncProgress{
+			StartingBlock: height,
+			CurrentBlock:  height,
+			HighestBlock:  height,
+		}
+		nodeAddrs []string
+	)
 
 	for {
 		select {
 		case <-checkc:
 			s.logger.Debug("check interval", "checkInterval", s.checkInterval)
 			// syncProgress.HighestBlock++ // TODO(anarcher): Until work together consensus
-			s.sync(syncProgress)
+			s.sync(syncProgress, nodeAddrs)
 			checkc = s.afterFunc(s.checkInterval)
-		case height := <-s.updateHighestBlock:
-			s.logger.Debug("update highest Height", "height", height)
+		case req := <-s.requestHighestBlock:
+			height := req.height
+			nodeAddrs = req.nodeAddrs
+			s.logger.Debug("update highest Height", "height", height, "nodes", len(nodeAddrs))
 			if height > syncProgress.CurrentBlock {
 				syncProgress.HighestBlock = height
-				s.sync(syncProgress)
+				s.sync(syncProgress, nodeAddrs)
 			}
 		case c := <-s.getSyncProgress:
 			c <- syncProgress.Clone()
@@ -169,7 +182,7 @@ func (s *Syncer) loop() {
 	}
 }
 
-func (s *Syncer) sync(p *SyncProgress) {
+func (s *Syncer) sync(p *SyncProgress, nodeAddrs []string) {
 	var (
 		startHeight       = p.CurrentBlock + 1
 		currentHeight     = p.CurrentBlock
@@ -197,7 +210,7 @@ func (s *Syncer) sync(p *SyncProgress) {
 	for height := startHeight; height <= highestHeight; height++ {
 		s.logger.Info("work height", "height", height)
 		// TryAdd for unblocking when the pool is full. Just keep syncprogress for next sync
-		if s.work(height) == false {
+		if s.work(height, nodeAddrs) == false {
 			break
 		}
 		currentHeight = height
@@ -208,7 +221,7 @@ func (s *Syncer) sync(p *SyncProgress) {
 	log("")
 }
 
-func (s *Syncer) work(height uint64) bool {
+func (s *Syncer) work(height uint64, nodeAddrs []string) bool {
 	ctx := s.ctx
 	work := func() {
 		latestHeight := s.latestBlockHeight()
@@ -218,8 +231,11 @@ func (s *Syncer) work(height uint64) bool {
 		}
 
 		var (
-			syncInfo = &SyncInfo{BlockHeight: height}
-			err      error
+			syncInfo = &SyncInfo{
+				BlockHeight: height,
+				NodeAddrs:   nodeAddrs,
+			}
+			err error
 		)
 
 	L:

--- a/lib/sync/syncer_test.go
+++ b/lib/sync/syncer_test.go
@@ -2,12 +2,14 @@ package sync
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,8 +23,11 @@ type SyncerTestContext struct {
 
 func TestSyncerSetSyncTarget(t *testing.T) {
 	fn := func(tctx *SyncerTestContext) {
-		ctx := context.Background()
-		syncer := tctx.syncer
+		var (
+			ctx    = context.Background()
+			syncer = tctx.syncer
+			infoc  = tctx.syncInfoC
+		)
 
 		{
 			bk := block.TestMakeNewBlock([]string{})
@@ -30,18 +35,32 @@ func TestSyncerSetSyncTarget(t *testing.T) {
 			bk.Save(tctx.st)
 		}
 
+		var (
+			height    uint64   = 10
+			cnt       uint64   = 2
+			nodeAddrs []string = []string{"a", "b"}
+		)
+
+		syncer.validator = &mockValidator{
+			validateFunc: func(ctx context.Context, si *SyncInfo) error {
+				assert.Equal(t, len(si.NodeAddrs), 2)
+				infoc <- si
+				atomic.AddUint64(&cnt, 1)
+				if atomic.LoadUint64(&cnt) > 10 {
+					close(infoc)
+				}
+				return nil
+			},
+		}
+
 		go func() {
 			syncer.Start()
 		}()
 
-		height := uint64(10)
-		syncer.SetSyncTargetBlock(ctx, height)
-		sp, err := syncer.SyncProgress(ctx)
-		require.Nil(t, err)
+		syncer.SetSyncTargetBlock(ctx, height, nodeAddrs)
 
 		var heights []uint64
-		for i := sp.StartingBlock; i <= sp.CurrentBlock; i++ {
-			si := <-tctx.syncInfoC
+		for si := range infoc {
 			heights = append(heights, si.BlockHeight)
 		}
 		require.Equal(t, len(heights), 9)
@@ -66,10 +85,8 @@ func SyncerTest(t *testing.T, fn func(*SyncerTestContext)) {
 		fetchFunc: func(ctx context.Context, si *SyncInfo) (*SyncInfo, error) {
 			bk := block.TestMakeNewBlock([]string{})
 			bk.Height = si.BlockHeight
-			si = &SyncInfo{
-				BlockHeight: bk.Height,
-				Block:       &bk,
-			}
+			si.BlockHeight = bk.Height
+			si.Block = &bk
 			return si, nil
 		},
 	}

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -25,7 +25,7 @@ func (s SyncProgress) Clone() *SyncProgress {
 }
 
 type SyncController interface {
-	SetSyncTargetBlock(ctx context.Context, height uint64) error
+	SetSyncTargetBlock(ctx context.Context, height uint64, nodeAddressList []string) error
 }
 
 type SyncInfo struct {
@@ -33,8 +33,11 @@ type SyncInfo struct {
 	Block       *block.Block
 	Txs         []*transaction.Transaction
 
-	BlockTxs []*block.BlockTransaction
-	BlockOps []*block.BlockOperation
+	NodeAddrs []string
+
+	//TODO(anarcher): Remove
+	//BlockTxs []*block.BlockTransaction
+	//BlockOps []*block.BlockOperation
 }
 
 type Doer interface {

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -33,7 +33,9 @@ type SyncInfo struct {
 	Block       *block.Block
 	Txs         []*transaction.Transaction
 
-	NodeAddrs []string // Fetching target node addresses
+	// Fetching target node addresses, `NodeAddrs` is  the validators which
+	// participated and confirmed the consensus of latest ballot.
+	NodeAddrs []string
 }
 
 type Doer interface {

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -33,11 +33,7 @@ type SyncInfo struct {
 	Block       *block.Block
 	Txs         []*transaction.Transaction
 
-	NodeAddrs []string
-
-	//TODO(anarcher): Remove
-	//BlockTxs []*block.BlockTransaction
-	//BlockOps []*block.BlockOperation
+	NodeAddrs []string // Fetching target node addresses
 }
 
 type Doer interface {


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

```
type SyncController interface {
	SetSyncTargetBlock(ctx context.Context, height uint64, nodeAddressList []string) error
}
```

if syncer and fetcher get this `nodeAddressList`,  fetcher choose node of them (nodeAddressList) randomly.



### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->
