### PR TITLE
Reduce signal to noise ratio in unittests

### DIFF
--- a/lib/common/test/log.go
+++ b/lib/common/test/log.go
@@ -12,7 +12,7 @@ func LogHandler() logging.Handler {
 			return logging.DiscardHandler()
 		},
 		"stdout": func() logging.Handler {
-			return logging.CallerStackHandler("%+v", logging.StdoutHandler)
+			return logging.StdoutHandler
 		},
 	}
 

--- a/lib/node/runner/init_test.go
+++ b/lib/node/runner/init_test.go
@@ -8,5 +8,5 @@ import (
 )
 
 func init() {
-	common.SetLogging(log, logging.LvlDebug, test.LogHandler())
+	common.SetLogging(log, logging.LvlInfo, test.LogHandler())
 }


### PR DESCRIPTION
This reduce the amount of data that gets output back to a sane level.
Whenever developing, it frequently happens that one test doesn't pass because I need to fix something, but the huge amount of things they output to the screen makes it hard to find.