### PR TITLE
Adding Middleware In Base Router

### DIFF
--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -154,9 +154,14 @@ func (t *HTTP2Network) setNotReadyHandler() {
 }
 
 func (t *HTTP2Network) AddMiddleware(routerName string, mws ...mux.MiddlewareFunc) error {
-	r, ok := t.routers[routerName]
-	if !ok {
-		return errors.ErrorNotMatcHTTPRouter
+	var r *mux.Router
+	if len(routerName) < 1 {
+		r = t.router
+	} else {
+		var ok bool
+		if r, ok = t.routers[routerName]; !ok {
+			return errors.ErrorNotMatcHTTPRouter
+		}
 	}
 	for _, mw := range mws {
 		r.Use(mw)

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -158,6 +158,10 @@ func (nr *NodeRunner) Ready() {
 		nr.log.Error("Middleware has an error", "err", err)
 		return
 	}
+	if err := nr.network.AddMiddleware("", network.RecoverMiddleware(nr.log)); err != nil {
+		nr.log.Error("Middleware has an error", "err", err)
+		return
+	}
 
 	//CORS
 	{


### PR DESCRIPTION
### Background
After #510, `Middleware` was adopted in our code. One thing missed is `Middleware` was attached to `network.RouterNameAPI` and `network.RouterNameNode`. We also have the base router, the `/metrics` belongs to.

### Solution
Add middleware to the base router, `HTTP2Network.router`