### PR TITLE
Return 404 In API Handlers

### DIFF
--- a/lib/network/api/account_test.go
+++ b/lib/network/api/account_test.go
@@ -46,8 +46,8 @@ func TestGetAccountHandler(t *testing.T) {
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", unknownKey.Address(), -1)
 		req, _ := http.NewRequest("GET", ts.URL+url, nil)
 		resp, err := ts.Client().Do(req)
-		defer resp.Body.Close()
 		require.Nil(t, err)
+		defer resp.Body.Close()
 
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	}

--- a/lib/network/api/account_test.go
+++ b/lib/network/api/account_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -39,6 +40,17 @@ func TestGetAccountHandler(t *testing.T) {
 
 		require.Equal(t, ba.Address, recv["address"], "address is not same")
 	}
+
+	{ // unknown address
+		unknownKey, _ := keypair.Random()
+		url := strings.Replace(GetAccountHandlerPattern, "{id}", unknownKey.Address(), -1)
+		req, _ := http.NewRequest("GET", ts.URL+url, nil)
+		resp, err := ts.Client().Do(req)
+		defer resp.Body.Close()
+		require.Nil(t, err)
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}
 }
 
 func TestGetAccountHandlerStream(t *testing.T) {
@@ -50,6 +62,9 @@ func TestGetAccountHandlerStream(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 	ba := block.TestMakeBlockAccount()
+	err = ba.Save(storage)
+	require.Nil(t, err)
+
 	key := ba.Address
 
 	// Wait until request registered to observer

--- a/lib/network/api/account_test.go
+++ b/lib/network/api/account_test.go
@@ -62,7 +62,7 @@ func TestGetAccountHandlerStream(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 	ba := block.TestMakeBlockAccount()
-	err = ba.Save(storage)
+	ba.MustSave(storage)
 	require.Nil(t, err)
 
 	key := ba.Address

--- a/lib/network/api/operation_test.go
+++ b/lib/network/api/operation_test.go
@@ -39,8 +39,7 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 
 	{
 		ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
-		err := ba.Save(storage)
-		require.Nil(t, err)
+		ba.MustSave(storage)
 	}
 
 	{
@@ -76,8 +75,7 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	kp, boList, err := prepareOps(storage, 0, 10, nil)
 	require.Nil(t, err)
 	ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
-	err = ba.Save(storage)
-	require.Nil(t, err)
+	ba.MustSave(storage)
 
 	// Do a Request
 	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
@@ -139,8 +137,7 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 		boMap[bo.Hash] = bo
 	}
 	ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
-	err = ba.Save(storage)
-	require.Nil(t, err)
+	ba.MustSave(storage)
 
 	// Wait until request registered to observer
 	{

--- a/lib/network/api/transaction_test.go
+++ b/lib/network/api/transaction_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -26,6 +27,15 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 	_, _, bt, err := prepareTxWithoutSave()
 	require.Nil(t, err)
 	bt.MustSave(storage)
+
+	{ // unknown transaction
+		req, _ := http.NewRequest("GET", ts.URL+GetTransactionsHandlerPattern+"/findme", nil)
+		resp, err := ts.Client().Do(req)
+		require.Nil(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}
 
 	var reader *bufio.Reader
 	// Do a Request

--- a/lib/network/api/tx_operations.go
+++ b/lib/network/api/tx_operations.go
@@ -3,8 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
-
-	"github.com/gorilla/mux"
+	"strings"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/observer"
@@ -12,7 +11,7 @@ import (
 	"boscoin.io/sebak/lib/network/api/resource"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/storage"
-	"strings"
+	"github.com/gorilla/mux"
 )
 
 func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter, r *http.Request) {
@@ -20,7 +19,7 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter,
 	hash := vars["id"]
 
 	if hash == "" {
-		http.NotFound(w, r) //TODO(anarcher): 404-JSON
+		httputils.WriteJSONError(w, errors.ErrorBlockTransactionDoesNotExists)
 		return
 	}
 
@@ -42,6 +41,10 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter,
 	}
 
 	ops, cursor := api.getOperationsByTxHash(hash, options)
+	if len(ops) < 1 {
+		httputils.WriteJSONError(w, errors.ErrorBlockTransactionDoesNotExists)
+		return
+	}
 
 	self := r.URL.String()
 	next := strings.Replace(resource.URLTransactionOperations, "{id}", hash, -1) + "?" + options.SetCursor(cursor).SetReverse(false).Encode()

--- a/lib/network/api/tx_operations_test.go
+++ b/lib/network/api/tx_operations_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"net/http"
 	"strings"
 	"sync"
 	"testing"
@@ -28,6 +29,16 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 	require.Nil(t, err)
 
 	bt := btList[0]
+
+	{ // unknown transaction
+		url := strings.Replace(GetTransactionOperationsHandlerPattern, "{id}", "showme", -1)
+		req, _ := http.NewRequest("GET", ts.URL+url, nil)
+		resp, err := ts.Client().Do(req)
+		require.Nil(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	}
 
 	// Do a Request
 	url := strings.Replace(GetTransactionOperationsHandlerPattern, "{id}", bt.Hash, -1)

--- a/lib/network/httputils/httputils.go
+++ b/lib/network/httputils/httputils.go
@@ -18,7 +18,9 @@ func IsEventStream(r *http.Request) bool {
 var (
 	// ErrorsToStatus defines errors.Error does not have 400 status code.
 	ErrorsToStatus = map[uint]int{
-		errors.ErrorTooManyRequests.Code: http.StatusTooManyRequests,
+		errors.ErrorTooManyRequests.Code:               http.StatusTooManyRequests,
+		errors.ErrorBlockTransactionDoesNotExists.Code: http.StatusNotFound,
+		errors.ErrorBlockAccountDoesNotExists.Code:     http.StatusNotFound,
 	}
 )
 


### PR DESCRIPTION
### Background

I found the `api.GetTransactionByHashHandler()` does not return `404` with unknown hash, `400` return. With this PR, several handlers will return `404` status code.

* `api.GetAccountHandler()`
* `api.GetOperationsByAccountHandler()`
* `api.GetTransactionByHashHandler()`