### PR TITLE
Support Rate Limit For API

### DIFF
--- a/cmd/sebak/cmd/cmd_test.go
+++ b/cmd/sebak/cmd/cmd_test.go
@@ -221,4 +221,72 @@ func TestParseFlagRateLimit(t *testing.T) {
 		require.Equal(t, time.Second, rule.ByIPAddress[allowedIP].Period)
 		require.Equal(t, int64(8), rule.ByIPAddress[allowedIP].Limit)
 	}
+
+	{ // unlimit
+		testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+		var fr cmdcommon.ListFlags
+		testCmd.Var(&fr, "rate-limit-api", "")
+
+		cmdline := "--rate-limit-api=0-S"
+		err := testCmd.Parse(strings.Fields(cmdline))
+		require.Nil(t, err)
+
+		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+		require.Nil(t, err)
+		require.Equal(t, time.Second, rule.Default.Period)
+		require.Equal(t, int64(0), rule.Default.Limit)
+		require.Equal(t, 0, len(rule.ByIPAddress))
+	}
+
+	{ // lowercase
+		{ // second
+			testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+			var fr cmdcommon.ListFlags
+			testCmd.Var(&fr, "rate-limit-api", "")
+
+			cmdline := "--rate-limit-api=10-s"
+			err := testCmd.Parse(strings.Fields(cmdline))
+			require.Nil(t, err)
+
+			rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+			require.Nil(t, err)
+			require.Equal(t, time.Second, rule.Default.Period)
+			require.Equal(t, int64(10), rule.Default.Limit)
+			require.Equal(t, 0, len(rule.ByIPAddress))
+		}
+		{ // minute
+			testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+			var fr cmdcommon.ListFlags
+			testCmd.Var(&fr, "rate-limit-api", "")
+
+			cmdline := "--rate-limit-api=10-m"
+			err := testCmd.Parse(strings.Fields(cmdline))
+			require.Nil(t, err)
+
+			rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+			require.Nil(t, err)
+			require.Equal(t, time.Minute, rule.Default.Period)
+			require.Equal(t, int64(10), rule.Default.Limit)
+			require.Equal(t, 0, len(rule.ByIPAddress))
+		}
+		{ // hour
+			testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+			var fr cmdcommon.ListFlags
+			testCmd.Var(&fr, "rate-limit-api", "")
+
+			cmdline := "--rate-limit-api=10-h"
+			err := testCmd.Parse(strings.Fields(cmdline))
+			require.Nil(t, err)
+
+			rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+			require.Nil(t, err)
+			require.Equal(t, time.Hour, rule.Default.Period)
+			require.Equal(t, int64(10), rule.Default.Limit)
+			require.Equal(t, 0, len(rule.ByIPAddress))
+		}
+	}
 }

