### PR TITLE
Add pprof handlers

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -54,6 +54,7 @@ var (
 	flagOperationsLimit     string              = common.GetENVValue("SEBAK_OPERATIONS_LIMIT", "1000")
 	flagRateLimitAPI        cmdcommon.ListFlags // "SEBAK_RATE_LIMIT_API"
 	flagRateLimitNode       cmdcommon.ListFlags // "SEBAK_RATE_LIMIT_NODE"
+	flagDebugPProf          bool                = common.GetENVValue("SEBAK_DEBUG_PPROF", "0") == "1"
 )
 
 var (
@@ -158,6 +159,7 @@ func init() {
 		"rate-limit-node",
 		fmt.Sprintf("rate limit for %s: [<ip>=]<limit>-<period>, ex) '10-S' '3.3.3.3=1000-M'", network.UrlPathPrefixNode),
 	)
+	nodeCmd.Flags().BoolVar(&flagDebugPProf, "debug-pprof", flagDebugPProf, "set debug pprof")
 
 	rootCmd.AddCommand(nodeCmd)
 }
@@ -411,6 +413,9 @@ func parseFlagsNode() {
 	if flagVerbose {
 		http2.VerboseLogs = true
 		network.VerboseLogs = true
+	}
+	if flagDebugPProf {
+		runner.DebugPProf = true
 	}
 }
 

--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -180,6 +180,11 @@ func (t *HTTP2Network) AddHandler(pattern string, handler http.HandlerFunc) (rou
 		routerName = RouterNameAPI
 		prefix = pattern[len(UrlPathPrefixAPI):]
 	default:
+		// if a pattern has a suffix *,the router sets path prefix and handler
+		if strings.HasSuffix(pattern, "*") {
+			pathPrefix := strings.TrimSuffix(pattern, "*")
+			return t.router.PathPrefix(pathPrefix).Handler(handler)
+		}
 		// if unknown pattern, it will be attached to base router
 		return t.router.HandleFunc(pattern, handler)
 	}

--- a/lib/node/runner/init.go
+++ b/lib/node/runner/init.go
@@ -7,6 +7,7 @@ import (
 )
 
 var log logging.Logger = logging.New("module", "noderunner")
+var DebugPProf bool = false
 
 func init() {
 	SetLogging(common.DefaultLogLevel, common.DefaultLogHandler)

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -9,6 +9,7 @@ package runner
 
 import (
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	ghandlers "github.com/gorilla/handlers"
@@ -206,6 +207,7 @@ func (nr *NodeRunner) Ready() {
 	nr.network.AddHandler(nodeHandler.HandlerURLPattern(GetTransactionPattern), nodeHandler.GetNodeTransactionsHandler).
 		Methods("GET", "POST").
 		MatcherFunc(common.PostAndJSONMatcher)
+
 	nr.network.AddHandler("/metrics", promhttp.Handler().ServeHTTP)
 
 	// api handlers
@@ -245,6 +247,15 @@ func (nr *NodeRunner) Ready() {
 		apiHandler.HandlerURLPattern(api.GetTransactionsHandlerPattern),
 		TransactionsHandler,
 	).Methods("GET", "POST").MatcherFunc(common.PostAndJSONMatcher)
+
+	// pprof
+	if DebugPProf == true {
+		nr.network.AddHandler("/debug/pprof/cmdline", pprof.Cmdline)
+		nr.network.AddHandler("/debug/pprof/profile", pprof.Profile)
+		nr.network.AddHandler("/debug/pprof/symbol", pprof.Symbol)
+		nr.network.AddHandler("/debug/pprof/trace", pprof.Trace)
+		nr.network.AddHandler("/debug/pprof/*", pprof.Index)
+	}
 
 	nr.network.Ready()
 }


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Fixes #508 

### Background

For profiling node performance, Add `http/pprof` to node.


### Solution

```
$sebak node -h
Run sebak node

Usage:
  sebak node [flags]

Flags:
      --bind string                 bind to listen on (default "https://0.0.0.0:12345")
      --block-time string           block creation time (default "5")
      --debug-pprof                 set debug pprof
...

export SEBAK_DEBUG_PPROF=1
```

- http://127.0.0.1:2821/debug/pprof/

##### Heap profile

```
$go tool pprof http://localhost:2821/debug/pprof/heap
Fetching profile over HTTP from http://localhost:2821/debug/pprof/heap
Saved profile in /Users/anarch/pprof/pprof.alloc_objects.alloc_space.inuse_objects.inuse_space.006.pb.gz
Type: inuse_space
Time: Oct 17, 2018 at 12:28am (KST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top5
Showing nodes accounting for 9218.83kB, 100% of 9218.83kB total
Showing top 5 nodes out of 46
      flat  flat%   sum%        cum   cum%
 8194.75kB 88.89% 88.89%  8194.75kB 88.89%  github.com/syndtr/goleveldb/leveldb/memdb.New
  512.05kB  5.55% 94.45%   512.05kB  5.55%  github.com/syndtr/goleveldb/leveldb/cache.(*mBucket).get
  512.03kB  5.55%   100%   512.03kB  5.55%  runtime.systemstack
         0     0%   100%  4097.37kB 44.45%  boscoin.io/sebak/cmd/sebak/cmd.Execute
         0     0%   100%  4097.37kB 44.45%  boscoin.io/sebak/cmd/sebak/cmd.init.2.func1
(pprof)
```

##### CPU profile

```
$go tool pprof http://127.0.0.1:2821/debug/pprof/profile?seconds=120
Fetching profile over HTTP from http://127.0.0.1:2821/debug/pprof/profile?seconds=120
Saved profile in /Users/anarch/pprof/pprof.samples.cpu.005.pb.gz
Type: cpu
Time: Oct 17, 2018 at 12:24am (KST)
Duration: 2mins, Total samples = 760ms ( 0.63%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top10
Showing nodes accounting for 660ms, 86.84% of 760ms total
Showing top 10 nodes out of 171
      flat  flat%   sum%        cum   cum%
     170ms 22.37% 22.37%      170ms 22.37%  syscall.Syscall
     160ms 21.05% 43.42%      160ms 21.05%  runtime.pthread_cond_signal
     110ms 14.47% 57.89%      110ms 14.47%  runtime.pthread_cond_wait
      60ms  7.89% 65.79%       60ms  7.89%  runtime.memclrNoHeapPointers
      50ms  6.58% 72.37%       50ms  6.58%  runtime.nanotime
      40ms  5.26% 77.63%       40ms  5.26%  runtime.usleep
      20ms  2.63% 80.26%       20ms  2.63%  github.com/agl/ed25519/edwards25519.FeCMove
      20ms  2.63% 82.89%       20ms  2.63%  runtime.netpoll
      20ms  2.63% 85.53%       20ms  2.63%  runtime.stkbucket
      10ms  1.32% 86.84%       50ms  6.58%  boscoin.io/sebak/lib/network.(*ValidatorConnectionManager).connectingValidator
```

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

- Maybe it's not timing for profiling yet :->
- We need to figure out how to use `http/pprof` :->


### References
- https://github.com/prometheus/prometheus/blob/master/cmd/prometheus/main.go#L24
- https://blog.golang.org/profiling-go-programs
- https://artem.krylysov.com/blog/2017/03/13/profiling-and-optimizing-go-web-applications/

