### PR TITLE
Remove the need to pass the testing object to helper functions

### DIFF
--- a/lib/node/runner/isaac_simulation_test.go
+++ b/lib/node/runner/isaac_simulation_test.go
@@ -25,7 +25,7 @@ TestISAACSimulationProposer indicates the following:
 */
 func TestISAACSimulationProposer(t *testing.T) {
 	nr, nodes, _ := createNodeRunnerForTesting(5, common.NewConfig(), nil)
-	tx, _ := GetTransaction(t)
+	tx, _ := GetTransaction()
 
 	// `nr` is proposer's runner
 	proposer := nr.localNode
@@ -50,38 +50,38 @@ func TestISAACSimulationProposer(t *testing.T) {
 	conf := common.NewConfig()
 
 	ballotSIGN1 := GenerateBallot(t, proposer, round, tx, ballot.StateSIGN, nodes[1], conf)
-	err = ReceiveBallot(t, nr, ballotSIGN1)
+	err = ReceiveBallot(nr, ballotSIGN1)
 	require.Nil(t, err)
 
 	ballotSIGN2 := GenerateBallot(t, proposer, round, tx, ballot.StateSIGN, nodes[2], conf)
-	err = ReceiveBallot(t, nr, ballotSIGN2)
+	err = ReceiveBallot(nr, ballotSIGN2)
 	require.Nil(t, err)
 
 	ballotSIGN3 := GenerateBallot(t, proposer, round, tx, ballot.StateSIGN, nodes[3], conf)
-	err = ReceiveBallot(t, nr, ballotSIGN3)
+	err = ReceiveBallot(nr, ballotSIGN3)
 	require.Nil(t, err)
 
 	ballotSIGN4 := GenerateBallot(t, proposer, round, tx, ballot.StateSIGN, nodes[4], conf)
-	err = ReceiveBallot(t, nr, ballotSIGN4)
+	err = ReceiveBallot(nr, ballotSIGN4)
 	require.Nil(t, err)
 
 	rr := nr.Consensus().RunningRounds[round.Index()]
 	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(ballot.StateSIGN)))
 
 	ballotACCEPT0 := GenerateBallot(t, proposer, round, tx, ballot.StateACCEPT, nodes[0], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT0)
+	err = ReceiveBallot(nr, ballotACCEPT0)
 	require.Nil(t, err)
 
 	ballotACCEPT1 := GenerateBallot(t, proposer, round, tx, ballot.StateACCEPT, nodes[1], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT1)
+	err = ReceiveBallot(nr, ballotACCEPT1)
 	require.Nil(t, err)
 
 	ballotACCEPT2 := GenerateBallot(t, proposer, round, tx, ballot.StateACCEPT, nodes[2], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT2)
+	err = ReceiveBallot(nr, ballotACCEPT2)
 	require.Nil(t, err)
 
 	ballotACCEPT3 := GenerateBallot(t, proposer, round, tx, ballot.StateACCEPT, nodes[3], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT3)
+	err = ReceiveBallot(nr, ballotACCEPT3)
 
 	_, ok := err.(CheckerStopCloseConsensus)
 	require.True(t, ok)

--- a/lib/node/runner/isaac_voting_empty_transaction_test.go
+++ b/lib/node/runner/isaac_voting_empty_transaction_test.go
@@ -53,16 +53,16 @@ func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
 	b := ballot.NewBallot(nr.localNode.Address(), nr.localNode.Address(), round, []string{})
 	b.SetVote(ballot.StateINIT, ballot.VotingYES)
 
-	ballotSIGN1 := GenerateEmptyTxBallot(t, proposer, round, ballot.StateSIGN, nodes[1], conf)
-	err = ReceiveBallot(t, nr, ballotSIGN1)
+	ballotSIGN1 := GenerateEmptyTxBallot(proposer, round, ballot.StateSIGN, nodes[1], conf)
+	err = ReceiveBallot(nr, ballotSIGN1)
 	require.Nil(t, err)
 
