### PR TITLE
For pre-flight request of CORS, Add allow headers, options

### DIFF
--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -176,8 +176,9 @@ func (nr *NodeRunner) Ready() {
 	{ //CORS
 		allowedOrigins := ghandlers.AllowedOrigins([]string{"*"})
 		allowedMethods := ghandlers.AllowedMethods([]string{"GET", "POST"})
+		allowedHeaders := ghandlers.AllowedHeaders([]string{"Content-Type", "X-Requested-With", "Cache-Control", "Access-Control"})
 
-		cors := ghandlers.CORS(allowedOrigins, allowedMethods)
+		cors := ghandlers.CORS(allowedOrigins, allowedMethods, allowedHeaders)
 		err := nr.network.AddMiddleware(network.RouterNameAPI, cors)
 		if err != nil {
 			nr.log.Error("Middleware has an error", "err", err)
@@ -227,23 +228,23 @@ func (nr *NodeRunner) Ready() {
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetAccountHandlerPattern),
 		apiHandler.GetAccountHandler,
-	).Methods("GET")
+	).Methods("GET", "OPTIONS")
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetAccountTransactionsHandlerPattern),
 		apiHandler.GetTransactionsByAccountHandler,
-	).Methods("GET")
+	).Methods("GET", "OPTIONS")
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetAccountOperationsHandlerPattern),
 		apiHandler.GetOperationsByAccountHandler,
-	).Methods("GET")
+	).Methods("GET", "OPTIONS")
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetTransactionByHashHandlerPattern),
 		apiHandler.GetTransactionByHashHandler,
-	).Methods("GET")
+	).Methods("GET", "OPTIONS")
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetTransactionOperationsHandlerPattern),
 		apiHandler.GetOperationsByTxHashHandler,
-	).Methods("GET")
+	).Methods("GET", "OPTIONS")
 
 	TransactionsHandler := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
@@ -258,7 +259,7 @@ func (nr *NodeRunner) Ready() {
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetTransactionsHandlerPattern),
 		TransactionsHandler,
-	).Methods("GET", "POST").MatcherFunc(common.PostAndJSONMatcher)
+	).Methods("GET", "POST", "OPTIONS").MatcherFunc(common.PostAndJSONMatcher)
 
 	// pprof
 	if DebugPProf == true {


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

To support pre-flight request of CORS, Allow OPTIONS method in handlers and add `allowedHeaders` like below:

```
allowedHeaders := ghandlers.AllowedHeaders([]string{"Content-Type", "X-Requested-With", "Cache-Control", "Access-Control"})
```

If you have to add `allowed headres`, let me know about it :->

### Solution
It's my curl testing. I am not sure the response is right.
```
$curl --verbose --request OPTIONS $URL --header 'Origin: http://example.com' --header 'Access-Control-Request-Headers: Origin, Accept, Content-Type'  --header 'Access-Control-Request-Method: GET'
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 2821 (#0)
> OPTIONS /api/v1/accounts/GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ HTTP/1.1
> Host: localhost:2821
> User-Agent: curl/7.54.0
> Accept: */*
> Origin: http://example.com
> Access-Control-Request-Headers: Origin, Accept, Content-Type
> Access-Control-Request-Method: GET
> 
< HTTP/1.1 200 OK
< Access-Control-Allow-Headers: Content-Type
< Access-Control-Allow-Origin: *
< X-Ratelimit-Limit: 
< X-Ratelimit-Limit: 
< X-Ratelimit-Remaining: 
< X-Ratelimit-Remaining: 
< X-Ratelimit-Reset: 
< X-Ratelimit-Reset: 
< Date: Wed, 17 Oct 2018 16:39:07 GMT
< Content-Length: 0
< 
* Connection #0 to host localhost left intact
```

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

