### PR TITLE
Move genesis/common block functionality into their own file

### DIFF
--- a/lib/block/block.go
+++ b/lib/block/block.go
@@ -5,15 +5,12 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/stellar/go/keypair"
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/consensus/round"
 	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/storage"
-	"boscoin.io/sebak/lib/transaction"
-	"boscoin.io/sebak/lib/transaction/operation"
 )
 
 const (
@@ -40,102 +37,6 @@ func (bck Block) Serialize() (encoded []byte, err error) {
 func (bck Block) String() string {
 	encoded, _ := json.MarshalIndent(bck, "", "  ")
 	return string(encoded)
-}
-
-// MakeGenesisBlock makes genesis block.
-//
-// This special block has different part from the other Block
-// * `Block.Proposer` is empty
-// * `Block.Transaction` is empty
-// * `Block.Confirmed` is `common.GenesisBlockConfirmedTime`
-// * has only one `Transaction`
-//
-// This Transaction is different from other normal Transaction;
-// * signed by `keypair.Master(string(networkID))`
-// * must have only two `Operation`, `CreateAccount`
-// * The first `Operation` is for genesis account
-//   * `CreateAccount.Amount` is same with balance of genesis account
-//   * `CreateAccount.Target` is genesis account
-// * The next `Operation` is for common account
-//   * `CreateAccount.Amount` is 0
-//   * `CreateAccount.Target` is common account
-// * `Transaction.B.Fee` is 0
-func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, commonAccount BlockAccount, networdID []byte) (blk *Block, err error) {
-	if genesisAccount.Address == commonAccount.Address {
-		err = fmt.Errorf("genesis account and common account are same.")
-		return
-	}
-
-	var exists bool
-	if exists, err = ExistsBlockByHeight(st, 1); exists || err != nil {
-		if exists {
-			err = errors.ErrorBlockAlreadyExists
-		}
-
-		return
-	}
-
-	// create create-account transaction.
-	var ops []operation.Operation
-	{
-		opb := operation.NewCreateAccount(genesisAccount.Address, genesisAccount.Balance, "")
-		op := operation.Operation{
-			H: operation.Header{
-				Type: operation.TypeCreateAccount,
-			},
-			B: opb,
-		}
-		ops = append(ops, op)
-	}
-
-	{
-		opb := operation.NewCreateAccount(commonAccount.Address, commonAccount.Balance, "")
-		op := operation.Operation{
-			H: operation.Header{
-				Type: operation.TypeCreateAccount,
-			},
-			B: opb,
-		}
-		ops = append(ops, op)
-	}
-
-	txBody := transaction.Body{
-		Source:     genesisAccount.Address,
-		Fee:        0,
-		SequenceID: genesisAccount.SequenceID,
-		Operations: ops,
-	}
-
-	tx := transaction.Transaction{
-		T: "transaction",
-		H: transaction.Header{
-			Created: common.GenesisBlockConfirmedTime,
-			Hash:    txBody.MakeHashString(),
-		},
-		B: txBody,
-	}
-
-	kp := keypair.Master(string(networkID))
-	tx.Sign(kp, []byte(networdID))
-
-	blk = NewBlock(
-		"",
-		round.Round{},
-		"",
-		[]string{tx.GetHash()},
-		common.GenesisBlockConfirmedTime,
-	)
-	if err = blk.Save(st); err != nil {
-		return
-	}
-
-	raw, _ := tx.Serialize()
-	bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx, raw)
-	if err = bt.Save(st); err != nil {
-		return
-	}
-
-	return
 }
 
 // NewBlock creates new block; `ptx` represents the
