### PR TITLE
Added time diff in `default_runner.sh`

### DIFF
--- a/tests/default_runner.sh
+++ b/tests/default_runner.sh
@@ -13,6 +13,8 @@ cd $DIR
 echo "===== ${DIR}: Default test runner ====="
 
 for JSONFILE in $(find . -name "*.json" -type f | sort); do
+    starttime=$(date +%s)
+
     PORT=$(echo "${JSONFILE}" | cut -d'_' -f3)
     curl --insecure \
          --request POST \
@@ -24,4 +26,6 @@ for JSONFILE in $(find . -name "*.json" -type f | sort); do
     if [ -f ${JSONFILE}.check ]; then
         bash -c ${JSONFILE}.check
     fi
+
+    echo ${JSONFILE} "- Elapsed Time:" $(expr $(date +%s) - ${starttime}) "seconds"
 done


### PR DESCRIPTION
### Background

Recently I dug the logs of integration tests and I want to check the elapsed time of each json check. It will be helpful to the block confirmation time when succeed.

### Solution

This PR will print the elapsed time when each json check is finished.
```
./request_1_2821_create_account_1.json - Elapsed Time: 2 seconds
+ echo ./request_1_2821_create_account_1.json '- Elapsed Time:' 2 seconds
```