### PR TITLE
Add MustWriteJSON for convenient  API

### DIFF
--- a/lib/network/api/account.go
+++ b/lib/network/api/account.go
@@ -50,7 +50,5 @@ func (api NetworkHandlerAPI) GetAccountHandler(w http.ResponseWriter, r *http.Re
 		return
 	}
 
-	if err := httputils.WriteJSON(w, 200, payload); err != nil {
-		httputils.WriteJSONError(w, err)
-	}
+	httputils.MustWriteJSON(w, 200, payload)
 }

--- a/lib/network/api/operation.go
+++ b/lib/network/api/operation.go
@@ -77,8 +77,5 @@ func (api NetworkHandlerAPI) GetOperationsByAccountHandler(w http.ResponseWriter
 	prev := strings.Replace(resource.URLAccountOperations, "{id}", address, -1) + "?" + options.SetReverse(true).Encode()
 	list := resource.NewResourceList(txs, self, next, prev)
 
-	if err := httputils.WriteJSON(w, 200, list); err != nil {
-		httputils.WriteJSONError(w, err)
-		return
-	}
+	httputils.MustWriteJSON(w, 200, list)
 }

--- a/lib/network/api/transaction.go
+++ b/lib/network/api/transaction.go
@@ -6,13 +6,14 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"strings"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/error"
 	"boscoin.io/sebak/lib/network/api/resource"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/storage"
-	"strings"
 )
 
 func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *http.Request) {
@@ -56,10 +57,7 @@ func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *ht
 	prev := GetTransactionsHandlerPattern + "?" + options.SetReverse(true).Encode()
 	list := resource.NewResourceList(txs, self, next, prev)
 
-	if err := httputils.WriteJSON(w, 200, list); err != nil {
-		http.Error(w, "Error reading request body", http.StatusInternalServerError)
-		return
-	}
+	httputils.WriteJSON(w, 200, list)
 }
 
 func (api NetworkHandlerAPI) GetTransactionByHashHandler(w http.ResponseWriter, r *http.Request) {
@@ -146,8 +144,5 @@ func (api NetworkHandlerAPI) GetTransactionsByAccountHandler(w http.ResponseWrit
 	prev := strings.Replace(resource.URLAccountTransactions, "{id}", address, -1) + "?" + options.SetReverse(true).Encode()
 	list := resource.NewResourceList(txs, self, next, prev)
 
-	if err := httputils.WriteJSON(w, 200, list); err != nil {
-		httputils.WriteJSONError(w, err)
-		return
-	}
+	httputils.MustWriteJSON(w, 200, list)
 }

--- a/lib/network/api/transaction.go
+++ b/lib/network/api/transaction.go
@@ -57,7 +57,7 @@ func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *ht
 	prev := GetTransactionsHandlerPattern + "?" + options.SetReverse(true).Encode()
 	list := resource.NewResourceList(txs, self, next, prev)
 
-	httputils.WriteJSON(w, 200, list)
+	httputils.MustWriteJSON(w, 200, list)
 }
 
 func (api NetworkHandlerAPI) GetTransactionByHashHandler(w http.ResponseWriter, r *http.Request) {
@@ -92,13 +92,9 @@ func (api NetworkHandlerAPI) GetTransactionByHashHandler(w http.ResponseWriter, 
 	}
 	payload, err := readFunc()
 	if err == nil {
-		if err := httputils.WriteJSON(w, 200, payload); err != nil {
-			http.Error(w, "Error reading request body", http.StatusInternalServerError)
-		}
+		httputils.MustWriteJSON(w, 200, payload)
 	} else {
-		if err := httputils.WriteJSON(w, httputils.StatusCode(err), err); err != nil {
-			http.Error(w, "Error reading request body", http.StatusInternalServerError)
-		}
+		httputils.WriteJSONError(w, err)
 	}
 }
 

--- a/lib/network/api/tx_operations.go
+++ b/lib/network/api/tx_operations.go
@@ -51,10 +51,7 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter,
 	prev := strings.Replace(resource.URLTransactionOperations, "{id}", hash, -1) + "?" + options.SetReverse(true).Encode()
 	list := resource.NewResourceList(ops, self, next, prev)
 
-	if err := httputils.WriteJSON(w, 200, list); err != nil {
-		httputils.WriteJSONError(w, err)
-		return
-	}
+	httputils.MustWriteJSON(w, 200, list)
 }
 
 func (api NetworkHandlerAPI) getOperationsByTxHash(txHash string, options storage.ListOptions) (txs []resource.Resource, cursor []byte) {

--- a/lib/network/httputils/json.go
+++ b/lib/network/httputils/json.go
@@ -11,6 +11,13 @@ type HALResource interface {
 	Resource() *hal.Resource
 }
 
+// MustWriteJSON writes the value or an error of it to the http response as json
+func MustWriteJSON(w http.ResponseWriter, code int, v interface{}) {
+	if err := WriteJSON(w, code, v); err != nil {
+		WriteJSONError(w, err)
+	}
+}
+
 // WriteJSONError writes the error to the http response as json encoding
 func WriteJSONError(w http.ResponseWriter, err error) {
 	code := StatusCode(err) //TODO(anarcher): ErrorStateCode is more suitable?


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

Most using of `httputils.WriteJSON` looks like below:
```
  if err := httputils.WriteJSON(w, 200, payload); err != nil {
        httputils.WriteJSONError(w, err)
    }
```

For convenient, Add `httputils.MustWriteJSON`

```
httputils.MustWriteJSON(w,200,payload)
```

Do it make sense? :->


### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

