### PR TITLE
Validating Incoming Transactions in API

### DIFF
--- a/lib/block/block.go
+++ b/lib/block/block.go
@@ -60,8 +60,6 @@ func (bck Block) String() string {
 // * The next `Operation` is for common account
 //   * `CreateAccount.Amount` is 0
 //   * `CreateAccount.Target` is common account
-// * `Transaction.B.Source` is same with `CreateAccount.Target` of
-// genesis account
 // * `Transaction.B.Fee` is 0
 func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, commonAccount BlockAccount, networdID []byte) (blk Block, err error) {
 	if genesisAccount.Address == commonAccount.Address {

--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -140,10 +140,11 @@ func TestMakeGenesisBlock(t *testing.T) {
 	bt, err := GetBlockTransaction(st, bk.Transactions[0])
 	require.Nil(t, err)
 
+	genesisBlockKP := keypair.Master(string(networkID))
 	require.Equal(t, genesisAccount.SequenceID, bt.SequenceID)
 	require.Equal(t, common.Amount(0), bt.Fee)
 	require.Equal(t, 2, len(bt.Operations))
-	require.Equal(t, genesisAccount.Address, bt.Source)
+	require.Equal(t, genesisBlockKP.Address(), bt.Source)
 	require.Equal(t, bk.Hash, bt.Block)
 
 	// operation
@@ -156,7 +157,7 @@ func TestMakeGenesisBlock(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, bt.Hash, bo.TxHash)
 	require.Equal(t, operation.TypeCreateAccount, bo.Type)
-	require.Equal(t, genesisAccount.Address, bo.Source)
+	require.Equal(t, genesisBlockKP.Address(), bo.Source)
 
 	{
 		opb, err := operation.UnmarshalBodyJSON(bo.Type, bo.Body)
@@ -239,18 +240,6 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 		opbp := opb.(operation.Payable)
 
 		genesisAccount, err := GetBlockAccount(st, opbp.TargetAddress())
-		require.Nil(t, err)
-
-		require.Equal(t, account.Address, genesisAccount.Address)
-		require.Equal(t, account.Balance, genesisAccount.Balance)
-		require.Equal(t, account.SequenceID, genesisAccount.SequenceID)
-	}
-
-	{ // with `Transaction`
-		bk, _ := GetBlockByHeight(st, 1)
-		bt, _ := GetBlockTransaction(st, bk.Transactions[0])
-
-		genesisAccount, err := GetBlockAccount(st, bt.Source)
 		require.Nil(t, err)
 
 		require.Equal(t, account.Address, genesisAccount.Address)

--- a/lib/common/router.go
+++ b/lib/common/router.go
@@ -1,0 +1,17 @@
+package common
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+func PostAndJSONMatcher(r *http.Request, rm *mux.RouteMatch) bool {
+	if r.Method == "POST" {
+		if r.Header.Get("Content-Type") != "application/json" {
+			return false
+		}
+	}
+
+	return true
+}

--- a/lib/common/router_test.go
+++ b/lib/common/router_test.go
@@ -23,7 +23,7 @@ func TestRouterHeaderMatcher(t *testing.T) {
 	u, _ := url.Parse(server.URL)
 	u.Path = "/showme"
 
-	{ // GET msut be passed
+	{ // GET must pass
 		req, _ := http.NewRequest("GET", u.String(), nil)
 		resp, err := server.Client().Do(req)
 		require.Nil(t, err)

--- a/lib/common/router_test.go
+++ b/lib/common/router_test.go
@@ -1,0 +1,99 @@
+package common
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRouterHeaderMatcher(t *testing.T) {
+	router := mux.NewRouter()
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		return
+	}
+
+	router.HandleFunc("/showme", dummyHandler).MatcherFunc(PostAndJSONMatcher)
+	server := httptest.NewServer(router)
+	u, _ := url.Parse(server.URL)
+	u.Path = "/showme"
+
+	{ // GET msut be passed
+		req, _ := http.NewRequest("GET", u.String(), nil)
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	{ // POST && empty 'Content-Type'
+		req, _ := http.NewRequest("POST", u.String(), nil)
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}
+
+	{ // POST && invalid 'Content-Type'
+		req, _ := http.NewRequest("POST", u.String(), nil)
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}
+
+	{ // POST && valid 'Content-Type'
+		req, _ := http.NewRequest("POST", u.String(), nil)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+}
+
+func TestRouterHeaderMatcherWithMethodMatcher(t *testing.T) {
+	router := mux.NewRouter()
+
+	dummyHandler := func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		return
+	}
+
+	router.HandleFunc("/showme", dummyHandler).Methods("GET", "POST").MatcherFunc(PostAndJSONMatcher)
+	server := httptest.NewServer(router)
+	u, _ := url.Parse(server.URL)
+	u.Path = "/showme"
+
+	{ // GET msut be passed
+		req, _ := http.NewRequest("GET", u.String(), nil)
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+
+	{ // POST && empty 'Content-Type'
+		req, _ := http.NewRequest("POST", u.String(), nil)
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}
+
+	{ // POST && invalid 'Content-Type'
+		req, _ := http.NewRequest("POST", u.String(), nil)
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}
+
+	{ // POST && valid 'Content-Type'
+		req, _ := http.NewRequest("POST", u.String(), nil)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+}

--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -68,4 +68,5 @@ var (
 	ErrorInvalidInflationRatio                = NewError(161, "invalid inflation ratio found")
 	ErrorNotImplemented                       = NewError(162, "not implemented")
 	ErrorHTTPProblem                          = NewError(163, "http failed to get response")
+	ErrorInvalidTransaction                   = NewError(164, "invalid transaction")
 )

--- a/lib/network/http2_client.go
+++ b/lib/network/http2_client.go
@@ -67,12 +67,12 @@ func (c *HTTP2NetworkClient) GetNodeInfo() (body []byte, err error) {
 		return
 	}
 	defer response.Body.Close()
+	body, err = ioutil.ReadAll(response.Body)
+
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
 		return
 	}
-
-	body, err = ioutil.ReadAll(response.Body)
 
 	return
 }
@@ -88,12 +88,12 @@ func (c *HTTP2NetworkClient) Connect(n node.Node) (body []byte, err error) {
 		return
 	}
 	defer response.Body.Close()
+	body, err = ioutil.ReadAll(response.Body)
+
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
 		return
 	}
-
-	body, err = ioutil.ReadAll(response.Body)
 
 	return
 }
@@ -115,12 +115,12 @@ func (c *HTTP2NetworkClient) SendMessage(message common.Serializable) (retBody [
 		return
 	}
 	defer response.Body.Close()
+	retBody, err = ioutil.ReadAll(response.Body)
+
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
 		return
 	}
-
-	retBody, err = ioutil.ReadAll(response.Body)
 
 	return
 }
@@ -142,12 +142,12 @@ func (c *HTTP2NetworkClient) SendBallot(message common.Serializable) (retBody []
 		return
 	}
 	defer response.Body.Close()
+	retBody, err = ioutil.ReadAll(response.Body)
+
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
 		return
 	}
-
-	retBody, err = ioutil.ReadAll(response.Body)
 
 	return
 }
@@ -169,12 +169,12 @@ func (c *HTTP2NetworkClient) GetTransactions(txs []string) (retBody []byte, err 
 		return
 	}
 	defer response.Body.Close()
+	retBody, err = ioutil.ReadAll(response.Body)
+
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
 		return
 	}
-
-	retBody, err = ioutil.ReadAll(response.Body)
 
 	return
 }

