### PR TITLE
Add tx pool limit

### DIFF
--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -15,8 +15,9 @@ type Config struct {
 	TimeoutACCEPT time.Duration
 	BlockTime     time.Duration
 
-	TxsLimit int
-	OpsLimit int
+	TxsLimit    int
+	OpsLimit    int
+	TxPoolLimit int
 
 	RateLimitRuleAPI  RateLimitRule
 	RateLimitRuleNode RateLimitRule
@@ -32,6 +33,8 @@ func NewConfig() Config {
 
 	p.TxsLimit = 1000
 	p.OpsLimit = 1000
+	p.TxPoolLimit = 100000
+
 	p.RateLimitRuleAPI = NewRateLimitRule(RateLimitAPI)
 	p.RateLimitRuleNode = NewRateLimitRule(RateLimitNode)
 

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -30,6 +30,9 @@ const (
 
 	// BlockHeightEndOfInflation sets the block height of inflation end.
 	BlockHeightEndOfInflation uint64 = 36000000
+
+	// DefaultTxPoolLimit is the default tx pool limit.
+	DefaultTxPoolLimit int = 1000000
 )
 
 var (

--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -78,4 +78,6 @@ var (
 	ErrorUnfreezingRequestAlreadyReceived          = NewError(171, "unfreezing request already received from client")
 	ErrorTooManyRequests                           = NewError(172, "too many requests; reached limit")
 	ErrorHTTPServerError                           = NewError(173, "Internal Server Error")
+	ErrorTransactionAlreadyExistsInPool            = NewError(174, "transaction already exists in transaction pool")
+	ErrorTransactionPoolFull                       = NewError(175, "transaction pool is full")
 )

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -60,7 +60,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 		common.NewConfig(),
 	)
 	p.consensus = isaac
-	p.TransactionPool = transaction.NewPool(transaction.PoolDefaultLimit)
+	p.TransactionPool = transaction.NewPool(common.DefaultTxPoolLimit)
 
 	apiHandler := NetworkHandlerNode{storage: p.st, consensus: isaac, transactionPool: p.TransactionPool}
 

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -60,7 +60,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 		common.NewConfig(),
 	)
 	p.consensus = isaac
-	p.TransactionPool = transaction.NewPool()
+	p.TransactionPool = transaction.NewPool(transaction.PoolDefaultLimit)
 
 	apiHandler := NetworkHandlerNode{storage: p.st, consensus: isaac, transactionPool: p.TransactionPool}
 

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -306,7 +306,10 @@ func getMissingTransaction(checker *BallotChecker) (err error) {
 	}
 
 	for _, tx := range receivedTransaction {
-		checker.NodeRunner.TransactionPool.Add(tx)
+		err := checker.NodeRunner.TransactionPool.Add(tx)
+		if err == errors.ErrorTransactionPoolFull {
+			return err
+		}
 	}
 
 	return

--- a/lib/node/runner/checker_message.go
+++ b/lib/node/runner/checker_message.go
@@ -129,15 +129,18 @@ func MessageValidate(c common.Checker, args ...interface{}) (err error) {
 
 // PushIntoTransactionPool add the incoming
 // transactions into `Pool`.
-func PushIntoTransactionPool(c common.Checker, args ...interface{}) (err error) {
+func PushIntoTransactionPool(c common.Checker, args ...interface{}) error {
 	checker := c.(*MessageChecker)
 
 	tx := checker.Transaction
-	checker.TransactionPool.Add(tx)
+	err := checker.TransactionPool.Add(tx)
+	if err == errors.ErrorTransactionPoolFull {
+		return err
+	}
 
 	checker.Log.Debug("push transaction into TransactionPool")
 
-	return
+	return nil
 }
 
 // BroadcastTransaction broadcasts the incoming

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -105,7 +105,7 @@ func NewNodeRunner(
 		policy:          policy,
 		network:         n,
 		consensus:       c,
-		TransactionPool: transaction.NewPool(),
+		TransactionPool: transaction.NewPool(conf.TxPoolLimit),
 		storage:         storage,
 		log:             log.New(logging.Ctx{"node": localNode.Alias()}),
 		Conf:            conf,

--- a/lib/transaction/pool.go
+++ b/lib/transaction/pool.go
@@ -68,14 +68,6 @@ func (tp *Pool) Add(tx Transaction) error {
 	return nil
 }
 
-func (tp *Pool) TryAdd(tx Transaction) bool {
-	err := tp.Add(tx)
-	if err != nil {
-		return false
-	}
-	return true
-}
-
 func (tp *Pool) Remove(hashes ...string) {
 	if len(hashes) < 1 {
 		return

--- a/lib/transaction/pool.go
+++ b/lib/transaction/pool.go
@@ -3,10 +3,9 @@ package transaction
 import (
 	"sync"
 
+	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/error"
 )
-
-const PoolDefaultLimit = 100000
 
 type Pool struct {
 	sync.RWMutex
@@ -19,7 +18,7 @@ type Pool struct {
 
 func NewPool(limit int) *Pool {
 	if limit <= 0 {
-		limit = PoolDefaultLimit
+		limit = common.DefaultTxPoolLimit
 	}
 	return &Pool{
 		Pool:    map[string]Transaction{},


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Related: #588 

### Background


### Solution

- Add `limit` to the pool
- ` Add(tx) error and TryAdd(tx) bool`
- Add errors
### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

- In the current (master) branch, API handlers do not use the Tx pool.