### PR TITLE
Transactions will be removed only by `VotingYES` in TransactionPool

### DIFF
--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -74,7 +74,9 @@ func (is *ISAAC) CloseConsensus(proposer string, round round.Round, vh ballot.Vo
 		return
 	}
 
-	transactionPool.Remove(rr.Transactions[proposer]...)
+	if vh == ballot.VotingYES {
+		transactionPool.Remove(rr.Transactions[proposer]...)
+	}
 
 	delete(is.RunningRounds, roundHash)
 


### PR DESCRIPTION
### Background
I found some problems during testing with `hot-body`(aka. sebak stress testing tool), that is,
* EXP ballot produced,
* After EXP ballot reached to `ACCEPT`, the `checker` called `ISAAC.CloseConsensus()`.
* `ISAAC.CloseConsensus()` cleaned up the transactions of the round even if not `VotingYES` :(

In the last step, EXP voting result removed the transactions from `TransactionPool`. According to the new ISAAC design, only `VotingYES` accepted result will clean up the transactions from `TransactionPool`

### Solution
Simply check the `VotingHole` in `ISAAC.CloseConsensus()`.