### PR TITLE
Add Middleware

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -320,6 +320,7 @@ func parseFlagsNode() {
 
 	if flagVerbose {
 		http2.VerboseLogs = true
+		network.VerboseLogs = true
 	}
 }
 

--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -69,4 +69,5 @@ var (
 	ErrorNotImplemented                       = NewError(162, "not implemented")
 	ErrorHTTPProblem                          = NewError(163, "http failed to get response")
 	ErrorInvalidTransaction                   = NewError(164, "invalid transaction")
+	ErrorNotMatcHTTPRouter                    = NewError(165, "doesn't match http router")
 )

--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -16,6 +16,7 @@ type Network interface {
 	GetClient(endpoint *common.Endpoint) NetworkClient
 	AddWatcher(func(Network, net.Conn, http.ConnState))
 	AddHandler(string, http.HandlerFunc) *mux.Route
+	AddMiddleware(string, ...mux.MiddlewareFunc)
 
 	// Starts network handling
 	// Blocks until finished, either because of an error

--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -16,7 +16,7 @@ type Network interface {
 	GetClient(endpoint *common.Endpoint) NetworkClient
 	AddWatcher(func(Network, net.Conn, http.ConnState))
 	AddHandler(string, http.HandlerFunc) *mux.Route
-	AddMiddleware(string, ...mux.MiddlewareFunc)
+	AddMiddleware(string, ...mux.MiddlewareFunc) error
 
 	// Starts network handling
 	// Blocks until finished, either because of an error

--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -152,6 +152,16 @@ func (t *HTTP2Network) setNotReadyHandler() {
 	t.server.Handler = HTTP2Log15Handler{log: t.log, handler: t.router}
 }
 
+func (t *HTTP2Network) AddMiddleware(routerName string, mws ...mux.MiddlewareFunc) {
+	r, ok := t.routers[routerName]
+	if !ok {
+		// ignore it
+	}
+	for _, mw := range mws {
+		r.Use(mw)
+	}
+}
+
 func (t *HTTP2Network) AddHandler(pattern string, handler http.HandlerFunc) (router *mux.Route) {
 	var routerName string
 	var prefix string

--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/net/http2"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/node"
 )
 
@@ -152,14 +153,15 @@ func (t *HTTP2Network) setNotReadyHandler() {
 	t.server.Handler = HTTP2Log15Handler{log: t.log, handler: t.router}
 }
 
-func (t *HTTP2Network) AddMiddleware(routerName string, mws ...mux.MiddlewareFunc) {
+func (t *HTTP2Network) AddMiddleware(routerName string, mws ...mux.MiddlewareFunc) error {
 	r, ok := t.routers[routerName]
 	if !ok {
-		// ignore it
+		return errors.ErrorNotMatcHTTPRouter
 	}
 	for _, mw := range mws {
 		r.Use(mw)
 	}
+	return nil
 }
 
 func (t *HTTP2Network) AddHandler(pattern string, handler http.HandlerFunc) (router *mux.Route) {

--- a/lib/network/http_middlewares.go
+++ b/lib/network/http_middlewares.go
@@ -12,6 +12,9 @@ import (
 )
 
 func RecoverMiddleware(logger log15.Logger) mux.MiddlewareFunc {
+	if logger != nil {
+		logger = log // use network.log
+	}
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
@@ -21,9 +24,7 @@ func RecoverMiddleware(logger log15.Logger) mux.MiddlewareFunc {
 						err = fmt.Errorf("panic: %v", r)
 					}
 					httputils.WriteJSONError(w, err)
-					if logger == nil {
-						logger = log // use network.log
-					}
+
 					logger.Error("recover an panic", "err", err)
 					if VerboseLogs == true {
 						debug.PrintStack()

--- a/lib/network/http_middlewares.go
+++ b/lib/network/http_middlewares.go
@@ -1,0 +1,31 @@
+package network
+
+import (
+	"fmt"
+	"net/http"
+	"runtime/debug"
+
+	"boscoin.io/sebak/lib/network/httputils"
+	"github.com/gorilla/mux"
+)
+
+func RecoverMiddleware(printStack bool) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if r := recover(); r != nil {
+					err, ok := r.(error)
+					if !ok {
+						err = fmt.Errorf("panic: %v", r)
+					}
+					httputils.WriteJSONError(w, err)
+					log.Error("recover an panic", "err", err)
+					if printStack == true {
+						debug.PrintStack()
+					}
+				}
+			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/lib/network/http_middlewares.go
+++ b/lib/network/http_middlewares.go
@@ -12,7 +12,7 @@ import (
 )
 
 func RecoverMiddleware(logger log15.Logger) mux.MiddlewareFunc {
-	if logger != nil {
+	if logger == nil {
 		logger = log // use network.log
 	}
 	return func(next http.Handler) http.Handler {

--- a/lib/network/http_middlewares.go
+++ b/lib/network/http_middlewares.go
@@ -5,11 +5,13 @@ import (
 	"net/http"
 	"runtime/debug"
 
-	"boscoin.io/sebak/lib/network/httputils"
 	"github.com/gorilla/mux"
+	"github.com/inconshreveable/log15"
+
+	"boscoin.io/sebak/lib/network/httputils"
 )
 
-func RecoverMiddleware(printStack bool) mux.MiddlewareFunc {
+func RecoverMiddleware(logger log15.Logger) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {
@@ -19,8 +21,11 @@ func RecoverMiddleware(printStack bool) mux.MiddlewareFunc {
 						err = fmt.Errorf("panic: %v", r)
 					}
 					httputils.WriteJSONError(w, err)
-					log.Error("recover an panic", "err", err)
-					if printStack == true {
+					if logger == nil {
+						logger = log // use network.log
+					}
+					logger.Error("recover an panic", "err", err)
+					if VerboseLogs == true {
 						debug.PrintStack()
 					}
 				}

--- a/lib/network/http_middlewares_test.go
+++ b/lib/network/http_middlewares_test.go
@@ -2,56 +2,41 @@ package network
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
-	"boscoin.io/sebak/lib/common"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRecoverMiddleware(t *testing.T) {
-	endpoint, err := common.NewEndpointFromString(
-		fmt.Sprintf("http://localhost:%s", getPort()),
-	)
-	require.Nil(t, err)
-
-	network, err := makeTestHTTP2NetworkForTLS(endpoint)
-	require.Nil(t, err)
-	defer network.Stop()
-
 	handlerURL := UrlPathPrefixAPI + "/test"
 	panicMsg := "Don't panic,just use go"
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		panic(panicMsg)
 	}
 
-	VerboseLogs = false
-	network.AddMiddleware(RouterNameAPI, RecoverMiddleware(nil))
-	network.AddHandler(handlerURL, handler)
+	router := mux.NewRouter()
+	router.Use(RecoverMiddleware(nil))
+	router.HandleFunc(handlerURL, http.HandlerFunc(handler)).Methods("GET")
 
-	{
-		// with normal HTTP2Client
-		client, err := common.NewHTTP2Client(
-			defaultTimeout,
-			defaultIdleTimeout,
-			false,
-		)
-		require.Nil(t, err)
+	ts := httptest.NewServer(router)
+	defer ts.Close()
 
-		resp, err := client.Get(endpoint.String()+handlerURL, http.Header{})
-		require.Nil(t, err)
-		require.Equal(t, 500, resp.StatusCode)
-		require.Equal(t, "application/problem+json", resp.Header["Content-Type"][0])
+	resp, err := http.Get(ts.URL + handlerURL)
+	require.Nil(t, err)
 
-		bs, err := ioutil.ReadAll(resp.Body)
-		defer resp.Body.Close()
-		require.Nil(t, err)
+	require.Equal(t, 500, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header["Content-Type"][0])
 
-		var msg map[string]interface{}
-		err = json.Unmarshal(bs, &msg)
-		require.Nil(t, err)
-		require.Equal(t, "panic: "+panicMsg, msg["title"])
-	}
+	bs, err := ioutil.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	require.Nil(t, err)
+
+	var msg map[string]interface{}
+	err = json.Unmarshal(bs, &msg)
+	require.Nil(t, err)
+	require.Equal(t, "panic: "+panicMsg, msg["title"])
 }

--- a/lib/network/http_middlewares_test.go
+++ b/lib/network/http_middlewares_test.go
@@ -1,0 +1,57 @@
+package network
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"boscoin.io/sebak/lib/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRecoverMiddleware(t *testing.T) {
+	endpoint, err := common.NewEndpointFromString(
+		fmt.Sprintf("http://localhost:%s", getPort()),
+	)
+	require.Nil(t, err)
+
+	network, err := makeTestHTTP2NetworkForTLS(endpoint)
+	require.Nil(t, err)
+	defer network.Stop()
+
+	handlerURL := UrlPathPrefixAPI + "/test"
+	panicMsg := "Don't panic,just use go"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		panic(panicMsg)
+	}
+
+	VerboseLogs = false
+	network.AddMiddleware(RouterNameAPI, RecoverMiddleware(nil))
+	network.AddHandler(handlerURL, handler)
+
+	{
+		// with normal HTTP2Client
+		client, err := common.NewHTTP2Client(
+			defaultTimeout,
+			defaultIdleTimeout,
+			false,
+		)
+		require.Nil(t, err)
+
+		resp, err := client.Get(endpoint.String()+handlerURL, http.Header{})
+		require.Nil(t, err)
+		require.Equal(t, 500, resp.StatusCode)
+		require.Equal(t, "application/problem+json", resp.Header["Content-Type"][0])
+
+		bs, err := ioutil.ReadAll(resp.Body)
+		defer resp.Body.Close()
+		require.Nil(t, err)
+
+		var msg map[string]interface{}
+		err = json.Unmarshal(bs, &msg)
+		require.Nil(t, err)
+		require.Equal(t, "panic: "+panicMsg, msg["title"])
+	}
+}

--- a/lib/network/init.go
+++ b/lib/network/init.go
@@ -5,6 +5,7 @@ import (
 	logging "github.com/inconshreveable/log15"
 )
 
+var VerboseLogs bool
 var log logging.Logger = logging.New("module", "network")
 
 func init() {

--- a/lib/network/memory.go
+++ b/lib/network/memory.go
@@ -129,5 +129,6 @@ func (p *MemoryNetwork) AddHandler(string, http.HandlerFunc) *mux.Route {
 	return &mux.Route{}
 }
 
-func (p *MemoryNetwork) AddMiddleware(string, ...mux.MiddlewareFunc) {
+func (p *MemoryNetwork) AddMiddleware(string, ...mux.MiddlewareFunc) error {
+	return nil
 }

--- a/lib/network/memory.go
+++ b/lib/network/memory.go
@@ -128,3 +128,6 @@ func (prev *MemoryNetwork) NewMemoryNetwork() *MemoryNetwork {
 func (p *MemoryNetwork) AddHandler(string, http.HandlerFunc) *mux.Route {
 	return &mux.Route{}
 }
+
+func (p *MemoryNetwork) AddMiddleware(string, ...mux.MiddlewareFunc) {
+}

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -149,6 +149,9 @@ func (nr *NodeRunner) Ready() {
 		nr.Conf,
 	)
 
+	nr.network.AddMiddleware(network.RouterNameAPI, network.RecoverMiddleware(false))
+	nr.network.AddMiddleware(network.RouterNameNode, network.RecoverMiddleware(false))
+
 	nr.network.AddHandler(nodeHandler.HandlerURLPattern(NodeInfoHandlerPattern), nodeHandler.NodeInfoHandler)
 	nr.network.AddHandler(nodeHandler.HandlerURLPattern(ConnectHandlerPattern), nodeHandler.ConnectHandler).
 		Methods("POST").

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -149,8 +149,14 @@ func (nr *NodeRunner) Ready() {
 		nr.Conf,
 	)
 
-	nr.network.AddMiddleware(network.RouterNameAPI, network.RecoverMiddleware(false))
-	nr.network.AddMiddleware(network.RouterNameNode, network.RecoverMiddleware(false))
+	if err := nr.network.AddMiddleware(network.RouterNameAPI, network.RecoverMiddleware(nr.log)); err != nil {
+		nr.log.Error("Middleware has an error", "err", err)
+		return
+	}
+	if err := nr.network.AddMiddleware(network.RouterNameNode, network.RecoverMiddleware(nr.log)); err != nil {
+		nr.log.Error("Middleware has an error", "err", err)
+		return
+	}
 
 	nr.network.AddHandler(nodeHandler.HandlerURLPattern(NodeInfoHandlerPattern), nodeHandler.NodeInfoHandler)
 	nr.network.AddHandler(nodeHandler.HandlerURLPattern(ConnectHandlerPattern), nodeHandler.ConnectHandler).


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Fixes: #375 

### Background

- `AddMiddleware` to `Network`

```
 AddMiddleware(string, ...mux.MiddlewareFunc)
```

- Add `RecoverMiddleware`

```
 nr.network.AddMiddleware(network.RouterNameAPI, network.RecoverMiddleware(false))
 nr.network.AddMiddleware(network.RouterNameNode, network.RecoverMiddleware(false))
```

### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

- [x] Add tests

