### PR TITLE
 Make GetLatestBlock panic on error + do more error checking

### DIFF
--- a/lib/block/account_test.go
+++ b/lib/block/account_test.go
@@ -29,7 +29,7 @@ func TestSaveExistingBlockAccount(t *testing.T) {
 	st := storage.NewTestStorage()
 
 	b := TestMakeBlockAccount()
-	b.Save(st)
+	b.MustSave(st)
 
 	err := b.Deposit(common.Amount(100))
 	require.Nil(t, err)
@@ -47,7 +47,7 @@ func TestSortMultipleBlockAccount(t *testing.T) {
 	var createdOrder []string
 	for i := 0; i < 50; i++ {
 		b := TestMakeBlockAccount()
-		b.Save(st)
+		b.MustSave(st)
 
 		createdOrder = append(createdOrder, b.Address)
 	}
@@ -75,7 +75,7 @@ func TestGetSortedBlockAccounts(t *testing.T) {
 	var createdOrder []string
 	for i := 0; i < 50; i++ {
 		b := TestMakeBlockAccount()
-		b.Save(st)
+		b.MustSave(st)
 
 		createdOrder = append(createdOrder, b.Address)
 	}
@@ -101,14 +101,14 @@ func TestBlockAccountSaveBlockAccountSequenceIDs(t *testing.T) {
 	st := storage.NewTestStorage()
 
 	b := TestMakeBlockAccount()
-	b.Save(st)
+	b.MustSave(st)
 
 	expectedSavedLength := 10
 	var saved []BlockAccount
 	saved = append(saved, *b)
 	for i := 0; i < expectedSavedLength-len(saved); i++ {
 		b.SequenceID = rand.Uint64()
-		b.Save(st)
+		b.MustSave(st)
 
 		saved = append(saved, *b)
 	}
@@ -148,7 +148,7 @@ func TestBlockAccountObserver(t *testing.T) {
 
 	st := storage.NewTestStorage()
 
-	b.Save(st)
+	b.MustSave(st)
 
 	wg.Wait()
 

--- a/lib/block/block.go
+++ b/lib/block/block.go
@@ -221,16 +221,15 @@ func GetBlockHeaderByHeight(st *storage.LevelDBBackend, height uint64) (bt Heade
 	return GetBlockHeader(st, hash)
 }
 
-func GetLatestBlock(st *storage.LevelDBBackend) (b Block, err error) {
+func GetLatestBlock(st *storage.LevelDBBackend) Block {
 	// get latest blocks
 	iterFunc, closeFunc := GetBlocksByConfirmed(st, storage.NewDefaultListOptions(true, nil, 1))
-	b, _, _ = iterFunc()
+	b, _, _ := iterFunc()
 	closeFunc()
 
 	if b.Hash == "" {
-		err = errors.ErrorBlockNotFound
-		return
+		panic(errors.ErrorBlockNotFound)
 	}
 
-	return
+	return b
 }

--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -20,7 +20,7 @@ func TestBlockConfirmedOrdering(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		bk := TestMakeNewBlock([]string{})
 		bk.Height = uint64(i)
-		require.Nil(t, bk.Save(st))
+		bk.MustSave(st)
 		inserted = append(inserted, bk)
 	}
 
@@ -216,11 +216,11 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 	kp, _ := keypair.Random()
 	balance := common.Amount(100)
 	account := NewBlockAccount(kp.Address(), balance)
-	account.Save(st)
+	account.MustSave(st)
 
 	commonKP, _ := keypair.Random()
 	commonAccount := NewBlockAccount(commonKP.Address(), 0)
-	commonAccount.Save(st)
+	commonAccount.MustSave(st)
 
 	{
 		bk, err := MakeGenesisBlock(st, *account, *commonAccount, networkID)
@@ -256,11 +256,11 @@ func TestMakeGenesisBlockFindCommonAccount(t *testing.T) {
 	kp, _ := keypair.Random()
 	balance := common.Amount(100)
 	genesisAccount := NewBlockAccount(kp.Address(), balance)
-	genesisAccount.Save(st)
+	genesisAccount.MustSave(st)
 
 	commonKP, _ := keypair.Random()
 	commonAccount := NewBlockAccount(commonKP.Address(), 0)
-	commonAccount.Save(st)
+	commonAccount.MustSave(st)
 
 	{
 		bk, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -50,7 +50,7 @@ func TestBlockOperationSaveExisting(t *testing.T) {
 
 	bos := TestMakeNewBlockOperation(networkID, 1)
 	bo := bos[0]
-	bo.Save(st)
+	bo.MustSave(st)
 
 	exists, err := ExistsBlockOperation(st, bos[0].Hash)
 	require.Nil(t, err)
@@ -72,7 +72,7 @@ func TestGetSortedBlockOperationsByTxHash(t *testing.T) {
 		txHashes = append(txHashes, bos[0].TxHash)
 
 		for _, bo := range bos {
-			bo.Save(st)
+			bo.MustSave(st)
 
 			createdOrder[bo.TxHash] = append(createdOrder[bo.TxHash], bo.Hash)
 		}

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -72,6 +72,34 @@ func InitTestBlockchain() *storage.LevelDBBackend {
 	return st
 }
 
+/// Version of `Block.Save` that panics on error, usable only in tests
+func (b *Block) MustSave(st *storage.LevelDBBackend) {
+	if err := b.Save(st); err != nil {
+		panic(err)
+	}
+}
+
+/// Version of `BlockAccount.Save` that panics on error, usable only in tests
+func (b *BlockAccount) MustSave(st *storage.LevelDBBackend) {
+	if err := b.Save(st); err != nil {
+		panic(err)
+	}
+}
+
+/// Version of `BlockTransaction.Save` that panics on error, usable only in tests
+func (b *BlockTransaction) MustSave(st *storage.LevelDBBackend) {
+	if err := b.Save(st); err != nil {
+		panic(err)
+	}
+}
+
+/// Version of `BlockTransaction.Save` that panics on error, usable only in tests
+func (b *BlockOperation) MustSave(st *storage.LevelDBBackend) {
+	if err := b.Save(st); err != nil {
+		panic(err)
+	}
+}
+
 func TestMakeNewBlock(transactions []string) Block {
 	kp, _ := keypair.Random()
 

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -257,8 +257,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
-		err := bt.Save(st)
-		require.Nil(t, err)
+		bt.MustSave(st)
 	}
 
 	// create txs from another keypair source but target is this keypair
@@ -275,8 +274,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
-		err := bt.Save(st)
-		require.Nil(t, err)
+		bt.MustSave(st)
 	}
 
 	// create txs from another keypair
@@ -292,8 +290,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	for _, tx := range txs {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
-		err := bt.Save(st)
-		require.Nil(t, err)
+		bt.MustSave(st)
 	}
 
 	{
@@ -336,7 +333,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	for _, tx := range txs0 {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block0.Hash, block0.Height, block0.Confirmed, tx, a)
-		require.Nil(t, bt.Save(st))
+		bt.MustSave(st)
 	}
 
 	var txs1 []transaction.Transaction
@@ -353,7 +350,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	for _, tx := range txs1 {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block1.Hash, block1.Height, block1.Confirmed, tx, a)
-		require.Nil(t, bt.Save(st))
+		bt.MustSave(st)
 	}
 
 	{
@@ -421,11 +418,10 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		for _, tx := range txs {
 			a, _ := tx.Serialize()
 			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
-			err := bt.Save(st)
-			require.Nil(t, err)
+			bt.MustSave(st)
 		}
 		transactionOrder = append(transactionOrder, createdOrder...)
-		block.Save(st)
+		block.MustSave(st)
 	}
 
 	// Make transactions with height 1
@@ -444,12 +440,11 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		for _, tx := range txs {
 			a, _ := tx.Serialize()
 			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
-			err := bt.Save(st)
-			require.Nil(t, err)
+			bt.MustSave(st)
 		}
 
 		transactionOrder = append(createdOrder, transactionOrder...)
-		block.Save(st)
+		block.MustSave(st)
 	}
 
 	var halfSaved []BlockTransaction

--- a/lib/network/api/account_test.go
+++ b/lib/network/api/account_test.go
@@ -23,7 +23,7 @@ func TestGetAccountHandler(t *testing.T) {
 	defer ts.Close()
 	// Make Dummy BlockAccount
 	ba := block.TestMakeBlockAccount()
-	ba.Save(storage)
+	ba.MustSave(storage)
 	{
 		// Do a Request
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", ba.Address, -1)
@@ -63,7 +63,7 @@ func TestGetAccountHandlerStream(t *testing.T) {
 				}
 				observer.BlockAccountObserver.RUnlock()
 			}
-			ba.Save(storage)
+			ba.MustSave(storage)
 			wg.Done()
 		}()
 	}

--- a/lib/network/api/operation_test.go
+++ b/lib/network/api/operation_test.go
@@ -77,7 +77,7 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 				observer.BlockOperationObserver.RUnlock()
 			}
 			for _, bo := range boMap {
-				bo.Save(storage)
+				bo.MustSave(storage)
 			}
 			wg.Done()
 		}()

--- a/lib/network/api/resource/resource_test.go
+++ b/lib/network/api/resource/resource_test.go
@@ -20,7 +20,7 @@ func TestResourceAccount(t *testing.T) {
 	{
 		ba := block.TestMakeBlockAccount()
 		ba.SequenceID = 123
-		ba.Save(storage)
+		ba.MustSave(storage)
 
 		ra := NewAccount(ba)
 		r := ra.Resource()
@@ -45,7 +45,7 @@ func TestResourceAccount(t *testing.T) {
 		a, err := tx.Serialize()
 		require.Nil(t, err)
 		bt := block.NewBlockTransactionFromTransaction("dummy", 0, common.NowISO8601(), tx, a)
-		bt.Save(storage)
+		bt.MustSave(storage)
 
 		rt := NewTransaction(&bt)
 		r := rt.Resource()
@@ -73,7 +73,7 @@ func TestResourceAccount(t *testing.T) {
 		a, err := tx.Serialize()
 		require.Nil(t, err)
 		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
-		bt.Save(storage)
+		bt.MustSave(storage)
 		bo, err := block.GetBlockOperation(storage, bt.Operations[0])
 
 		ro := NewOperation(&bo)
@@ -98,7 +98,7 @@ func TestResourceAccount(t *testing.T) {
 		a, err := tx.Serialize()
 		require.Nil(t, err)
 		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
-		bt.Save(storage)
+		bt.MustSave(storage)
 
 		var rol []Resource
 		for _, boHash := range bt.Operations {

--- a/lib/network/api/transaction_test.go
+++ b/lib/network/api/transaction_test.go
@@ -25,7 +25,7 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 
 	_, _, bt, err := prepareTxWithoutSave()
 	require.Nil(t, err)
-	bt.Save(storage)
+	bt.MustSave(storage)
 
 	var reader *bufio.Reader
 	// Do a Request
@@ -163,7 +163,7 @@ func TestGetTransactionsHandlerStream(t *testing.T) {
 				observer.BlockTransactionObserver.RUnlock()
 			}
 			for _, bt := range btMap {
-				bt.Save(storage)
+				bt.MustSave(storage)
 			}
 			wg.Done()
 		}()
@@ -263,7 +263,7 @@ func TestGetTransactionsByAccountHandlerStream(t *testing.T) {
 				observer.BlockTransactionObserver.RUnlock()
 			}
 			for _, bt := range btMap {
-				bt.Save(storage)
+				bt.MustSave(storage)
 			}
 			wg.Done()
 		}()

--- a/lib/network/api/tx_operations_test.go
+++ b/lib/network/api/tx_operations_test.go
@@ -89,7 +89,7 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 				observer.BlockOperationObserver.RUnlock()
 			}
 			for _, bo := range boMap {
-				bo.Save(storage)
+				bo.MustSave(storage)
 			}
 			wg.Done()
 		}()

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -57,14 +57,12 @@ func (p *HelperTestGetBlocksHandler) createBlock() block.Block {
 	height := int(latest.Height)
 	bk := block.TestMakeNewBlock(txHashes)
 	bk.Height = uint64(height + 1)
-	bk.Save(p.st)
+	bk.MustSave(p.st)
 
 	for _, tx := range txs {
 		b, _ := tx.Serialize()
 		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx, b)
-		if err := btx.Save(p.st); err != nil {
-			panic(err)
-		}
+		btx.MustSave(p.st)
 	}
 
 	return bk

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -53,16 +53,8 @@ func (p *HelperTestGetBlocksHandler) createBlock() block.Block {
 		txs = append(txs, tx)
 	}
 
-	var height int
-	latest, err := block.GetLatestBlock(p.st)
-	if err == nil {
-		height = int(latest.Height)
-	} else {
-		if _, ok := err.(*errors.Error); !ok {
-			panic(err)
-		}
-		height = 0
-	}
+	latest := block.GetLatestBlock(p.st)
+	height := int(latest.Height)
 	bk := block.TestMakeNewBlock(txHashes)
 	bk.Height = uint64(height + 1)
 	bk.Save(p.st)
@@ -70,7 +62,7 @@ func (p *HelperTestGetBlocksHandler) createBlock() block.Block {
 	for _, tx := range txs {
 		b, _ := tx.Serialize()
 		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx, b)
-		if err = btx.Save(p.st); err != nil {
+		if err := btx.Save(p.st); err != nil {
 			panic(err)
 		}
 	}

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -69,7 +69,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 
 	p.genesisKeypair, _ = keypair.Random()
 	p.genesisAccount = block.NewBlockAccount(p.genesisKeypair.Address(), common.MaximumBalance)
-	p.genesisAccount.Save(p.st)
+	p.genesisAccount.MustSave(p.st)
 
 	for i := 0; i < 3; i++ {
 		p.blocks = append(p.blocks, p.createBlock())
@@ -102,7 +102,7 @@ func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
 	height := int(latest.Height)
 	bk := block.TestMakeNewBlock(txHashes)
 	bk.Height = uint64(height + 1)
-	bk.Save(p.st)
+	bk.MustSave(p.st)
 
 	for _, tx := range txs {
 		b, _ := tx.Serialize()

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -98,9 +98,8 @@ func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
 		p.transactionHashes = append(p.transactionHashes, tx.GetHash())
 	}
 
-	var height int
 	latest := block.GetLatestBlock(p.st)
-	height = int(latest.Height)
+	height := int(latest.Height)
 	bk := block.TestMakeNewBlock(txHashes)
 	bk.Height = uint64(height + 1)
 	bk.Save(p.st)

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -99,15 +99,8 @@ func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
 	}
 
 	var height int
-	latest, err := block.GetLatestBlock(p.st)
-	if err == nil {
-		height = int(latest.Height)
-	} else {
-		if _, ok := err.(*errors.Error); !ok {
-			panic(err)
-		}
-		height = -1
-	}
+	latest := block.GetLatestBlock(p.st)
+	height = int(latest.Height)
 	bk := block.TestMakeNewBlock(txHashes)
 	bk.Height = uint64(height + 1)
 	bk.Save(p.st)
@@ -115,7 +108,7 @@ func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
 	for _, tx := range txs {
 		b, _ := tx.Serialize()
 		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx, b)
-		if err = btx.Save(p.st); err != nil {
+		if err := btx.Save(p.st); err != nil {
 			panic(err)
 		}
 	}

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -57,7 +57,7 @@ func (p *ballotCheckerProposedTransaction) MakeBallot(numberOfTxs int) (blt *bal
 	for i := 0; i < numberOfTxs; i++ {
 		kpA, _ := keypair.Random()
 		accountA := block.NewBlockAccount(kpA.Address(), common.Amount(common.BaseReserve))
-		accountA.Save(p.nr.Storage())
+		accountA.MustSave(p.nr.Storage())
 
 		kpB, _ := keypair.Random()
 

--- a/lib/node/runner/checker_ballot_transaction_test.go
+++ b/lib/node/runner/checker_ballot_transaction_test.go
@@ -58,7 +58,7 @@ func TestValidateTxPaymentMissingBlockAccount(t *testing.T) {
 		Address: kps.Address(),
 		Balance: common.Amount(1 * common.AmountPerCoin),
 	}
-	bas.Save(st)
+	bas.MustSave(st)
 	require.Equal(t, ValidateTx(st, tx), errors.ErrorBlockAccountDoesNotExists)
 
 	// Now just the target
@@ -68,14 +68,14 @@ func TestValidateTxPaymentMissingBlockAccount(t *testing.T) {
 		Address: kpt.Address(),
 		Balance: common.Amount(1 * common.AmountPerCoin),
 	}
-	bat.Save(st1)
+	bat.MustSave(st1)
 	require.Equal(t, ValidateTx(st1, tx), errors.ErrorBlockAccountDoesNotExists)
 
 	// And finally, bot
 	st2 := storage.NewTestStorage()
 	defer st2.Close()
-	bas.Save(st2)
-	bat.Save(st2)
+	bas.MustSave(st2)
+	bat.MustSave(st2)
 	require.Nil(t, ValidateTx(st2, tx))
 }
 
@@ -95,8 +95,8 @@ func TestValidateTxWrongSequenceID(t *testing.T) {
 		Address: kpt.Address(),
 		Balance: common.Amount(1 * common.AmountPerCoin),
 	}
-	bas.Save(st)
-	bat.Save(st)
+	bas.MustSave(st)
+	bat.MustSave(st)
 
 	tx := transaction.Transaction{
 		T: "transaction",
@@ -139,8 +139,8 @@ func TestValidateTxOverBalance(t *testing.T) {
 		Address: kpt.Address(),
 		Balance: common.Amount(1 * common.AmountPerCoin),
 	}
-	bas.Save(st)
-	bat.Save(st)
+	bas.MustSave(st)
+	bat.MustSave(st)
 
 	opbody := operation.Payment{Target: kpt.Address(), Amount: bas.Balance}
 	tx := transaction.Transaction{
@@ -197,8 +197,8 @@ func TestValidateOpCreateExistsAccount(t *testing.T) {
 		Address: kpt.Address(),
 		Balance: common.Amount(1 * common.AmountPerCoin),
 	}
-	bat.Save(st)
-	bas.Save(st)
+	bat.MustSave(st)
+	bas.MustSave(st)
 
 	tx := transaction.Transaction{
 		T: "transaction",
@@ -222,6 +222,6 @@ func TestValidateOpCreateExistsAccount(t *testing.T) {
 
 	st1 := storage.NewTestStorage()
 	defer st1.Close()
-	bas.Save(st1)
+	bas.MustSave(st1)
 	require.Nil(t, ValidateTx(st1, tx))
 }

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -58,7 +58,7 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 
 	{ // valid transaction
 		targetAccount, targetKP := TestMakeBlockAccount(common.Amount(10000000000000) /* 100,00000 BOS */)
-		targetAccount.Save(nodeRunner.Storage())
+		targetAccount.MustSave(nodeRunner.Storage())
 
 		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, rootKP, targetKP)
 		tx.B.SequenceID = rootAccount.SequenceID
@@ -71,7 +71,7 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 
 	{ // invalid transaction: same source already in Pool
 		targetAccount, targetKP := TestMakeBlockAccount(common.Amount(10000000000000))
-		targetAccount.Save(nodeRunner.Storage())
+		targetAccount.MustSave(nodeRunner.Storage())
 
 		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, rootKP, targetKP)
 		tx.B.SequenceID = rootAccount.SequenceID
@@ -89,7 +89,7 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 	{ // invalid transaction: source account does not exists
 		_, sourceKP := TestMakeBlockAccount(common.Amount(10000000000000))
 		targetAccount, targetKP := TestMakeBlockAccount(common.Amount(10000000000000))
-		targetAccount.Save(nodeRunner.Storage())
+		targetAccount.MustSave(nodeRunner.Storage())
 
 		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, sourceKP, targetKP)
 
@@ -105,7 +105,7 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 	{ // invalid transaction: target account does not exists
 		sourceAccount, sourceKP := TestMakeBlockAccount(common.Amount(10000000000000))
 		_, targetKP := TestMakeBlockAccount(common.Amount(10000000000000))
-		sourceAccount.Save(nodeRunner.Storage())
+		sourceAccount.MustSave(nodeRunner.Storage())
 
 		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, sourceKP, targetKP)
 		tx.B.SequenceID = sourceAccount.SequenceID
@@ -196,7 +196,7 @@ func (g *getMissingTransactionTesting) MakeBallot(numberOfTxs int) (blt *ballot.
 	for i := 0; i < numberOfTxs; i++ {
 		kpA, _ := keypair.Random()
 		accountA := block.NewBlockAccount(kpA.Address(), common.Amount(common.BaseReserve)*2)
-		accountA.Save(g.proposerNR.Storage())
+		accountA.MustSave(g.proposerNR.Storage())
 
 		kpB, _ := keypair.Random()
 
@@ -425,7 +425,7 @@ func (p *irregularIncomingBallot) makeBallot(state ballot.State) (blt *ballot.Ba
 
 	p.keyA, _ = keypair.Random()
 	p.accountA = block.NewBlockAccount(p.keyA.Address(), common.Amount(common.BaseReserve)*2)
-	p.accountA.Save(p.nr.Storage())
+	p.accountA.MustSave(p.nr.Storage())
 
 	kpB, _ := keypair.Random()
 

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -433,11 +433,7 @@ func (nr *NodeRunner) handleBallotMessage(message common.NetworkMessage) (err er
 
 func (nr *NodeRunner) InitRound() {
 	// get latest blocks
-	var err error
-	var latestBlock block.Block
-	if latestBlock, err = block.GetLatestBlock(nr.storage); err != nil {
-		panic(err)
-	}
+	latestBlock := block.GetLatestBlock(nr.storage)
 
 	nr.consensus.SetLatestBlock(latestBlock)
 	nr.consensus.SetLatestRound(round.Round{})

--- a/lib/node/runner/util_test.go
+++ b/lib/node/runner/util_test.go
@@ -14,10 +14,10 @@ func TestGetGenesisAccount(t *testing.T) {
 	st := storage.NewTestStorage()
 
 	genesisAccount := block.NewBlockAccount(block.GenesisKP.Address(), common.Amount(1))
-	genesisAccount.Save(st)
+	genesisAccount.MustSave(st)
 
 	commonAccount := block.NewBlockAccount(block.CommonKP.Address(), 0)
-	commonAccount.Save(st)
+	commonAccount.MustSave(st)
 
 	block.MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
 
@@ -39,10 +39,10 @@ func TestGetInitialBalance(t *testing.T) {
 
 	initialBalance := common.Amount(99)
 	genesisAccount := block.NewBlockAccount(block.GenesisKP.Address(), initialBalance)
-	genesisAccount.Save(st)
+	genesisAccount.MustSave(st)
 
 	commonAccount := block.NewBlockAccount(block.CommonKP.Address(), 0)
-	commonAccount.Save(st)
+	commonAccount.MustSave(st)
 
 	block.MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
 


### PR DESCRIPTION
```
GetLatestBlock should never error out, as at least the GenesisBlock always exists
```

In addition, the last commit introduce the test-only `MustSave` function which allows to simplify test error checking. As can be seen from the diff, in many case, error checking was simply ignored. With `MustSave`, we safely provide a mean to do error checking at no cost in unittests.