--- a/cmd/sebak/cmd/cmd_test.go
+++ b/cmd/sebak/cmd/cmd_test.go
@@ -1,10 +1,18 @@
 package cmd
 
 import (
+	"fmt"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
-	"boscoin.io/sebak/lib/node"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/require"
+
+	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/node"
 )
 
 func TestParseFlagValidators(t *testing.T) {
@@ -121,4 +129,96 @@ func TestAddingSelfWithoutValidators(t *testing.T) {
 	flagBindURL = "http://0.0.0.0:12345"
 	_, err := parseFlagValidators(flagValidators)
 	require.NotNil(t, err)
+}
+
+func TestParseFlagRateLimit(t *testing.T) {
+	{ // weired value
+		testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+		var fr cmdcommon.ListFlags
+		testCmd.Var(&fr, "rate-limit-api", "")
+
+		cmdline := "--rate-limit-api=showme"
+		err := testCmd.Parse(strings.Fields(cmdline))
+		require.Nil(t, err)
+
+		_, err = parseFlagRateLimit(fr, common.RateLimitAPI)
+		require.NotNil(t, err)
+	}
+
+	{ // valid value
+		testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+		var fr cmdcommon.ListFlags
+		testCmd.Var(&fr, "rate-limit-api", "")
+
+		cmdline := "--rate-limit-api=10-S"
+		err := testCmd.Parse(strings.Fields(cmdline))
+		require.Nil(t, err)
+
+		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+		require.Nil(t, err)
+		require.Equal(t, time.Second, rule.Default.Period)
+		require.Equal(t, int64(10), rule.Default.Limit)
+		require.Equal(t, 0, len(rule.ByIPAddress))
+	}
+
+	{ // multiple value, last will be choose.
+		testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+		var fr cmdcommon.ListFlags
+		testCmd.Var(&fr, "rate-limit-api", "")
+
+		cmdline := "--rate-limit-api=10-S --rate-limit-api=9-M"
+		err := testCmd.Parse(strings.Fields(cmdline))
+		require.Nil(t, err)
+
+		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+		require.Nil(t, err)
+		require.Equal(t, time.Minute, rule.Default.Period)
+		require.Equal(t, int64(9), rule.Default.Limit)
+		require.Equal(t, 0, len(rule.ByIPAddress))
+	}
+
+	{ // with ip address, but `common.RateLimitAPI` will be default
+		testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+		var fr cmdcommon.ListFlags
+		testCmd.Var(&fr, "rate-limit-api", "")
+
+		allowedIP := "1.2.3.4"
+		cmdline := fmt.Sprintf("--rate-limit-api=%s=8-S", allowedIP)
+		err := testCmd.Parse(strings.Fields(cmdline))
+		require.Nil(t, err)
+
+		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+		require.Nil(t, err)
+		require.Equal(t, common.RateLimitAPI.Period, rule.Default.Period)
+		require.Equal(t, common.RateLimitAPI.Limit, rule.Default.Limit)
+		require.Equal(t, 1, len(rule.ByIPAddress))
+		require.NotNil(t, rule.ByIPAddress[allowedIP])
+		require.Equal(t, time.Second, rule.ByIPAddress[allowedIP].Period)
+		require.Equal(t, int64(8), rule.ByIPAddress[allowedIP].Limit)
+	}
+
+	{ // with ip address and with default
+		testCmd := pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+
+		var fr cmdcommon.ListFlags
+		testCmd.Var(&fr, "rate-limit-api", "")
+
+		allowedIP := "1.2.3.4"
+		cmdline := fmt.Sprintf("--rate-limit-api=11-H --rate-limit-api=%s=8-S", allowedIP)
+		err := testCmd.Parse(strings.Fields(cmdline))
+		require.Nil(t, err)
+
+		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
+		require.Nil(t, err)
+		require.Equal(t, time.Hour, rule.Default.Period)
+		require.Equal(t, int64(11), rule.Default.Limit)
+		require.Equal(t, 1, len(rule.ByIPAddress))
+		require.NotNil(t, rule.ByIPAddress[allowedIP])
+		require.Equal(t, time.Second, rule.ByIPAddress[allowedIP].Period)
+		require.Equal(t, int64(8), rule.ByIPAddress[allowedIP].Limit)
+	}
 }

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -201,8 +201,7 @@ func parseFlagRateLimit(l cmdcommon.ListFlags, defaultRate limiter.Rate) (rule c
 		}
 	}
 