--- a/lib/network/http2_client.go
+++ b/lib/network/http2_client.go
@@ -71,7 +71,6 @@ func (c *HTTP2NetworkClient) GetNodeInfo() (body []byte, err error) {
 
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
-		return
 	}
 
 	return
@@ -92,7 +91,6 @@ func (c *HTTP2NetworkClient) Connect(n node.Node) (body []byte, err error) {
 
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
-		return
 	}
 
 	return
@@ -119,7 +117,6 @@ func (c *HTTP2NetworkClient) SendMessage(message common.Serializable) (retBody [
 
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
-		return
 	}
 
 	return
@@ -146,7 +143,6 @@ func (c *HTTP2NetworkClient) SendBallot(message common.Serializable) (retBody []
 
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
-		return
 	}
 
 	return
@@ -173,7 +169,6 @@ func (c *HTTP2NetworkClient) GetTransactions(txs []string) (retBody []byte, err 
 
 	if response.StatusCode != http.StatusOK {
 		err = errors.ErrorHTTPProblem.Clone().SetData("status", response.StatusCode)
-		return
 	}
 
 	return

--- a/lib/network/httputils/httputils.go
+++ b/lib/network/httputils/httputils.go
@@ -1,8 +1,9 @@
 package httputils
 
 import (
-	"boscoin.io/sebak/lib/error"
 	"net/http"
+
+	"boscoin.io/sebak/lib/error"
 )
 
 // IsEventStream checks request header accept is text/event-stream
@@ -15,59 +16,17 @@ func IsEventStream(r *http.Request) bool {
 }
 
 var (
-	ErrorsToStatus = map[uint]int{
-		//TODO: set relevant code
-		100: 400,
-		101: 400,
-		102: 400,
-		103: 400,
-		104: 400,
-		105: 400,
-		106: 400,
-		107: 400,
-		108: 400,
-		109: 400,
-		110: 400,
-		111: 400,
-		112: 400,
-		113: 400,
-		114: 400,
-		115: 400,
-		116: 400,
-		118: 400,
-		119: 400,
-		120: 400,
-		121: 400,
-		122: 400,
-		123: 400,
-		124: 400,
-		125: 400,
-		126: 400,
-		127: 400,
-		128: 400,
-		129: 400,
-		130: 400,
-		131: 400,
-		132: 400,
-		133: 400,
-		134: 400,
-		135: 400,
-		136: 400,
-		137: 400,
-		138: 400,
-		139: 400,
-		140: 400,
-		141: 400,
-		142: 400,
-		143: 400,
-		144: 400,
-		145: 400,
-	}
+	// ErrorsToStatus defines errors.Error does not have 400 status code.
+	ErrorsToStatus = map[uint]int{}
 )
 
 func StatusCode(err error) int {
 	if e, ok := err.(*errors.Error); ok {
-		return ErrorsToStatus[e.Code]
+		if c, ok := ErrorsToStatus[e.Code]; ok {
+			return c
+		}
+		return 400
 	}
+
 	return 500
 }

--- a/lib/network/memory.go
+++ b/lib/network/memory.go
@@ -18,6 +18,8 @@ type MemoryNetwork struct {
 	receiveChannel chan common.NetworkMessage
 	// They all share the same map to find each other
 	peers map[ /* endpoint */ string]*MemoryNetwork
+
+	messageBroker MessageBroker
 }
 
 func (t *MemoryNetwork) GetClient(endpoint *common.Endpoint) NetworkClient {
@@ -52,11 +54,12 @@ func (p *MemoryNetwork) Ready() error {
 	return nil
 }
 
-func (p *MemoryNetwork) SetMessageBroker(MessageBroker) {
+func (p *MemoryNetwork) SetMessageBroker(mb MessageBroker) {
+	p.messageBroker = mb
 }
 
 func (p *MemoryNetwork) MessageBroker() MessageBroker {
-	return nil
+	return p.messageBroker
 }
 
 func (p *MemoryNetwork) IsReady() bool {

--- a/lib/network/validator_connection_manager.go
+++ b/lib/network/validator_connection_manager.go
@@ -192,16 +192,17 @@ func (c *ValidatorConnectionManager) Broadcast(message common.Message) {
 				client := c.GetConnection(v.Address())
 
 				var err error
+				var response []byte
 				if message.GetType() == common.BallotMessage {
-					_, err = client.SendBallot(message)
+					response, err = client.SendBallot(message)
 				} else if message.GetType() == string(common.TransactionMessage) {
-					_, err = client.SendMessage(message)
+					response, err = client.SendMessage(message)
 				} else {
 					panic("invalid message")
 				}
 
 				if err != nil {
-					c.log.Error("failed to SendBallot", "error", err, "validator", v)
+					c.log.Error("failed to broadcast", "error", err, "validator", v, "message", message, "response", string(response))
 				}
 			}(c.validators[addr])
 		}

--- a/lib/node/runner/api_message_handler_test.go
+++ b/lib/node/runner/api_message_handler_test.go
@@ -1,0 +1,197 @@
+package runner
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/network/api"
+	"boscoin.io/sebak/lib/network/httputils"
+	"boscoin.io/sebak/lib/transaction"
+)
+
+type HelperTestNodeMessageHandler struct {
+	HelperTestGetNodeTransactionsHandler
+
+	nodeHandler *NetworkHandlerNode
+}
+
+func (p *HelperTestNodeMessageHandler) Prepare() {
+	p.HelperTestGetNodeTransactionsHandler.Prepare()
+
+	p.nodeHandler = NewNetworkHandlerNode(
+		p.localNode,
+		p.network,
+		p.st,
+		p.consensus,
+		network.UrlPathPrefixNode,
+	)
+
+	// override existing handler
+	p.router = mux.NewRouter()
+	p.server = httptest.NewServer(p.router)
+	p.router.HandleFunc(api.PostTransactionPattern, p.nodeHandler.MessageHandler).
+		Methods("POST").
+		MatcherFunc(common.PostAndJSONMatcher)
+}
+
+func (p *HelperTestNodeMessageHandler) URL(urlValues url.Values) (u *url.URL) {
+	u, _ = url.Parse(p.server.URL)
+	u.Path = api.PostTransactionPattern
+
+	if urlValues != nil {
+		u.RawQuery = urlValues.Encode()
+	}
+
+	return
+}
+
+func (p *HelperTestNodeMessageHandler) makeTransaction() (tx transaction.Transaction) {
+	receiverKP, _ := keypair.Random()
+	tx = transaction.MakeTransactionCreateAccount(p.genesisKeypair, receiverKP.Address(), common.BaseReserve)
+	tx.B.SequenceID = p.genesisAccount.SequenceID
+	tx.Sign(p.genesisKeypair, networkID)
+
+	return
+}
+
+func TestNodeMessageHandler(t *testing.T) {
+	p := &HelperTestNodeMessageHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	u := p.URL(nil)
+
+	tx := p.makeTransaction()
+	require.Nil(t, tx.IsWellFormed(networkID))
+
+	postData, _ := tx.Serialize()
+	req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
+	req.Header.Set("Content-Type", "application/json")
+	require.Nil(t, err)
+	resp, err := p.server.Client().Do(req)
+	require.Nil(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	require.True(t, p.consensus.TransactionPool.Has(tx.GetHash()))
+}
+
+func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
+	p := &HelperTestNodeMessageHandler{}
+	p.Prepare()
+	defer p.Done()
+
+	u := p.URL(nil)
+
+	{ // invalid signature
+		tx := p.makeTransaction()
+		tx.H.Signature = "findme"
+		errIsWellformed := tx.IsWellFormed(networkID)
+		require.Equal(t, errors.ErrorInvalidTransaction.Code, errIsWellformed.(*errors.Error).Code)
+
+		postData, _ := tx.Serialize()
+		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
+		req.Header.Set("Content-Type", "application/json")
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var problem httputils.Problem
+		{
+			err := json.Unmarshal(body, &problem)
+			require.Nil(t, err)
+		}
+		require.Equal(t, problem.Detail, errIsWellformed.(*errors.Error).Data["error"])
+		require.Equal(
+			t,
+			problem.Type,
+			httputils.ProblemTypeByCode(errIsWellformed.(*errors.Error).Code),
+		)
+	}
+
+	{ // under BaseReserve
+		tx := p.makeTransaction()
+		tx.H.Signature = "findme"
+		opb := tx.B.Operations[0].B.(transaction.OperationBodyCreateAccount)
+		opb.Amount = common.Amount(0)
+		tx.B.Operations[0].B = opb
+		tx.Sign(p.genesisKeypair, networkID)
+
+		errIsWellformed := tx.IsWellFormed(networkID)
+		require.Equal(t, errors.ErrorOperationAmountUnderflow.Code, errIsWellformed.(*errors.Error).Code)
+
+		postData, _ := tx.Serialize()
+		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
+		req.Header.Set("Content-Type", "application/json")
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var problem httputils.Problem
+		{
+			err := json.Unmarshal(body, &problem)
+			require.Nil(t, err)
+		}
+		require.Equal(
+			t,
+			problem.Type,
+			httputils.ProblemTypeByCode(errIsWellformed.(*errors.Error).Code),
+		)
+	}
+
+	{ // already in history
+		tx := p.makeTransaction()
+		postData, _ := tx.Serialize()
+
+		{
+			req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
+			req.Header.Set("Content-Type", "application/json")
+			require.Nil(t, err)
+			resp, err := p.server.Client().Do(req)
+			require.Nil(t, err)
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+		}
+
+		// send again
+		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
+		req.Header.Set("Content-Type", "application/json")
+		require.Nil(t, err)
+		resp, err := p.server.Client().Do(req)
+		require.Nil(t, err)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+		body, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var problem httputils.Problem
+		{
+			err := json.Unmarshal(body, &problem)
+			require.Nil(t, err)
+		}
+
+		require.Equal(
+			t,
+			problem.Type,
+			httputils.ProblemTypeByCode(errors.ErrorNewButKnownMessage.Code),
+		)
+	}
+}

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -28,15 +28,17 @@ type NetworkHandlerNode struct {
 	storage   *storage.LevelDBBackend
 	consensus *consensus.ISAAC
 	urlPrefix string
+	conf      common.Config
 }
 
-func NewNetworkHandlerNode(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend, consensus *consensus.ISAAC, urlPrefix string) *NetworkHandlerNode {
+func NewNetworkHandlerNode(localNode *node.LocalNode, network network.Network, storage *storage.LevelDBBackend, consensus *consensus.ISAAC, urlPrefix string, conf common.Config) *NetworkHandlerNode {
 	return &NetworkHandlerNode{
 		localNode: localNode,
 		network:   network,
 		storage:   storage,
 		consensus: consensus,
 		urlPrefix: urlPrefix,
+		conf:      conf,
 	}
 }
 
@@ -114,6 +116,7 @@ func (api NetworkHandlerNode) MessageHandler(w http.ResponseWriter, r *http.Requ
 		NetworkID:      api.consensus.NetworkID,
 		Message:        message,
 		Log:            log,
+		Conf:           api.conf,
 	}
 
 	if err = common.RunChecker(checker, common.DefaultDeferFunc); err != nil {

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -126,15 +126,18 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Netw
 }
 
 type TestMessageBroker struct {
-	network *network.HTTP2Network
+	network  *network.HTTP2Network
+	Messages []common.NetworkMessage
 }
 
-func (r TestMessageBroker) Response(w io.Writer, o []byte) error {
+func (r *TestMessageBroker) Response(w io.Writer, o []byte) error {
 	_, err := w.Write(o)
 	return err
 }
 
-func (r TestMessageBroker) Receive(common.NetworkMessage) {}
+func (r *TestMessageBroker) Receive(m common.NetworkMessage) {
+	r.Messages = append(r.Messages, m)
+}
 
 func removeWhiteSpaces(str string) string {
 	return strings.Map(func(r rune) rune {
@@ -147,7 +150,7 @@ func removeWhiteSpaces(str string) string {
 
 func TestHTTP2NetworkGetNodeInfo(t *testing.T) {
 	_, s0, nodeRunner := createNewHTTP2Network(t)
-	s0.SetMessageBroker(TestMessageBroker{network: s0})
+	s0.SetMessageBroker(&TestMessageBroker{network: s0})
 	nodeRunner.Ready()
 
 	go nodeRunner.Start()
@@ -204,7 +207,7 @@ func TestHTTP2NetworkMessageBrokerResponseMessage(t *testing.T) {
 
 func TestHTTP2NetworkConnect(t *testing.T) {
 	_, s0, nodeRunner := createNewHTTP2Network(t)
-	s0.SetMessageBroker(TestMessageBroker{network: s0})
+	s0.SetMessageBroker(&TestMessageBroker{network: s0})
 	nodeRunner.Ready()
 
 	go nodeRunner.Start()

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -25,11 +25,16 @@ import (
 )
 
 type HelperTestGetNodeTransactionsHandler struct {
+	localNode         *node.LocalNode
 	st                *storage.LevelDBBackend
 	server            *httptest.Server
 	blocks            []block.Block
 	transactionHashes []string
 	consensus         *consensus.ISAAC
+	router            *mux.Router
+	genesisAccount    *block.BlockAccount
+	genesisKeypair    *keypair.Full
+	network           *network.MemoryNetwork
 }
 
 func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
@@ -39,22 +44,32 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 	endpoint, _ := common.NewEndpointFromString(
 		fmt.Sprintf("http://localhost:12345"),
 	)
-	localNode, _ := node.NewLocalNode(kp, endpoint, "")
-	localNode.AddValidators(localNode.ConvertToValidator())
+	p.localNode, _ = node.NewLocalNode(kp, endpoint, "")
+	p.localNode.AddValidators(p.localNode.ConvertToValidator())
+
+	_, p.network, _ = network.CreateMemoryNetwork(nil)
+	p.network.SetLocalNode(p.localNode)
+
 	isaac, _ := consensus.NewISAAC(
 		networkID,
-		localNode,
+		p.localNode,
 		nil,
 		network.NewValidatorConnectionManager(localNode, nil, nil),
+		network.NewValidatorConnectionManager(p.localNode, nil, nil),
 		common.NewConfig(),
 	)
 	p.consensus = isaac
+
 	apiHandler := NetworkHandlerNode{storage: p.st, consensus: isaac}
 
-	router := mux.NewRouter()
-	router.HandleFunc(GetTransactionPattern, apiHandler.GetNodeTransactionsHandler).Methods("GET", "POST")
+	p.router = mux.NewRouter()
+	p.router.HandleFunc(GetTransactionPattern, apiHandler.GetNodeTransactionsHandler).Methods("GET", "POST")
 
-	p.server = httptest.NewServer(router)
+	p.server = httptest.NewServer(p.router)
+
+	p.genesisKeypair, _ = keypair.Random()
+	p.genesisAccount = block.NewBlockAccount(p.genesisKeypair.Address(), common.MaximumBalance)
+	p.genesisAccount.Save(p.st)
 
 	var bks []block.Block
 	for i := 0; i < 3; i++ {

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -54,7 +54,6 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 		networkID,
 		p.localNode,
 		nil,
-		network.NewValidatorConnectionManager(localNode, nil, nil),
 		network.NewValidatorConnectionManager(p.localNode, nil, nil),
 		common.NewConfig(),
 	)

--- a/lib/node/runner/checker_message.go
+++ b/lib/node/runner/checker_message.go
@@ -29,6 +29,7 @@ import (
 type MessageChecker struct {
 	common.DefaultChecker
 
+	Conf        common.Config
 	LocalNode   *node.LocalNode
 	NetworkID   []byte
 	Message     common.NetworkMessage
@@ -48,7 +49,7 @@ func TransactionUnmarshal(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	if err = tx.IsWellFormed(checker.NetworkID, checker.NodeRunner.Conf); err != nil {
+	if err = tx.IsWellFormed(checker.NetworkID, checker.Conf); err != nil {
 		return
 	}
 

--- a/lib/node/runner/checker_message_test.go
+++ b/lib/node/runner/checker_message_test.go
@@ -24,8 +24,9 @@ func TestMessageChecker(t *testing.T) {
 	nodeRunner, localNode := MakeNodeRunner()
 	checker := &MessageChecker{
 		DefaultChecker: common.DefaultChecker{},
-		NodeRunner:     nodeRunner,
 		LocalNode:      localNode,
+		Consensus:      nodeRunner.Consensus(),
+		Storage:        nodeRunner.Storage(),
 		NetworkID:      networkID,
 		Message:        validMessage,
 	}
@@ -40,12 +41,12 @@ func TestMessageChecker(t *testing.T) {
 	err = SaveTransactionHistory(checker)
 	require.Nil(t, err)
 	var found bool
-	found, err = block.ExistsBlockTransactionHistory(checker.NodeRunner.Storage(), checker.Transaction.GetHash())
+	found, err = block.ExistsBlockTransactionHistory(checker.Storage, checker.Transaction.GetHash())
 	require.True(t, found)
 
 	err = PushIntoTransactionPool(checker)
 	require.Nil(t, err)
-	require.True(t, checker.NodeRunner.Consensus().TransactionPool.Has(validTx.GetHash()))
+	require.True(t, checker.Consensus.TransactionPool.Has(validTx.GetHash()))
 
 	// TransactionBroadcast(checker) is not suitable in unittest
 
@@ -85,10 +86,11 @@ func TestMessageCheckerWithInvalidHash(t *testing.T) {
 	invalidMessage := common.NetworkMessage{Type: common.TransactionMessage, Data: b}
 	nodeRunner, localNode := MakeNodeRunner()
 	checker := &MessageChecker{
-		NodeRunner: nodeRunner,
-		LocalNode:  localNode,
-		NetworkID:  networkID,
-		Message:    invalidMessage,
+		Consensus: nodeRunner.Consensus(),
+		Storage:   nodeRunner.Storage(),
+		LocalNode: localNode,
+		NetworkID: networkID,
+		Message:   invalidMessage,
 	}
 
 	err = TransactionUnmarshal(checker)

--- a/lib/node/runner/checker_message_test.go
+++ b/lib/node/runner/checker_message_test.go
@@ -29,6 +29,8 @@ func TestMessageChecker(t *testing.T) {
 		Storage:        nodeRunner.Storage(),
 		NetworkID:      networkID,
 		Message:        validMessage,
+		Log:            nodeRunner.Log(),
+		Conf:           nodeRunner.Conf,
 	}
 
 	err = TransactionUnmarshal(checker)
@@ -91,6 +93,8 @@ func TestMessageCheckerWithInvalidHash(t *testing.T) {
 		LocalNode: localNode,
 		NetworkID: networkID,
 		Message:   invalidMessage,
+		Log:       nodeRunner.Log(),
+		Conf:      nodeRunner.Conf,
 	}
 
 	err = TransactionUnmarshal(checker)

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -38,9 +38,10 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 		messageData, _ := tx.Serialize()
 
 		checker := &MessageChecker{
-			DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleTransactionCheckerFuncs},
-			NodeRunner:     nodeRunner,
+			DefaultChecker: common.DefaultChecker{Funcs: HandleTransactionCheckerFuncs},
 			LocalNode:      nodeRunner.Node(),
+			Consensus:      nodeRunner.Consensus(),
+			Storage:        nodeRunner.Storage(),
 			NetworkID:      networkID,
 			Message:        common.NetworkMessage{Type: "message", Data: messageData},
 		}

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -44,6 +44,8 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 			Storage:        nodeRunner.Storage(),
 			NetworkID:      networkID,
 			Message:        common.NetworkMessage{Type: "message", Data: messageData},
+			Log:            nodeRunner.Log(),
+			Conf:           nodeRunner.Conf,
 		}
 
 		if err := common.RunChecker(checker, nil); err != nil {

--- a/lib/node/runner/isaac_simulation_test.go
+++ b/lib/node/runner/isaac_simulation_test.go
@@ -25,9 +25,7 @@ TestISAACSimulationProposer indicates the following:
 */
 func TestISAACSimulationProposer(t *testing.T) {
 	nr, nodes, _ := createNodeRunnerForTesting(5, common.NewConfig(), nil)
-	tx, txByte := GetTransaction(t)
-
-	message := common.NetworkMessage{Type: common.TransactionMessage, Data: txByte}
+	tx, _ := GetTransaction(t)
 
 	// `nr` is proposer's runner
 	proposer := nr.localNode
@@ -35,10 +33,7 @@ func TestISAACSimulationProposer(t *testing.T) {
 	nr.Consensus().SetLatestBlock(genesisBlock)
 
 	var err error
-	err = nr.handleTransaction(message)
-
-	require.Nil(t, err)
-	require.True(t, nr.Consensus().TransactionPool.Has(tx.GetHash()))
+	nr.Consensus().TransactionPool.Add(tx)
 
 	// Generate proposed ballot in nr
 	roundNumber := uint64(0)

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -146,6 +146,7 @@ func (nr *NodeRunner) Ready() {
 		nr.storage,
 		nr.consensus,
 		network.UrlPathPrefixNode,
+		nr.Conf,
 	)
 
 	nr.network.AddHandler(nodeHandler.HandlerURLPattern(NodeInfoHandlerPattern), nodeHandler.NodeInfoHandler)

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -238,29 +238,6 @@ func TestCreateNodeRunner(t *testing.T) {
 	require.Equal(t, 3, len(nodeRunners))
 }
 
-// Check that when a node receives transaction, the node broadcasts it to validators
-func TestNodeRunnerTransactionBroadcast(t *testing.T) {
-	nodeRunners := createTestNodeRunner(3, common.NewConfig())
-
-	tx, txByte := GetTransaction(t)
-
-	message := common.NetworkMessage{Type: common.TransactionMessage, Data: txByte}
-
-	nodeRunner := nodeRunners[0]
-
-	nodeRunner.Consensus().SetLatestBlock(genesisBlock)
-	b := nodeRunner.Consensus().LatestBlock()
-	require.Equal(t, uint64(1), b.Height)
-	require.Equal(t, uint64(1), b.TotalTxs)
-
-	var err error
-	err = nodeRunner.handleTransaction(message)
-
-	require.Nil(t, err)
-	require.True(t, nodeRunner.Consensus().TransactionPool.Has(tx.GetHash()))
-
-}
-
 /*
 func TestNodeRunnerSaveBlock(t *testing.T) {
 	numberOfNodes := 4

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -108,6 +108,9 @@ func (tx Transaction) IsWellFormed(networkID []byte, conf common.Config) (err er
 		Conf:           conf,
 	}
 	if err = common.RunChecker(checker, common.DefaultDeferFunc); err != nil {
+		if _, ok := err.(*errors.Error); !ok {
+			err = errors.ErrorInvalidTransaction.Clone().SetData("error", err.Error())
+		}
 		return
 	}
 
@@ -177,6 +180,7 @@ func (tx Transaction) String() string {
 }
 
 func (tx *Transaction) Sign(kp keypair.KP, networkID []byte) {
+	tx.B.Source = kp.Address()
 	tx.H.Hash = tx.B.MakeHashString()
 	signature, _ := common.MakeSignature(kp, networkID, tx.H.Hash)
 


### PR DESCRIPTION
### Background
If not-wellformed transaction is received, the API just eat it and return 'status ok'. If API handler returns the validated or not to client, it will be useful for client.

### Solution

`NetworkHandlerNode.MessageHandler` will do the `runner.HandleTransactionCheckerFuncs` using `Checker` and the existing `NodeRunner.handleTransaction()` was removed.