### PR TITLE
Consensus rules cannot be broken in finishOperation

### DIFF
--- a/lib/node/runner/finish_ballot.go
+++ b/lib/node/runner/finish_ballot.go
@@ -195,42 +195,19 @@ func finishOperation(st *storage.LevelDBBackend, source string, op operation.Ope
 	}
 }
 
-func finishCreateAccount(st *storage.LevelDBBackend, source string, op operation.CreateAccount, log logging.Logger) (err error) {
-	if _, err = block.GetBlockAccount(st, source); err != nil {
-		err = errors.BlockAccountDoesNotExists
-		return
-	}
-
-	var baTarget *block.BlockAccount
-	if baTarget, err = block.GetBlockAccount(st, op.TargetAddress()); err == nil {
-		err = errors.BlockAccountAlreadyExists
-		return
-	} else {
-		err = nil
-	}
-
-	baTarget = block.NewBlockAccountLinked(
+func finishCreateAccount(st *storage.LevelDBBackend, source string, op operation.CreateAccount, log logging.Logger) error {
+	baTarget := block.NewBlockAccountLinked(
 		op.TargetAddress(),
 		op.GetAmount(),
 		op.Linked,
 	)
-	if err = baTarget.Save(st); err != nil {
-		return
-	}
-
-	return
+	return baTarget.Save(st)
 }
 
 func finishPayment(st *storage.LevelDBBackend, source string, op operation.Payment, log logging.Logger) (err error) {
-	if _, err = block.GetBlockAccount(st, source); err != nil {
-		err = errors.BlockAccountDoesNotExists
-		return
-	}
-
 	var baTarget *block.BlockAccount
 	if baTarget, err = block.GetBlockAccount(st, op.TargetAddress()); err != nil {
-		err = errors.BlockAccountDoesNotExists
-		return
+		panic(err)
 	}
 
 	if err = baTarget.Deposit(op.GetAmount()); err != nil {


### PR DESCRIPTION
The consensus rules are checked in checker_ballot_transaction's `ValidateOp`.
So if this error happens, it means there's an important bug in sebak,
and that the consensus rules were bypassed.
As a result, we remove the checks which are not necessary,
and panic on operations that shouldn't return an error.