-	// select last defined default rate
-	if givenRate.Limit < 1 {
+	if givenRate.Period < 1 && givenRate.Limit < 1 {
 		givenRate = defaultRate
 	}
 

--- a/cmd/sebak/common/util.go
+++ b/cmd/sebak/common/util.go
@@ -51,3 +51,18 @@ func ParseAmountFromString(input string) (common.Amount, error) {
 	amountStr = strings.Replace(amountStr, "_", "", -1)
 	return common.AmountFromString(amountStr)
 }
+
+type ListFlags []string
+
+func (i *ListFlags) Type() string {
+	return "list"
+}
+
+func (i *ListFlags) String() string {
+	return strings.Join([]string(*i), " ")
+}
+
+func (i *ListFlags) Set(value string) error {
+	*i = append(*i, value)
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/stellar/go v0.0.0-20180501231346-87a45bf9f03d
 	github.com/stretchr/testify v1.2.2
 	github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd
+	github.com/ulule/limiter v2.2.0+incompatible
 	golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20180501092740-78d5f264b493 // indirect

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,8 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd h1:WuVJ5mLz1bggtrjvb2pQCZxN4MBDEK/SoyQXGI5UtBA=
 github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
+github.com/ulule/limiter v2.2.0+incompatible h1:1SeOVtEtaMckX/1yBlsok6LLZjiUrZ33kF5FITMl3MU=
+github.com/ulule/limiter v2.2.0+incompatible/go.mod h1:VJx/ZNGmClQDS5F6EmsGqK8j3jz1qJYZ6D9+MdAD+kw=
 golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5 h1:ylIG3jIeS45kB0W95N19kS62fwermjMYLIyybf8xh9M=
 golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -17,6 +17,9 @@ type Config struct {
 
 	TxsLimit int
 	OpsLimit int
+
+	RateLimitRuleAPI  RateLimitRule
+	RateLimitRuleNode RateLimitRule
 }
 
 func NewConfig() Config {
@@ -29,6 +32,8 @@ func NewConfig() Config {
 
 	p.TxsLimit = 1000
 	p.OpsLimit = 1000
+	p.RateLimitRuleAPI = NewRateLimitRule(RateLimitAPI)
+	p.RateLimitRuleNode = NewRateLimitRule(RateLimitNode)
 
 	return p
 }

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -1,6 +1,10 @@
 package common
 
-import "time"
+import (
+	"time"
+
+	"github.com/ulule/limiter"
+)
 
 const (
 	// BaseFee is the default transaction fee, if fee is lower than BaseFee, the
@@ -36,4 +40,18 @@ var (
 	BallotConfirmedTimeAllowDuration time.Duration = time.Minute * time.Duration(1)
 
 	InflationRatioString string = InflationRatio2String(InflationRatio)
+
+	// RateLimitAPI set the rate limit for API interface, the default value
+	// allows 100 requests per minute.
+	RateLimitAPI limiter.Rate = limiter.Rate{
+		Period: 1 * time.Minute,
+		Limit:  100,
+	}
+
+	// RateLimitNode set the rate limit for node interface, the default value
+	// allows 100 requests per seconds.
+	RateLimitNode limiter.Rate = limiter.Rate{
+		Period: 1 * time.Second,
+		Limit:  100,
+	}
 )

--- a/lib/common/net.go
+++ b/lib/common/net.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -9,6 +10,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/ulule/limiter"
 )
 
 var DefaultEndpoint int = 12345
@@ -164,4 +167,20 @@ func RequestURLFromRequest(r *http.Request) *url.URL {
 		RawQuery:   r.URL.RawQuery,
 		Fragment:   r.URL.Fragment,
 	}
+}
+
+type RateLimitRule struct {
+	Default     limiter.Rate
+	ByIPAddress map[string]limiter.Rate
+}
+
+func NewRateLimitRule(rate limiter.Rate) RateLimitRule {
+	return RateLimitRule{
+		Default:     rate,
+		ByIPAddress: map[string]limiter.Rate{},
+	}
+}
+
+func (r RateLimitRule) Serializable() ([]byte, error) {
+	return json.Marshal(r)
 }

--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -70,4 +70,6 @@ var (
 	ErrorHTTPProblem                          = NewError(163, "http failed to get response")
 	ErrorInvalidTransaction                   = NewError(164, "invalid transaction")
 	ErrorNotMatcHTTPRouter                    = NewError(165, "doesn't match http router")
+	ErrorTooManyRequests                      = NewError(166, "too many requests; reached limit")
+	ErrorHTTPServerError                      = NewError(167, "Internal Server Error")
 )

--- a/lib/network/http_middlewares.go
+++ b/lib/network/http_middlewares.go
@@ -4,14 +4,21 @@ import (
 	"fmt"
 	"net/http"
 	"runtime/debug"
+	"strconv"
+	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/inconshreveable/log15"
+	logging "github.com/inconshreveable/log15"
+	"github.com/ulule/limiter"
+	"github.com/ulule/limiter/drivers/middleware/stdlib"
+	"github.com/ulule/limiter/drivers/store/memory"
 
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/network/httputils"
 )
 
-func RecoverMiddleware(logger log15.Logger) mux.MiddlewareFunc {
+func RecoverMiddleware(logger logging.Logger) mux.MiddlewareFunc {
 	if logger == nil {
 		logger = log // use network.log
 	}
@@ -31,6 +38,74 @@ func RecoverMiddleware(logger log15.Logger) mux.MiddlewareFunc {
 					}
 				}
 			}()
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func rateLimitReachedHandler(w http.ResponseWriter, r *http.Request) {
+	httputils.WriteJSONError(w, errors.ErrorTooManyRequests)
+}
+
+func rateLimitErrorHandler(w http.ResponseWriter, r *http.Request, err error) {
+	httputils.WriteJSONError(w, errors.ErrorHTTPServerError.Clone().SetData("error", err))
+}
+
+func RateLimitMiddleware(logger logging.Logger, rule common.RateLimitRule) mux.MiddlewareFunc {
+	if logger == nil {
+		logger = log
+	}
+
+	store := memory.NewStoreWithOptions(
+		limiter.StoreOptions{
+			CleanUpInterval: time.Duration(2) * time.Minute,
+		},
+	)
+
+	defaultMiddleware := stdlib.NewMiddleware(
+		limiter.New(store, rule.Default),
+		stdlib.WithForwardHeader(true),
+		stdlib.WithErrorHandler(rateLimitErrorHandler),
+		stdlib.WithLimitReachedHandler(rateLimitReachedHandler),
+	)
+
+	middlewares := map[ /* ip address */ string]*stdlib.Middleware{}
+	for ip, rate := range rule.ByIPAddress {
+		m := stdlib.NewMiddleware(
+			limiter.New(store, rate),
+			stdlib.WithForwardHeader(true),
+			stdlib.WithErrorHandler(rateLimitErrorHandler),
+			stdlib.WithLimitReachedHandler(rateLimitReachedHandler),
+		)
+		middlewares[ip] = m
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// find middleware by ip
+			ip := limiter.GetIPKey(r, true)
+
+			var middleware *stdlib.Middleware
+			var found bool
+			if middleware, found = middlewares[ip]; !found {
+				middleware = defaultMiddleware
+			}
+
+			context, err := middleware.Limiter.Get(r.Context(), ip)
+			if err != nil {
+				middleware.OnError(w, r, err)
+				return
+			}
+
+			w.Header().Add("X-RateLimit-Limit", strconv.FormatInt(context.Limit, 10))
+			w.Header().Add("X-RateLimit-Remaining", strconv.FormatInt(context.Remaining, 10))
+			w.Header().Add("X-RateLimit-Reset", strconv.FormatInt(context.Reset, 10))
+
+			if context.Reached {
+				middleware.OnLimitReached(w, r)
+				return
+			}
+
 			next.ServeHTTP(w, r)
 		})
 	}

--- a/lib/network/http_middlewares_test.go
+++ b/lib/network/http_middlewares_test.go
@@ -2,13 +2,21 @@ package network
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
+	"github.com/ulule/limiter"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/network/httputils"
 )
 
 func TestRecoverMiddleware(t *testing.T) {
@@ -39,4 +47,154 @@ func TestRecoverMiddleware(t *testing.T) {
 	err = json.Unmarshal(bs, &msg)
 	require.Nil(t, err)
 	require.Equal(t, "panic: "+panicMsg, msg["title"])
+}
+
+func TestRateLimitMiddleWare(t *testing.T) {
+	handlerURL := UrlPathPrefixAPI + "/test"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("1"))
+		return
+	}
+
+	{ // 1000 requests per second
+		rate := limiter.Rate{
+			Period: 1 * time.Second,
+			Limit:  1000,
+		}
+		router := mux.NewRouter()
+		router.Use(RateLimitMiddleware(nil, common.NewRateLimitRule(rate)))
+		router.HandleFunc(handlerURL, http.HandlerFunc(handler)).Methods("GET")
+		ts := httptest.NewServer(router)
+
+		resp, err := http.Get(ts.URL + handlerURL)
+		require.Nil(t, err)
+		ts.Close()
+
+		require.Equal(t, fmt.Sprintf("%d", rate.Limit), resp.Header.Get("X-Ratelimit-Limit"))
+		require.Equal(t, fmt.Sprintf("%d", rate.Limit-1), resp.Header.Get("X-Ratelimit-Remaining"))
+		require.NotEmptyf(t, resp.Header.Get("X-Ratelimit-Reset"), "")
+
+		body, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		require.Equal(t, []byte("1"), body)
+	}
+
+	{ // 1 requests per minute; over rate limit, the `HttpProblem` will be
+		// returned with `http.StatusTooManyRequests` status code
+		rate := limiter.Rate{
+			Period: 1 * time.Minute,
+			Limit:  1,
+		}
+		router := mux.NewRouter()
+		router.Use(RateLimitMiddleware(nil, common.NewRateLimitRule(rate)))
+		router.HandleFunc(handlerURL, http.HandlerFunc(handler)).Methods("GET")
+		ts := httptest.NewServer(router)
+
+		var wg sync.WaitGroup
+		wg.Add(10)
+		for i := 0; i < 10; i++ {
+			go func() {
+				http.Get(ts.URL + handlerURL)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		resp, err := http.Get(ts.URL + handlerURL)
+		require.Nil(t, err)
+
+		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+
+		require.Equal(t, fmt.Sprintf("%d", rate.Limit), resp.Header.Get("X-Ratelimit-Limit"))
+		require.Equal(t, "0", resp.Header.Get("X-Ratelimit-Remaining"))
+		require.NotEmptyf(t, resp.Header.Get("X-Ratelimit-Reset"), "")
+
+		body, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		var problem httputils.Problem
+		{
+			err := json.Unmarshal(body, &problem)
+			require.Nil(t, err)
+		}
+		require.Equal(
+			t,
+			problem.Type,
+			httputils.ProblemTypeByCode(errors.ErrorTooManyRequests.Code),
+		)
+
+		ts.Close()
+	}
+}
+
+func TestRateLimitMiddleWareByIPAddress(t *testing.T) {
+	handlerURL := UrlPathPrefixAPI + "/test"
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("1"))
+		return
+	}
+
+	allowedIP := "1.1.1.1"
+	// by default, 1 requests per minute, but 1000 request per minute from `1.1.1.1`
+	rate := limiter.Rate{
+		Period: 1 * time.Minute,
+		Limit:  1,
+	}
+	rate1000 := limiter.Rate{
+		Period: 1 * time.Minute,
+		Limit:  1000,
+	}
+
+	rule := common.NewRateLimitRule(rate)
+	rule.ByIPAddress[allowedIP] = rate1000
+
+	router := mux.NewRouter()
+	router.Use(RateLimitMiddleware(nil, rule))
+	router.HandleFunc(handlerURL, http.HandlerFunc(handler)).Methods("GET")
+	ts := httptest.NewServer(router)
+
+	{ // from localhost
+		var wg sync.WaitGroup
+		wg.Add(10)
+		for i := 0; i < 10; i++ {
+			go func() {
+				http.Get(ts.URL + handlerURL)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		resp, err := http.Get(ts.URL + handlerURL)
+		require.Nil(t, err)
+
+		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	}
+
+	{ // from localhost
+		var wg sync.WaitGroup
+		wg.Add(10)
+		for i := 0; i < 10; i++ {
+			go func() {
+				req, _ := http.NewRequest("GET", ts.URL+handlerURL, nil)
+				req.Header.Set("X-Forwarded-For", allowedIP)
+				ts.Client().Do(req)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		req, _ := http.NewRequest("GET", ts.URL+handlerURL, nil)
+		req.Header.Set("X-Forwarded-For", allowedIP)
+		resp, err := ts.Client().Do(req)
+		require.Nil(t, err)
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+
+		require.Equal(t, []byte("1"), body)
+	}
+	ts.Close()
 }

--- a/lib/network/httputils/httputils.go
+++ b/lib/network/httputils/httputils.go
@@ -17,7 +17,9 @@ func IsEventStream(r *http.Request) bool {
 
 var (
 	// ErrorsToStatus defines errors.Error does not have 400 status code.
-	ErrorsToStatus = map[uint]int{}
+	ErrorsToStatus = map[uint]int{
+		errors.ErrorTooManyRequests.Code: http.StatusTooManyRequests,
+	}
 )
 
 func StatusCode(err error) int {

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -142,20 +142,25 @@ func NewNodeRunner(
 func (nr *NodeRunner) Ready() {
 	rateLimitMiddlewareAPI := network.RateLimitMiddleware(nr.log, nr.Conf.RateLimitRuleAPI)
 	if err := nr.network.AddMiddleware(network.RouterNameAPI, rateLimitMiddlewareAPI); err != nil {
-		nr.log.Error("`network.RateLimitMiddleware` has an error", "err", err)
+		nr.log.Error("`network.RateLimitMiddleware` for `RouterNameAPI` has an error", "err", err)
+		return
+	}
+	if err := nr.network.AddMiddleware("", rateLimitMiddlewareAPI); err != nil {
+		nr.log.Error("`network.RateLimitMiddleware` for base router has an error", "err", err)
 		return
 	}
 	rateLimitMiddlewareNode := network.RateLimitMiddleware(nr.log, nr.Conf.RateLimitRuleNode)
 	if err := nr.network.AddMiddleware(network.RouterNameNode, rateLimitMiddlewareNode); err != nil {
-		nr.log.Error("`network.RateLimitMiddleware` has an error", "err", err)
+		nr.log.Error("`network.RateLimitMiddleware` for `RouterNameNode` has an error", "err", err)
 		return
 	}
+
 	if err := nr.network.AddMiddleware(network.RouterNameAPI, network.RecoverMiddleware(nr.log)); err != nil {
-		nr.log.Error("`network.RecoverMiddleware` has an error", "err", err)
+		nr.log.Error("`network.RecoverMiddleware` for `RouterNameAPI` has an error", "err", err)
 		return
 	}
 	if err := nr.network.AddMiddleware(network.RouterNameNode, network.RecoverMiddleware(nr.log)); err != nil {
-		nr.log.Error("`network.RecoverMiddleware` has an error", "err", err)
+		nr.log.Error("`network.RecoverMiddleware` for `RouterNameNode` has an error", "err", err)
 		return
 	}
 	if err := nr.network.AddMiddleware("", network.RecoverMiddleware(nr.log)); err != nil {

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -145,13 +145,13 @@ func (nr *NodeRunner) Ready() {
 		nr.log.Error("`network.RateLimitMiddleware` for `RouterNameAPI` has an error", "err", err)
 		return
 	}
-	if err := nr.network.AddMiddleware("", rateLimitMiddlewareAPI); err != nil {
-		nr.log.Error("`network.RateLimitMiddleware` for base router has an error", "err", err)
-		return
-	}
 	rateLimitMiddlewareNode := network.RateLimitMiddleware(nr.log, nr.Conf.RateLimitRuleNode)
 	if err := nr.network.AddMiddleware(network.RouterNameNode, rateLimitMiddlewareNode); err != nil {
 		nr.log.Error("`network.RateLimitMiddleware` for `RouterNameNode` has an error", "err", err)
+		return
+	}
+	if err := nr.network.AddMiddleware("", rateLimitMiddlewareAPI); err != nil {
+		nr.log.Error("`network.RateLimitMiddleware` for base router has an error", "err", err)
 		return
 	}
 


### PR DESCRIPTION
### Github Issue

resolves #25 #357 

### Background

Check #25 #357

### Solution

* Use github.com/ulule/limiter for rate limit

* added 2 option for rate-limit
    - `--rate-limit-api`
    - `--rate-limit-node`

* `--rate-limit-X` options examples,
    - `--rate-limit-api=10-S`: allow `10` requests per second
    - `--rate-limit-api=5-M`: allow `5` requests per minute
    - `--rate-limit-api=9-H`: allow `9` requests per hour

* By default,
    - `/api` has the rate limit, `100` requests per minute; `common.RateLimitAPI`
    - `/node` has the rate limit, `100` requests per second; `common.RateLimitNode`

* `--rate-limit-X` options support ip address, ex)
    - `--rate-limit-api="1.2.3.4=10-S"`: allow `10` requests per second from `1.2.3.4`

* In command line, multiple `--rate-limit-X` options can be set, ex)
    - `$ sebak node ... --rate-limit-api=10-S --rate-limit-api="1.2.3.4=1000-M"`: This allows `1000` requests per minute only from `1.2.3.4` and `10` requests per seconds from the others.

* If you set multiple options, the last rate limit will be applied, which does not have ip address. ex)
    - `$ sebak node ... --rate-limit-api=10-S --rate-limit-api=1000-M`: the last one, `1000-M` will be applied.

* Like other options, rate limit also can be set from shell environment variables
    - `--rate-limit-api` from `SEBAK_RATE_LIMIT_API`
    - `--rate-limit-node` from `SEBAK_RATE_LIMIT_NODE`

* Shell variables also can set the multple rate limit ex)
    - `SEBAK_RATE_LIMIT_API="10-S 1.2.3.4=1000-M"`
    - seperate values by blank space

* For unlimited limit, set the limit to `0`, ex)
    - `--rate-limit-api=0-S`

* Lowercase also possible, ex) `--rate-limit-api=10-s`, `--rate-limit-api=10-m`, `--rate-limit-api=10-h`