-	ballotSIGN2 := GenerateEmptyTxBallot(t, proposer, round, ballot.StateSIGN, nodes[2], conf)
-	err = ReceiveBallot(t, nr, ballotSIGN2)
+	ballotSIGN2 := GenerateEmptyTxBallot(proposer, round, ballot.StateSIGN, nodes[2], conf)
+	err = ReceiveBallot(nr, ballotSIGN2)
 	require.Nil(t, err)
 
-	ballotSIGN3 := GenerateEmptyTxBallot(t, proposer, round, ballot.StateSIGN, nodes[3], conf)
-	err = ReceiveBallot(t, nr, ballotSIGN3)
+	ballotSIGN3 := GenerateEmptyTxBallot(proposer, round, ballot.StateSIGN, nodes[3], conf)
+	err = ReceiveBallot(nr, ballotSIGN3)
 	require.Nil(t, err)
 
 	runningRounds := nr.Consensus().RunningRounds
@@ -74,20 +74,20 @@ func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
 	result := rr.Voted[proposer.Address()].GetResult(ballot.StateSIGN)
 	require.Equal(t, 3, len(result))
 
-	ballotACCEPT1 := GenerateEmptyTxBallot(t, proposer, round, ballot.StateACCEPT, nodes[1], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT1)
+	ballotACCEPT1 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[1], conf)
+	err = ReceiveBallot(nr, ballotACCEPT1)
 	require.Nil(t, err)
 
-	ballotACCEPT2 := GenerateEmptyTxBallot(t, proposer, round, ballot.StateACCEPT, nodes[2], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT2)
+	ballotACCEPT2 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[2], conf)
+	err = ReceiveBallot(nr, ballotACCEPT2)
 	require.Nil(t, err)
 
-	ballotACCEPT3 := GenerateEmptyTxBallot(t, proposer, round, ballot.StateACCEPT, nodes[3], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT3)
+	ballotACCEPT3 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[3], conf)
+	err = ReceiveBallot(nr, ballotACCEPT3)
 	require.Nil(t, err)
 
-	ballotACCEPT4 := GenerateEmptyTxBallot(t, proposer, round, ballot.StateACCEPT, nodes[4], conf)
-	err = ReceiveBallot(t, nr, ballotACCEPT4)
+	ballotACCEPT4 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[4], conf)
+	err = ReceiveBallot(nr, ballotACCEPT4)
 	require.EqualError(t, err, "ballot got consensus and will be stored")
 
 	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(ballot.StateACCEPT)))

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -300,7 +300,7 @@ func TestExpiredBallotCheckProposer(t *testing.T) {
 	}
 
 	// The createNodeRunnerForTesting has FixedSelector{localNode.Address()} so the proposer is always nr(nodes[0]).
-	validBallot := GenerateEmptyTxBallot(t, nr.localNode, round, ballot.StateSIGN, nodes[1], common.NewConfig())
+	validBallot := GenerateEmptyTxBallot(nr.localNode, round, ballot.StateSIGN, nodes[1], common.NewConfig())
 	validBallot.SetVote(ballot.StateSIGN, ballot.VotingEXP)
 
 	checker := &BallotChecker{
@@ -321,7 +321,7 @@ func TestExpiredBallotCheckProposer(t *testing.T) {
 
 	// The createNodeRunnerForTesting has FixedSelector{localNode.Address()} so the proposer is always nr(nodes[0]).
 	// The invalidBallot has nodes[1] as a proposer so it is invalid.
-	invalidBallot := GenerateEmptyTxBallot(t, nodes[1], round, ballot.StateSIGN, nodes[1], common.NewConfig())
+	invalidBallot := GenerateEmptyTxBallot(nodes[1], round, ballot.StateSIGN, nodes[1], common.NewConfig())
 	invalidBallot.SetVote(ballot.StateSIGN, ballot.VotingEXP)
 
 	checker = &BallotChecker{


### PR DESCRIPTION
```
Those test helpers function are generating data to make testing easier.
In principle, they should never fail, and if they do, there's a big bad bug somewhere.
We should not be using the testing object for those kinds of checks, as they are not part of the tests.
Moreover, if that bbb (big bad bug!) happens in another goroutine, it will be ignored
with the testing object, bug cause a crash with panic.
```