@@ -168,15 +69,6 @@ func GetBlockKeyPrefixConfirmed(confirmed string) string {
 
 func GetBlockKeyPrefixHeight(height uint64) string {
 	return fmt.Sprintf("%s%020d", common.BlockPrefixHeight, height)
-}
-
-// Returns: Genesis block
-func GetGenesis(st *storage.LevelDBBackend) Block {
-	if blk, err := GetBlockByHeight(st, common.GenesisBlockHeight); err != nil {
-		panic(err)
-	} else {
-		return blk
-	}
 }
 
 func (b Block) NewBlockKeyConfirmed() string {

--- a/lib/block/genesis.go
+++ b/lib/block/genesis.go
@@ -1,0 +1,124 @@
+//
+// Defines primitives used to build and interact with both the genesis
+// and common budget blocks / accounts, which are special blocks
+// in the BOScoin blockchain
+//
+package block
+
+import (
+	"fmt"
+
+	"github.com/stellar/go/keypair"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus/round"
+	"boscoin.io/sebak/lib/error"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
+	"boscoin.io/sebak/lib/transaction/operation"
+)
+
+// Returns: Genesis block
+func GetGenesis(st *storage.LevelDBBackend) Block {
+	if blk, err := GetBlockByHeight(st, common.GenesisBlockHeight); err != nil {
+		panic(err)
+	} else {
+		return blk
+	}
+}
+
+// MakeGenesisBlock makes genesis block.
+//
+// This special block has different part from the other Block
+// * `Block.Proposer` is empty
+// * `Block.Transaction` is empty
+// * `Block.Confirmed` is `common.GenesisBlockConfirmedTime`
+// * has only one `Transaction`
+//
+// This Transaction is different from other normal Transaction;
+// * signed by `keypair.Master(string(networkID))`
+// * must have only two `Operation`, `CreateAccount`
+// * The first `Operation` is for genesis account
+//   * `CreateAccount.Amount` is same with balance of genesis account
+//   * `CreateAccount.Target` is genesis account
+// * The next `Operation` is for common account
+//   * `CreateAccount.Amount` is 0
+//   * `CreateAccount.Target` is common account
+// * `Transaction.B.Fee` is 0
+func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, commonAccount BlockAccount, networdID []byte) (blk *Block, err error) {
+	if genesisAccount.Address == commonAccount.Address {
+		err = fmt.Errorf("genesis account and common account are same.")
+		return
+	}
+
+	var exists bool
+	if exists, err = ExistsBlockByHeight(st, 1); exists || err != nil {
+		if exists {
+			err = errors.ErrorBlockAlreadyExists
+		}
+
+		return
+	}
+
+	// create create-account transaction.
+	var ops []operation.Operation
+	{
+		opb := operation.NewCreateAccount(genesisAccount.Address, genesisAccount.Balance, "")
+		op := operation.Operation{
+			H: operation.Header{
+				Type: operation.TypeCreateAccount,
+			},
+			B: opb,
+		}
+		ops = append(ops, op)
+	}
+
+	{
+		opb := operation.NewCreateAccount(commonAccount.Address, commonAccount.Balance, "")
+		op := operation.Operation{
+			H: operation.Header{
+				Type: operation.TypeCreateAccount,
+			},
+			B: opb,
+		}
+		ops = append(ops, op)
+	}
+
+	txBody := transaction.Body{
+		Source:     genesisAccount.Address,
+		Fee:        0,
+		SequenceID: genesisAccount.SequenceID,
+		Operations: ops,
+	}
+
+	tx := transaction.Transaction{
+		T: "transaction",
+		H: transaction.Header{
+			Created: common.GenesisBlockConfirmedTime,
+			Hash:    txBody.MakeHashString(),
+		},
+		B: txBody,
+	}
+
+	kp := keypair.Master(string(networkID))
+	tx.Sign(kp, []byte(networdID))
+
+	blk = NewBlock(
+		"",
+		round.Round{},
+		"",
+		[]string{tx.GetHash()},
+		common.GenesisBlockConfirmedTime,
+	)
+	if err = blk.Save(st); err != nil {
+		return
+	}
+
+	raw, _ := tx.Serialize()
+	bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx, raw)
+	if err = bt.Save(st); err != nil {
+		return
+	}
+
+	return
+}


### PR DESCRIPTION
A simple refactoring / code move, we can also move it downwards in another package if the need arise, but at the moment it's better to just separate it this way. `MakeGenesisBlock` knows too much about the consensus rules, while `block` is one of (and should stay) the most basic packages we have.