### PR TITLE
Modify integration test timeouts(1-2-2-5), tx time=9s

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -45,13 +45,13 @@ for dir in ${TEST_DIRS}; do
     # Also SUPER IMPORTANT: the `-test` args need to be before any other args, or they are simply ignored...
     export NODE1=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node1.env \
                           ${NODE_DOCKER_IMAGE} -test.coverprofile=coverage.txt node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON}\
-                          --log-level=debug --timeout-init=10 --timeout-sign=10 --timeout-accept=10 --block-time=20)
+                          --log-level=debug)
     export NODE2=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node2.env \
                           ${NODE_DOCKER_IMAGE} -test.coverprofile=coverage.txt node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON}\
-                          --log-level=debug --timeout-init=10 --timeout-sign=10 --timeout-accept=10 --block-time=20)
+                          --log-level=debug)
     export NODE3=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node3.env \
                           ${NODE_DOCKER_IMAGE} -test.coverprofile=coverage.txt node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON}\
-                          --log-level=debug --timeout-init=10 --timeout-sign=10 --timeout-accept=10 --block-time=20)
+                          --log-level=debug)
 
     DOCKER_CONTAINERS="${DOCKER_CONTAINERS} ${NODE1} ${NODE2} ${NODE3}"
 

--- a/tests/utils.sh
+++ b/tests/utils.sh
@@ -27,7 +27,7 @@ function getAccountWithBalance () # u16 port, string addr and expected balance
     fi
 
     balance=0
-    for i in $(seq 100)
+    for i in $(seq 30)
     do
 	    balance=$(getAccount $1 $2 | jq ".balance" | sed 's/"//g')
 	    if [ "$balance" == "$3" ];then


### PR DESCRIPTION
### Background
Existing timeouts(10(INIT)-10(SIGN)-10(ACCEPT)-20(BLOCK-TIME)) are too loose to detect performance degradation in the test.

### Solution
Making the timeout tight(1-2-2-5). It also reduces the time it takes to check if a transaction has been performed(0.3 * 100 = 30s -> 0.3 * 30 = 9s)
These are based on https://gist.github.com/spikeekips/8fd0bfc9b805afdad0b7bcb35170332e by @spikeekips 
