### PR TITLE
Simple modify assert error in test code

### DIFF
--- a/cmd/sebak/cmd/cmd_test.go
+++ b/cmd/sebak/cmd/cmd_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestParseFlagValidators(t *testing.T) {
 	vs, err := parseFlagValidators("https://localhost:12346?address=GDPQ2LBYP3RL3O675H2N5IEYM6PRJNUA5QFMKXIHGTKEB5KS5T3KHFA2")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(vs))
 }
 
@@ -128,7 +128,7 @@ func TestAddingSelfWithoutValidators(t *testing.T) {
 	flagKPSecretSeed = "SCN4NSV5SVHIZWUDJFT4Z5FFVHO3TFRTOIBQLHMNPAZJ37K5A2YFSCBM"
 	flagBindURL = "http://0.0.0.0:12345"
 	_, err := parseFlagValidators(flagValidators)
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestParseFlagRateLimit(t *testing.T) {
@@ -140,10 +140,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 
 		cmdline := "--rate-limit-api=showme"
 		err := testCmd.Parse(strings.Fields(cmdline))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = parseFlagRateLimit(fr, common.RateLimitAPI)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	}
 
 	{ // valid value
@@ -154,10 +154,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 
 		cmdline := "--rate-limit-api=10-S"
 		err := testCmd.Parse(strings.Fields(cmdline))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, time.Second, rule.Default.Period)
 		require.Equal(t, int64(10), rule.Default.Limit)
 		require.Equal(t, 0, len(rule.ByIPAddress))
@@ -171,10 +171,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 
 		cmdline := "--rate-limit-api=10-S --rate-limit-api=9-M"
 		err := testCmd.Parse(strings.Fields(cmdline))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, time.Minute, rule.Default.Period)
 		require.Equal(t, int64(9), rule.Default.Limit)
 		require.Equal(t, 0, len(rule.ByIPAddress))
@@ -189,10 +189,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 		allowedIP := "1.2.3.4"
 		cmdline := fmt.Sprintf("--rate-limit-api=%s=8-S", allowedIP)
 		err := testCmd.Parse(strings.Fields(cmdline))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, common.RateLimitAPI.Period, rule.Default.Period)
 		require.Equal(t, common.RateLimitAPI.Limit, rule.Default.Limit)
 		require.Equal(t, 1, len(rule.ByIPAddress))
@@ -210,10 +210,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 		allowedIP := "1.2.3.4"
 		cmdline := fmt.Sprintf("--rate-limit-api=11-H --rate-limit-api=%s=8-S", allowedIP)
 		err := testCmd.Parse(strings.Fields(cmdline))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, time.Hour, rule.Default.Period)
 		require.Equal(t, int64(11), rule.Default.Limit)
 		require.Equal(t, 1, len(rule.ByIPAddress))
@@ -230,10 +230,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 
 		cmdline := "--rate-limit-api=0-S"
 		err := testCmd.Parse(strings.Fields(cmdline))
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, time.Second, rule.Default.Period)
 		require.Equal(t, int64(0), rule.Default.Limit)
 		require.Equal(t, 0, len(rule.ByIPAddress))
@@ -248,10 +248,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 
 			cmdline := "--rate-limit-api=10-s"
 			err := testCmd.Parse(strings.Fields(cmdline))
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, time.Second, rule.Default.Period)
 			require.Equal(t, int64(10), rule.Default.Limit)
 			require.Equal(t, 0, len(rule.ByIPAddress))
@@ -264,10 +264,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 
 			cmdline := "--rate-limit-api=10-m"
 			err := testCmd.Parse(strings.Fields(cmdline))
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, time.Minute, rule.Default.Period)
 			require.Equal(t, int64(10), rule.Default.Limit)
 			require.Equal(t, 0, len(rule.ByIPAddress))
@@ -280,10 +280,10 @@ func TestParseFlagRateLimit(t *testing.T) {
 
 			cmdline := "--rate-limit-api=10-h"
 			err := testCmd.Parse(strings.Fields(cmdline))
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			rule, err := parseFlagRateLimit(fr, common.RateLimitAPI)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, time.Hour, rule.Default.Period)
 			require.Equal(t, int64(10), rule.Default.Limit)
 			require.Equal(t, 0, len(rule.ByIPAddress))

--- a/lib/ballot/ballot_test.go
+++ b/lib/ballot/ballot_test.go
@@ -93,7 +93,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 		ballot.Sign(kp, networkID)
 
 		err := ballot.IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // bad `Ballot.B.Confirmed` time; too ahead
@@ -171,7 +171,7 @@ func TestBallotProposerTransaction(t *testing.T) {
 		blt := NewBallot(node.Address(), node.Address(), round, []string{})
 		blt.Sign(node.Keypair(), networkID)
 		err := blt.IsWellFormed(networkID, conf)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	}
 
 	{ // with ProposerTransaction
@@ -187,15 +187,15 @@ func TestBallotProposerTransaction(t *testing.T) {
 		var ptx ProposerTransaction
 		{
 			op, err := operation.NewOperation(opb)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			ptx, err = NewProposerTransaction(kp.Address(), op)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 
 		blt.SetProposerTransaction(ptx)
 		blt.Sign(node.Keypair(), networkID)
 		err := blt.IsWellFormed(networkID, conf)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	}
 }
 
@@ -245,7 +245,7 @@ func TestIsBallotWellFormed(t *testing.T) {
 
 	err := wellBallot.IsWellFormed(networkID, common.NewConfig())
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	wrongSignedBallot := NewBallot(n.Address(), p.Address(), round, []string{tx.GetHash()})
 	wrongSignedBallot.SetProposerTransaction(ptx)
@@ -254,7 +254,7 @@ func TestIsBallotWellFormed(t *testing.T) {
 
 	err = wrongSignedBallot.IsWellFormed(networkID, common.NewConfig())
 
-	require.NotNil(t, err)
+	require.Error(t, err)
 
 }
 
@@ -282,7 +282,7 @@ func TestIsExpiredBallotWellFormed(t *testing.T) {
 
 	err := b.IsWellFormed(networkID, common.NewConfig())
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 }
 
@@ -319,6 +319,6 @@ func TestIsExpiredBallotWithProposerTransactionWellFormed(t *testing.T) {
 
 	err := b.IsWellFormed(networkID, common.NewConfig())
 
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 }

--- a/lib/block/account_test.go
+++ b/lib/block/account_test.go
@@ -18,10 +18,10 @@ func TestSaveNewBlockAccount(t *testing.T) {
 
 	b := TestMakeBlockAccount()
 	err := b.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	exists, err := ExistsBlockAccount(st, b.Address)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, exists, true, "BlockAccount does not exists")
 }
 
@@ -32,10 +32,10 @@ func TestSaveExistingBlockAccount(t *testing.T) {
 	b.MustSave(st)
 
 	err := b.Deposit(common.Amount(100))
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = b.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	fetched, _ := GetBlockAccount(st, b.Address)
 	require.Equal(t, b.GetBalance(), fetched.GetBalance())

--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -88,7 +88,7 @@ func TestBlockHeightOrdering(t *testing.T) {
 		var fetched []Block
 		for i := 0; i < numberOfBlocks; i++ {
 			b, err := GetBlockByHeight(st, uint64(i))
-			require.Nil(t, err)
+			require.NoError(t, err)
 			fetched = append(fetched, b)
 		}
 
@@ -113,15 +113,15 @@ func TestMakeGenesisBlock(t *testing.T) {
 	balance := common.Amount(100)
 	genesisAccount := NewBlockAccount(genesisKP.Address(), balance)
 	err := genesisAccount.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	commonKP, _ := keypair.Random()
 	commonAccount := NewBlockAccount(commonKP.Address(), 0)
 	err = commonAccount.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	bk, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(1), bk.Height)
 	require.Equal(t, 1, len(bk.Transactions))
 	require.Equal(t, uint64(0), bk.Round)
@@ -132,12 +132,12 @@ func TestMakeGenesisBlock(t *testing.T) {
 	// transaction
 	{
 		exists, err := ExistsBlockTransaction(st, bk.Transactions[0])
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.True(t, exists)
 	}
 
 	bt, err := GetBlockTransaction(st, bk.Transactions[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	genesisBlockKP := keypair.Master(string(networkID))
 	require.Equal(t, genesisAccount.SequenceID, bt.SequenceID)
@@ -149,18 +149,18 @@ func TestMakeGenesisBlock(t *testing.T) {
 	// operation
 	{
 		exists, err := ExistsBlockOperation(st, bt.Operations[0])
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.True(t, exists)
 	}
 	bo, err := GetBlockOperation(st, bt.Operations[0])
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, bt.Hash, bo.TxHash)
 	require.Equal(t, operation.TypeCreateAccount, bo.Type)
 	require.Equal(t, genesisBlockKP.Address(), bo.Source)
 
 	{
 		opb, err := operation.UnmarshalBodyJSON(bo.Type, bo.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		opbp := opb.(operation.Payable)
 
@@ -178,15 +178,15 @@ func TestMakeGenesisBlockOverride(t *testing.T) {
 		balance := common.Amount(100)
 		account := NewBlockAccount(kp.Address(), balance)
 		err := account.Save(st)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		commonKP, _ := keypair.Random()
 		commonAccount := NewBlockAccount(commonKP.Address(), 0)
 		err = commonAccount.Save(st)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		bk, err := MakeGenesisBlock(st, *account, *commonAccount, networkID)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, uint64(1), bk.Height)
 	}
 
@@ -195,12 +195,12 @@ func TestMakeGenesisBlockOverride(t *testing.T) {
 		balance := common.Amount(100)
 		account := NewBlockAccount(kp.Address(), balance)
 		err := account.Save(st)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		commonKP, _ := keypair.Random()
 		commonAccount := NewBlockAccount(commonKP.Address(), 0)
 		err = commonAccount.Save(st)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = MakeGenesisBlock(st, *account, *commonAccount, networkID)
 		require.Equal(t, errors.ErrorBlockAlreadyExists, err)
@@ -223,7 +223,7 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 
 	{
 		bk, err := MakeGenesisBlock(st, *account, *commonAccount, networkID)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, uint64(1), bk.Height)
 	}
 
@@ -234,12 +234,12 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 		bo, _ := GetBlockOperation(st, bt.Operations[0])
 
 		opb, err := operation.UnmarshalBodyJSON(bo.Type, bo.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		opbp := opb.(operation.Payable)
 
 		genesisAccount, err := GetBlockAccount(st, opbp.TargetAddress())
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, account.Address, genesisAccount.Address)
 		require.Equal(t, account.Balance, genesisAccount.Balance)
@@ -263,7 +263,7 @@ func TestMakeGenesisBlockFindCommonAccount(t *testing.T) {
 
 	{
 		bk, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, uint64(1), bk.Height)
 	}
 
@@ -274,12 +274,12 @@ func TestMakeGenesisBlockFindCommonAccount(t *testing.T) {
 		bo, _ := GetBlockOperation(st, bt.Operations[1])
 
 		opb, err := operation.UnmarshalBodyJSON(bo.Type, bo.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		opbp := opb.(operation.Payable)
 
 		ac, err := GetBlockAccount(st, opbp.TargetAddress())
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, commonAccount.Address, ac.Address)
 		require.Equal(t, commonAccount.Balance, ac.Balance)

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -16,13 +16,13 @@ func TestNewBlockOperationFromOperation(t *testing.T) {
 
 	op := tx.B.Operations[0]
 	bo, err := NewBlockOperationFromOperation(op, tx, 0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, bo.Type, op.H.Type)
 	require.Equal(t, bo.TxHash, tx.H.Hash)
 	require.Equal(t, bo.Source, tx.B.Source)
 	encoded, err := op.B.Serialize()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, bo.Body, encoded)
 }
 
@@ -37,7 +37,7 @@ func TestBlockOperationSaveAndGet(t *testing.T) {
 
 	bo := bos[0]
 	fetched, err := GetBlockOperation(st, bo.Hash)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, bo.Type, fetched.Type)
 	require.Equal(t, bo.Hash, fetched.Hash)
@@ -53,7 +53,7 @@ func TestBlockOperationSaveExisting(t *testing.T) {
 	bo.MustSave(st)
 
 	exists, err := ExistsBlockOperation(st, bos[0].Hash)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, exists, true)
 
 	err = bo.Save(st)
@@ -104,7 +104,7 @@ func TestBlockOperationSaveByTransacton(t *testing.T) {
 	block := TestMakeNewBlock([]string{tx.GetHash()})
 	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, common.MustJSONMarshal(tx))
 	err := bt.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var saved []BlockOperation
 	iterFunc, closeFunc := GetBlockOperationsByTxHash(st, tx.GetHash(), nil)
@@ -124,7 +124,7 @@ func TestBlockOperationSaveByTransacton(t *testing.T) {
 		require.Equal(t, bo.TxHash, tx.H.Hash)
 		require.Equal(t, bo.Source, tx.B.Source)
 		encoded, err := op.B.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, bo.Body, encoded)
 	}
 }

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -41,10 +41,10 @@ func TestBlockTransactionSaveAndGet(t *testing.T) {
 
 	bt := TestMakeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	fetched, err := GetBlockTransaction(st, bt.Hash)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, bt.Hash, fetched.Hash)
 	require.Equal(t, bt.SequenceID, fetched.SequenceID)
@@ -61,14 +61,14 @@ func TestBlockTransactionSaveExisting(t *testing.T) {
 
 	bt := TestMakeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	exists, err := ExistsBlockTransaction(st, bt.Hash)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, exists, true)
 
 	err = bt.Save(st)
-	require.NotNil(t, err)
+	require.Error(t, err)
 	require.Equal(t, err, errors.ErrorAlreadySaved)
 }
 
@@ -95,7 +95,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	// create txs from another keypair
@@ -112,7 +112,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{
@@ -178,7 +178,7 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 		a, _ := tx.Serialize()
 		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 		err := bt.Save(st)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var saved []BlockTransaction
@@ -226,7 +226,7 @@ func TestBlockTransactionMultipleSave(t *testing.T) {
 
 	bt := TestMakeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	if err = bt.Save(st); err != nil {
 		if err != errors.ErrorAlreadySaved {

--- a/lib/common/router_test.go
+++ b/lib/common/router_test.go
@@ -26,14 +26,14 @@ func TestRouterHeaderMatcher(t *testing.T) {
 	{ // GET must pass
 		req, _ := http.NewRequest("GET", u.String(), nil)
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 
 	{ // POST && empty 'Content-Type'
 		req, _ := http.NewRequest("POST", u.String(), nil)
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	}
 
@@ -41,7 +41,7 @@ func TestRouterHeaderMatcher(t *testing.T) {
 		req, _ := http.NewRequest("POST", u.String(), nil)
 		req.Header.Set("Content-Type", "text/plain")
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	}
 
@@ -49,7 +49,7 @@ func TestRouterHeaderMatcher(t *testing.T) {
 		req, _ := http.NewRequest("POST", u.String(), nil)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 }
@@ -70,14 +70,14 @@ func TestRouterHeaderMatcherWithMethodMatcher(t *testing.T) {
 	{ // GET msut be passed
 		req, _ := http.NewRequest("GET", u.String(), nil)
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 
 	{ // POST && empty 'Content-Type'
 		req, _ := http.NewRequest("POST", u.String(), nil)
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	}
 
@@ -85,7 +85,7 @@ func TestRouterHeaderMatcherWithMethodMatcher(t *testing.T) {
 		req, _ := http.NewRequest("POST", u.String(), nil)
 		req.Header.Set("Content-Type", "text/plain")
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	}
 
@@ -93,7 +93,7 @@ func TestRouterHeaderMatcherWithMethodMatcher(t *testing.T) {
 		req, _ := http.NewRequest("POST", u.String(), nil)
 		req.Header.Set("Content-Type", "application/json")
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 }

--- a/lib/common/time_test.go
+++ b/lib/common/time_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseISO8601(t *testing.T) {
 	s := "2018-08-25T14:12:10.090758840+09:00"
 	parsed, err := ParseISO8601(s)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, 2018, parsed.Year())
 	require.Equal(t, time.Month(8), parsed.Month())
@@ -28,13 +28,13 @@ func TestParseISO8601Timezone(t *testing.T) {
 	now := time.Now()
 
 	location, err := time.LoadLocation("Europe/Amsterdam") // Wouter lives in Amsterdam.
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	nowCEST := now.In(location)
 	formattedCEST := FormatISO8601(nowCEST)
 
 	parsed, err := ParseISO8601(formattedCEST)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, time.Duration(0), now.Sub(parsed))
 }

--- a/lib/consensus/isaac_getsyncinfo_test.go
+++ b/lib/consensus/isaac_getsyncinfo_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestGetSyncInfoNormal(t *testing.T) {
 	vt, err := NewDefaultVotingThresholdPolicy(67)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	is := ISAAC{
 		policy:      vt,
@@ -37,7 +37,7 @@ func TestGetSyncInfoNormal(t *testing.T) {
 	is.nodesHeight[valids[3]] = 10
 
 	height, nodeAddrs, err := is.GetSyncInfo()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(10), height)
 	require.True(t, contains(nodeAddrs, valids[0]))
 	require.True(t, contains(nodeAddrs, valids[1]))
@@ -46,7 +46,7 @@ func TestGetSyncInfoNormal(t *testing.T) {
 }
 func TestGetSyncInfoBeforeFull(t *testing.T) {
 	vt, err := NewDefaultVotingThresholdPolicy(67)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	is := ISAAC{
 		policy:      vt,
@@ -73,7 +73,7 @@ func TestGetSyncInfoBeforeFull(t *testing.T) {
 	is.nodesHeight[valids[3]] = 10
 
 	height, nodeAddrs, err := is.GetSyncInfo()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(10), height)
 	require.True(t, contains(nodeAddrs, valids[0]))
 	require.True(t, contains(nodeAddrs, valids[1]))
@@ -83,7 +83,7 @@ func TestGetSyncInfoBeforeFull(t *testing.T) {
 
 func TestGetSyncInfoFoundSmallestHeight(t *testing.T) {
 	vt, err := NewDefaultVotingThresholdPolicy(67)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	is := ISAAC{
 		policy:      vt,
@@ -109,7 +109,7 @@ func TestGetSyncInfoFoundSmallestHeight(t *testing.T) {
 
 	is.log = logging.New("module", "consensus")
 	height, nodeAddrs, err := is.GetSyncInfo()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(33), height)
 
 	require.True(t, contains(nodeAddrs, nodes[1]))
@@ -120,7 +120,7 @@ func TestGetSyncInfoFoundSmallestHeight(t *testing.T) {
 
 func TestGetSyncInfoGenesis(t *testing.T) {
 	vt, err := NewDefaultVotingThresholdPolicy(67)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	is := ISAAC{
 		policy:      vt,
@@ -144,7 +144,7 @@ func TestGetSyncInfoGenesis(t *testing.T) {
 
 	is.log = logging.New("module", "consensus")
 	height, nodeAddrs, err := is.GetSyncInfo()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(1), height)
 	require.Equal(t, 3, len(nodeAddrs))
 }

--- a/lib/consensus/voting_policy_test.go
+++ b/lib/consensus/voting_policy_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestThreshold(t *testing.T) {
 	vt, err := NewDefaultVotingThresholdPolicy(66)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	vt.SetValidators(1000)
 	require.Equal(t, 660, vt.Threshold())

--- a/lib/error/base_test.go
+++ b/lib/error/base_test.go
@@ -29,17 +29,17 @@ func TestErrorsClone(t *testing.T) {
 func TestErrorsRLP(t *testing.T) {
 	{
 		_, err := rlp.EncodeToBytes(ErrorBlockAlreadyExists)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // with `SetData()`, the rlp encoded value must be different
 		encoded, err := rlp.EncodeToBytes(ErrorBlockAlreadyExists)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		e := ErrorBlockAlreadyExists.Clone()
 		e.SetData("findme", "killme")
 		encoded0, err := rlp.EncodeToBytes(e)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.NotEqual(t, encoded, encoded0)
 	}
 }

--- a/lib/network/http2_config_test.go
+++ b/lib/network/http2_config_test.go
@@ -24,7 +24,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		}
 
 		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // HTTPS + TLSCertFile
@@ -38,7 +38,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		}
 
 		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	}
 
 	{ // HTTPS + TLSKeyFile
@@ -52,7 +52,7 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		}
 
 		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
-		require.NotNil(t, err)
+		require.Error(t, err)
 	}
 
 	{ // HTTP
@@ -67,6 +67,6 @@ func TestHTTP2NetworkConfigHTTPSAndTLS(t *testing.T) {
 		}
 
 		_, err := NewHTTP2NetworkConfigFromEndpoint(nodeName, endpoint)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }

--- a/lib/network/http2_test.go
+++ b/lib/network/http2_test.go
@@ -92,7 +92,7 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 	}
 
 	network, err := makeTestHTTP2NetworkForTLS(endpoint)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer network.Stop()
 
 	{
@@ -103,10 +103,10 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 			false,
 		)
 
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = client.Get(endpoint.String(), http.Header{})
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{
@@ -117,7 +117,7 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 		client := &http.Client{Transport: transport}
 
 		_, err := client.Get(endpoint.String())
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }
 
@@ -128,10 +128,10 @@ func TestHTTP2NetworkWithoutTLS(t *testing.T) {
 	endpoint, err := common.NewEndpointFromString(
 		fmt.Sprintf("http://localhost:%s", getPort()),
 	)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	network, err := makeTestHTTP2NetworkForTLS(endpoint)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer network.Stop()
 
 	{
@@ -141,15 +141,15 @@ func TestHTTP2NetworkWithoutTLS(t *testing.T) {
 			defaultIdleTimeout,
 			false,
 		)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = client.Get(endpoint.String(), http.Header{})
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{
 		// with normal HTTPClient
 		_, err := http.Get(endpoint.String())
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }

--- a/lib/network/http_middlewares_test.go
+++ b/lib/network/http_middlewares_test.go
@@ -34,18 +34,18 @@ func TestRecoverMiddleware(t *testing.T) {
 	defer ts.Close()
 
 	resp, err := http.Get(ts.URL + handlerURL)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, 500, resp.StatusCode)
 	require.Equal(t, "application/problem+json", resp.Header["Content-Type"][0])
 
 	bs, err := ioutil.ReadAll(resp.Body)
 	defer resp.Body.Close()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var msg map[string]interface{}
 	err = json.Unmarshal(bs, &msg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, "panic: "+panicMsg, msg["title"])
 }
 
@@ -73,7 +73,7 @@ func TestRateLimitMiddleWare(t *testing.T) {
 		ts := httptest.NewServer(router)
 
 		resp, err := testRequestForRateLimit(ts, handlerURL, "3.3.3.3")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		ts.Close()
 
 		require.Equal(t, fmt.Sprintf("%d", rate.Limit), resp.Header.Get("X-Ratelimit-Limit"))
@@ -108,7 +108,7 @@ func TestRateLimitMiddleWare(t *testing.T) {
 		wg.Wait()
 
 		resp, err := testRequestForRateLimit(ts, handlerURL, "3.3.3.3")
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 
@@ -122,7 +122,7 @@ func TestRateLimitMiddleWare(t *testing.T) {
 		var problem httputils.Problem
 		{
 			err := json.Unmarshal(body, &problem)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		require.Equal(
 			t,
@@ -172,7 +172,7 @@ func TestRateLimitMiddleWareByIPAddress(t *testing.T) {
 		wg.Wait()
 
 		resp, err := testRequestForRateLimit(ts, handlerURL, "3.3.3.3")
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	}
@@ -193,7 +193,7 @@ func TestRateLimitMiddleWareByIPAddress(t *testing.T) {
 		req, _ := http.NewRequest("GET", ts.URL+handlerURL, nil)
 		req.Header.Set("X-Forwarded-For", allowedIP)
 		resp, err := ts.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -233,7 +233,7 @@ func TestRateLimitMiddleWareUnlimit(t *testing.T) {
 		wg.Wait()
 
 		resp, err := testRequestForRateLimit(ts, handlerURL, "3.3.3.3")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		ts.Close()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 

--- a/lib/network/httputils/http_problem_test.go
+++ b/lib/network/httputils/http_problem_test.go
@@ -44,11 +44,11 @@ func TestProblem(t *testing.T) {
 	{
 		url := ts.URL + fmt.Sprintf("/problem_status_default")
 		resp, err := http.Get(url)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 		reader := bufio.NewReader(resp.Body)
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		{
 			var f interface{}
 			json.Unmarshal(readByte, &f)
@@ -66,11 +66,11 @@ func TestProblem(t *testing.T) {
 	{
 		url := ts.URL + fmt.Sprintf("/problem_status_with_detail")
 		resp, err := http.Get(url)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 		reader := bufio.NewReader(resp.Body)
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		{
 			var f interface{}
 			json.Unmarshal(readByte, &f)
@@ -88,11 +88,11 @@ func TestProblem(t *testing.T) {
 	{
 		url := ts.URL + fmt.Sprintf("/problem_status_with_detail_instance")
 		resp, err := http.Get(url)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 		reader := bufio.NewReader(resp.Body)
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		{
 			var f interface{}
 			json.Unmarshal(readByte, &f)
@@ -110,11 +110,11 @@ func TestProblem(t *testing.T) {
 	{
 		url := ts.URL + fmt.Sprintf("/problem_with_error")
 		resp, err := http.Get(url)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 		reader := bufio.NewReader(resp.Body)
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		{
 			var f interface{}
 			json.Unmarshal(readByte, &f)

--- a/lib/node/runner/api/account_test.go
+++ b/lib/node/runner/api/account_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestGetAccountHandler(t *testing.T) {
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 	// Make Dummy BlockAccount
@@ -29,12 +29,12 @@ func TestGetAccountHandler(t *testing.T) {
 		// Do a Request
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", ba.Address, -1)
 		respBody, err := request(ts, url, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)
 
@@ -46,7 +46,7 @@ func TestGetAccountHandler(t *testing.T) {
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", unknownKey.Address(), -1)
 		req, _ := http.NewRequest("GET", ts.URL+url, nil)
 		resp, err := ts.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -58,12 +58,12 @@ func TestGetAccountHandlerStream(t *testing.T) {
 	wg.Add(1)
 
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 	ba := block.TestMakeBlockAccount()
 	ba.MustSave(storage)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	key := ba.Address
 
@@ -88,7 +88,7 @@ func TestGetAccountHandlerStream(t *testing.T) {
 	{
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", key, -1)
 		respBody, err := request(ts, url, true)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -96,7 +96,7 @@ func TestGetAccountHandlerStream(t *testing.T) {
 	// Check the output
 	{
 		line, err := reader.ReadBytes('\n')
-		require.Nil(t, err)
+		require.NoError(t, err)
 		recv := make(map[string]interface{})
 		json.Unmarshal(line, &recv)
 		require.Equal(t, key, recv["address"], "address is not same")
@@ -108,7 +108,7 @@ func TestGetAccountHandlerStream(t *testing.T) {
 func TestGetNonExistentAccountHandler(t *testing.T) {
 
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
@@ -119,12 +119,12 @@ func TestGetNonExistentAccountHandler(t *testing.T) {
 		kp, _ := keypair.Random()
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", kp.Address(), -1)
 		respBody, err := request(ts, url, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		reader := bufio.NewReader(respBody)
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		pByte, err := json.Marshal(p)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, pByte, readByte)
 	}
 }

--- a/lib/node/runner/api/node_info_test.go
+++ b/lib/node/runner/api/node_info_test.go
@@ -75,14 +75,14 @@ func TestAPIGetNodeInfoHandler(t *testing.T) {
 	defer ts.Close()
 
 	body, err := request(ts, GetNodeInfoPattern, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	data, err := ioutil.ReadAll(bufio.NewReader(body))
 	body.Close()
 
 	require.NotEmpty(t, data)
 
 	receivedNodeInfo, err := node.NewNodeInfoFromJSON(data)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.NotNil(t, receivedNodeInfo.Node.Endpoint)
 
@@ -103,7 +103,7 @@ func TestAPIGetNodeInfoHandler(t *testing.T) {
 	localNode.SetBooting()
 
 	body, err = request(ts, GetNodeInfoPattern, false)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	data, err = ioutil.ReadAll(bufio.NewReader(body))
 	body.Close()
 

--- a/lib/node/runner/api/operation_test.go
+++ b/lib/node/runner/api/operation_test.go
@@ -20,19 +20,19 @@ import (
 
 func TestGetOperationsByAccountHandler(t *testing.T) {
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	kp, boList, err := prepareOps(storage, 0, 10, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
 	{
 		// unknown address
 		req, _ := http.NewRequest("GET", ts.URL+url, nil)
 		resp, err := ts.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	}
@@ -45,11 +45,11 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 	{
 		// Do a Request
 		respBody, err := request(ts, url, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)
@@ -68,12 +68,12 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 
 func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	kp, boList, err := prepareOps(storage, 0, 10, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
 	ba.MustSave(storage)
 
@@ -82,12 +82,12 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	{
 		url := url + "?type=" + string(operation.TypeCreateAccount)
 		respBody, err := request(ts, url, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)
@@ -98,12 +98,12 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	{
 		url := url + "?type=" + string(operation.TypePayment)
 		respBody, err := request(ts, url, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)
@@ -126,13 +126,13 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 	wg.Add(1)
 
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	boMap := make(map[string]block.BlockOperation)
 	kp, boList, err := prepareOpsWithoutSave(0, 10, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	for _, bo := range boList {
 		boMap[bo.Hash] = bo
 	}
@@ -162,7 +162,7 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 	{
 		url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
 		respBody, err := request(ts, url, true)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -172,14 +172,14 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 		// Do stream Request to the Server
 		for n := 0; n < 10; n++ {
 			line, err := reader.ReadBytes('\n')
-			require.Nil(t, err)
+			require.NoError(t, err)
 			line = bytes.Trim(line, "\n\t ")
 			recv := make(map[string]interface{})
 			json.Unmarshal(line, &recv)
 			bo := boMap[recv["hash"].(string)]
 			r := resource.NewOperation(&bo)
 			txS, err := json.Marshal(r.Resource())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, txS, line)
 		}
 	}

--- a/lib/node/runner/api/resource/resource_test.go
+++ b/lib/node/runner/api/resource/resource_test.go
@@ -43,7 +43,7 @@ func TestResourceAccount(t *testing.T) {
 	{
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
 		a, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		bt := block.NewBlockTransactionFromTransaction("dummy", 0, common.NowISO8601(), tx, a)
 		bt.MustSave(storage)
 
@@ -71,7 +71,7 @@ func TestResourceAccount(t *testing.T) {
 	{
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
 		a, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
 		bt.MustSave(storage)
 		bo, err := block.GetBlockOperation(storage, bt.Operations[0])
@@ -96,7 +96,7 @@ func TestResourceAccount(t *testing.T) {
 	{
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 3)
 		a, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
 		bt.MustSave(storage)
 
@@ -104,7 +104,7 @@ func TestResourceAccount(t *testing.T) {
 		for _, boHash := range bt.Operations {
 			var bo block.BlockOperation
 			bo, err = block.GetBlockOperation(storage, boHash)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			ro := NewOperation(&bo)
 			rol = append(rol, ro)
@@ -130,7 +130,7 @@ func TestResourceAccount(t *testing.T) {
 				record := v.(map[string]interface{})
 				id := record["hash"].(string)
 				bo, err := block.GetBlockOperation(storage, id)
-				require.Nil(t, err)
+				require.NoError(t, err)
 				require.Equal(t, bo.Hash, record["hash"])
 				require.Equal(t, bo.Source, record["source"])
 				require.Equal(t, string(bo.Type), record["type"])

--- a/lib/node/runner/api/transaction_test.go
+++ b/lib/node/runner/api/transaction_test.go
@@ -20,18 +20,18 @@ import (
 func TestGetTransactionByHashHandler(t *testing.T) {
 
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	_, _, bt, err := prepareTxWithoutSave()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	bt.MustSave(storage)
 
 	{ // unknown transaction
 		req, _ := http.NewRequest("GET", ts.URL+GetTransactionsHandlerPattern+"/findme", nil)
 		resp, err := ts.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer resp.Body.Close()
 
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
@@ -41,14 +41,14 @@ func TestGetTransactionByHashHandler(t *testing.T) {
 	// Do a Request
 	{
 		respBody, err := request(ts, GetTransactionsHandlerPattern+"/"+bt.Hash, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
 	// Check the output
 	{
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)
 
@@ -61,12 +61,12 @@ func TestGetTransactionByHashHandlerStream(t *testing.T) {
 	wg.Add(1)
 
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	_, _, bt, err := prepareTxWithoutSave()
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Wait until request registered to observer
 	{
@@ -80,7 +80,7 @@ func TestGetTransactionByHashHandlerStream(t *testing.T) {
 				observer.BlockTransactionObserver.RUnlock()
 			}
 			err = bt.Save(storage)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			wg.Done()
 		}()
 	}
@@ -89,7 +89,7 @@ func TestGetTransactionByHashHandlerStream(t *testing.T) {
 	var reader *bufio.Reader
 	{
 		respBody, err := request(ts, GetTransactionsHandlerPattern+"/"+bt.Hash, true)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -97,7 +97,7 @@ func TestGetTransactionByHashHandlerStream(t *testing.T) {
 	// Check the output
 	{
 		line, err := reader.ReadBytes('\n')
-		require.Nil(t, err)
+		require.NoError(t, err)
 		recv := make(map[string]interface{})
 		json.Unmarshal(line, &recv)
 		require.Equal(t, bt.Hash, recv["hash"], "hash is not same")
@@ -107,18 +107,18 @@ func TestGetTransactionByHashHandlerStream(t *testing.T) {
 
 func TestGetTransactionsHandler(t *testing.T) {
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	_, btList, err := prepareTxs(storage, 0, 10, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var reader *bufio.Reader
 	{
 		// Do a Request
 		respBody, err := request(ts, GetTransactionsHandlerPattern, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -126,7 +126,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 	// Check the output
 	{
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)
@@ -148,14 +148,14 @@ func TestGetTransactionsHandlerStream(t *testing.T) {
 	wg.Add(1)
 
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	kp, err := keypair.Random()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	_, btList, err := prepareTxsWithoutSave(0, 10, kp)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	btMap := make(map[string]block.BlockTransaction)
 	for _, bt := range btList {
 		btMap[bt.Hash] = bt
@@ -183,7 +183,7 @@ func TestGetTransactionsHandlerStream(t *testing.T) {
 	var reader *bufio.Reader
 	{
 		respBody, err := request(ts, GetTransactionsHandlerPattern, true)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -192,14 +192,14 @@ func TestGetTransactionsHandlerStream(t *testing.T) {
 	{
 		for n := 0; n < 10; n++ {
 			line, err := reader.ReadBytes('\n')
-			require.Nil(t, err)
+			require.NoError(t, err)
 			line = bytes.Trim(line, "\n\t ")
 			recv := make(map[string]interface{})
 			json.Unmarshal(line, &recv)
 			bt := btMap[recv["hash"].(string)]
 			r := resource.NewTransaction(&bt)
 			txS, err := json.Marshal(r.Resource())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, txS, line)
 		}
 	}
@@ -208,19 +208,19 @@ func TestGetTransactionsHandlerStream(t *testing.T) {
 
 func TestGetTransactionsByAccountHandler(t *testing.T) {
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	kp, btList, err := prepareTxs(storage, 0, 10, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// Do a Request
 	var reader *bufio.Reader
 	{
 		url := strings.Replace(GetAccountTransactionsHandlerPattern, "{id}", kp.Address(), -1)
 		respBody, err := request(ts, url, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -228,7 +228,7 @@ func TestGetTransactionsByAccountHandler(t *testing.T) {
 	// Check the output
 	{
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)
@@ -250,13 +250,13 @@ func TestGetTransactionsByAccountHandlerStream(t *testing.T) {
 	wg.Add(1)
 
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	btMap := make(map[string]block.BlockTransaction)
 	kp, btList, err := prepareTxsWithoutSave(0, 10, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	for _, bt := range btList {
 		btMap[bt.Hash] = bt
 	}
@@ -284,7 +284,7 @@ func TestGetTransactionsByAccountHandlerStream(t *testing.T) {
 	{
 		url := strings.Replace(GetAccountTransactionsHandlerPattern, "{id}", kp.Address(), -1)
 		respBody, err := request(ts, url, true)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -293,14 +293,14 @@ func TestGetTransactionsByAccountHandlerStream(t *testing.T) {
 	{
 		for n := 0; n < 10; n++ {
 			line, err := reader.ReadBytes('\n')
-			require.Nil(t, err)
+			require.NoError(t, err)
 			line = bytes.Trim(line, "\n\t ")
 			recv := make(map[string]interface{})
 			json.Unmarshal(line, &recv)
 			bt := btMap[recv["hash"].(string)]
 			r := resource.NewTransaction(&bt)
 			txS, err := json.Marshal(r.Resource())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, txS, line)
 		}
 	}
@@ -309,21 +309,21 @@ func TestGetTransactionsByAccountHandlerStream(t *testing.T) {
 
 func TestGetTransactionsHandlerPage(t *testing.T) {
 	ts, storage, err := prepareAPIServer()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	defer storage.Close()
 	defer ts.Close()
 
 	_, btList, err := prepareTxs(storage, 0, 10, nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	requestFunction := func(url string) ([]interface{}, map[string]interface{}) {
 		respBody, err := request(ts, url, false)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 
 		readByte, err := ioutil.ReadAll(reader)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		recv := make(map[string]interface{})
 		json.Unmarshal(readByte, &recv)

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -117,13 +117,13 @@ func TestGetBlocksHandler(t *testing.T) {
 	u := p.URL(nil)
 
 	req, err := http.NewRequest("GET", u.String(), nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	resp, err := p.server.Client().Do(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, len(p.blocks), len(rbs[NodeItemBlockHeader]))
 
 	for i, b := range p.blocks {
@@ -145,7 +145,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 	{ // empty options
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		options.SetMode(GetBlocksOptionsModeBlock)
 		u := p.URL(options.URLValues())
 
@@ -154,7 +154,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
@@ -169,7 +169,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 	{ // options.Limit = 3
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		options.SetMode(GetBlocksOptionsModeBlock).SetLimit(3)
 		u := p.URL(options.URLValues())
 
@@ -178,7 +178,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, int(options.Limit()), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks[:options.Limit()] {
@@ -193,7 +193,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 	{ // options.Reverse = true
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		options.SetMode(GetBlocksOptionsModeBlock).SetReverse(true)
 		u := p.URL(options.URLValues())
 
@@ -202,7 +202,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
@@ -220,7 +220,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 		expectedBlocks := p.blocks[cursorIndex+1:]
 
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		options.SetMode(GetBlocksOptionsModeBlock).SetCursor([]byte(p.blocks[cursorIndex].Hash))
 		u := p.URL(options.URLValues())
 
@@ -229,7 +229,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, len(expectedBlocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range expectedBlocks {
@@ -250,7 +250,7 @@ func TestGetBlocksHandlerWithInvalidLimit(t *testing.T) {
 
 	{ // options.Limit is string
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		urlValues := options.URLValues()
 		urlValues.Set("limit", "killme")
 
@@ -263,7 +263,7 @@ func TestGetBlocksHandlerWithInvalidLimit(t *testing.T) {
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
@@ -271,7 +271,7 @@ func TestGetBlocksHandlerWithInvalidLimit(t *testing.T) {
 
 	{ // options.Limit is negative
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		urlValues := options.URLValues()
 		urlValues.Set("limit", "-100")
 
@@ -284,7 +284,7 @@ func TestGetBlocksHandlerWithInvalidLimit(t *testing.T) {
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
@@ -298,7 +298,7 @@ func TestGetBlocksHandlerWithInvalidReverse(t *testing.T) {
 
 	{ // options.Reverse unknown value
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		urlValues := options.URLValues()
 		urlValues.Set("reverse", "killme")
 
@@ -311,7 +311,7 @@ func TestGetBlocksHandlerWithInvalidReverse(t *testing.T) {
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
@@ -319,7 +319,7 @@ func TestGetBlocksHandlerWithInvalidReverse(t *testing.T) {
 
 	{ // options.Reverse capitalized
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		urlValues := options.URLValues()
 		urlValues.Set("reverse", "TRUE")
 
@@ -340,7 +340,7 @@ func TestGetBlocksHandlerWithUnknownCursor(t *testing.T) {
 
 	{ // options.Cursor unknown cursor
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		options.SetCursor([]byte("killme"))
 		u := p.URL(options.URLValues())
 
@@ -351,7 +351,7 @@ func TestGetBlocksHandlerWithUnknownCursor(t *testing.T) {
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
@@ -367,7 +367,7 @@ func TestGetBlocksHandlerWithHeightRange(t *testing.T) {
 		expectedLength := 2
 
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		options.SetMode(GetBlocksOptionsModeBlock).SetHeightRange([2]uint64{p.blocks[1].Height, p.blocks[1+expectedLength].Height})
 		u := p.URL(options.URLValues())
 
@@ -376,7 +376,7 @@ func TestGetBlocksHandlerWithHeightRange(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, expectedLength, len(rbs[NodeItemBlock]))
 
 		for i := 1; i < 1+expectedLength; i++ {
@@ -399,7 +399,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 	{ // if value is missing, it will be ok
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		u := p.URL(options.URLValues())
 		u.RawQuery = "height-range="
 
@@ -409,7 +409,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlockHeader]))
 
 		for i, b := range p.blocks {
@@ -424,7 +424,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 	{ // wrong format
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		u := p.URL(options.URLValues())
 		u.RawQuery = fmt.Sprintf("height-range=%d-", 1)
 
@@ -435,7 +435,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
@@ -443,7 +443,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 	{ // not uint64 value
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		u := p.URL(options.URLValues())
 		u.RawQuery = fmt.Sprintf("height-range=%d-%s", 1, "findme")
 
@@ -454,7 +454,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
@@ -462,7 +462,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 	{ // bigger start value than end
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		u := p.URL(options.URLValues())
 		u.RawQuery = fmt.Sprintf("height-range=%d-%d", 1, 0)
 
@@ -473,7 +473,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
@@ -482,7 +482,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 	{ // height is bigger than limit, set to limit
 		var expectedLength uint64 = 2
 		options, err := NewGetBlocksOptionsFromRequest(nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		options.SetHeightRange([2]uint64{1, p.blocks[len(p.blocks)-1].Height}).SetLimit(expectedLength)
 		require.True(t, options.Height() > expectedLength)
 
@@ -494,7 +494,7 @@ func TestGetBlocksHandlerWithInvalidHeightRange(t *testing.T) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, int(expectedLength), len(rbs[NodeItemBlockHeader]))
 	}
 }
@@ -511,13 +511,13 @@ func TestGetBlocksHandlerWithModeBlock(t *testing.T) {
 		u.RawQuery = fmt.Sprintf("mode=%s", GetBlocksOptionsModeBlock)
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
@@ -543,13 +543,13 @@ func TestGetBlocksHandlerWithModeHeader(t *testing.T) {
 		u.RawQuery = fmt.Sprintf("mode=%s", GetBlocksOptionsModeHeader)
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlockHeader]))
 
 		for i, b := range p.blocks {
@@ -573,13 +573,13 @@ func TestGetBlocksHandlerWithModeFull(t *testing.T) {
 		u.RawQuery = fmt.Sprintf("mode=%s", GetBlocksOptionsModeFull)
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, len(p.blocks), len(rbs[NodeItemBlock]))
 
 		for i, b := range p.blocks {
@@ -644,16 +644,16 @@ func TestGetBlocksHandlerWithInvalidMode(t *testing.T) {
 		u.RawQuery = "mode=1"
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		body, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)

--- a/lib/node/runner/api_message_handler_test.go
+++ b/lib/node/runner/api_message_handler_test.go
@@ -83,9 +83,9 @@ func TestNodeMessageHandler(t *testing.T) {
 	postData, _ := tx.Serialize()
 	req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
 	req.Header.Set("Content-Type", "application/json")
-	require.Nil(t, err)
+	require.NoError(t, err)
 	resp, err := p.server.Client().Do(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.True(t, p.TransactionPool.Has(tx.GetHash()))
 }
@@ -106,9 +106,9 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 		postData, _ := tx.Serialize()
 		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
 		req.Header.Set("Content-Type", "application/json")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
@@ -117,7 +117,7 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 		var responseError errors.Error
 		{
 			err := json.Unmarshal(body, &responseError)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		require.Equal(t, responseError.Data["error"], errIsWellformed.(*errors.Error).Data["error"])
 		require.Equal(
@@ -141,9 +141,9 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 		postData, _ := tx.Serialize()
 		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
 		req.Header.Set("Content-Type", "application/json")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
@@ -152,7 +152,7 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 		var responseError errors.Error
 		{
 			err := json.Unmarshal(body, &responseError)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		require.Equal(t, responseError.Data["error"], errIsWellformed.(*errors.Error).Data["error"])
 		require.Equal(
@@ -170,18 +170,18 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 		{
 			req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
 			req.Header.Set("Content-Type", "application/json")
-			require.Nil(t, err)
+			require.NoError(t, err)
 			resp, err := p.server.Client().Do(req)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 		}
 
 		// send again
 		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
 		req.Header.Set("Content-Type", "application/json")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
@@ -190,7 +190,7 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 		var responseError errors.Error
 		{
 			err := json.Unmarshal(body, &responseError)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		require.Equal(t, responseError.Data["error"], errors.ErrorNewButKnownMessage.Data["error"])
 		require.Equal(

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -249,9 +249,9 @@ func TestGetNodeInfoHandler(t *testing.T) {
 		u.Path = NodeInfoHandlerPattern
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
@@ -259,7 +259,7 @@ func TestGetNodeInfoHandler(t *testing.T) {
 
 		var received map[string]interface{}
 		err = json.Unmarshal(body, &received)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, server.URL, received["endpoint"])
 	}
@@ -272,9 +272,9 @@ func TestGetNodeInfoHandler(t *testing.T) {
 		u.Path = NodeInfoHandlerPattern
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
@@ -282,7 +282,7 @@ func TestGetNodeInfoHandler(t *testing.T) {
 
 		var received map[string]interface{}
 		err = json.Unmarshal(body, &received)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, publishEndpoint.String(), received["endpoint"])
 	}

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -138,16 +138,16 @@ func TestGetNodeTransactionsHandlerWithoutHashes(t *testing.T) {
 	u := p.URL(nil)
 
 	req, err := http.NewRequest("GET", u.String(), nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	resp, err := p.server.Client().Do(req)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 	body, _ := ioutil.ReadAll(resp.Body)
 	resp.Body.Close()
 	responseError := errors.Error{}
 	err = json.Unmarshal(body, &responseError)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
 }
@@ -163,13 +163,13 @@ func TestGetNodeTransactionsHandlerWithUnknownHashes(t *testing.T) {
 		u.RawQuery = fmt.Sprintf("hash=%s", unknownHashKey)
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(rbs[NodeItemError]))
 		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(*errors.Error).Code)
 		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(*errors.Error).Data["hash"])
@@ -182,13 +182,13 @@ func TestGetNodeTransactionsHandlerWithUnknownHashes(t *testing.T) {
 		u.RawQuery = query.Encode()
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, 1, len(rbs[NodeItemError]))
 		require.Equal(t, errors.ErrorTransactionNotFound.Code, rbs[NodeItemError][0].(*errors.Error).Code)
 		require.Equal(t, unknownHashKey, rbs[NodeItemError][0].(*errors.Error).Data["hash"])
@@ -212,16 +212,16 @@ func TestGetNodeTransactionsHandlerPOST(t *testing.T) {
 		u.RawQuery = query.Encode()
 
 		req, err := http.NewRequest("POST", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, errors.ErrorContentTypeNotJSON.Code, responseError.Code)
 	}
@@ -233,13 +233,13 @@ func TestGetNodeTransactionsHandlerPOST(t *testing.T) {
 
 		req, err := http.NewRequest("POST", u.String(), nil)
 		req.Header.Set("Content-Type", "application/json")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, 1, len(rbs))
 		require.Equal(t, 1, len(rbs[NodeItemTransaction]))
@@ -263,13 +263,13 @@ func TestGetNodeTransactionsHandlerWithMultipleHashes(t *testing.T) {
 		u.RawQuery = query.Encode()
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, 1, len(rbs))
 		require.Equal(t, len(txHashes), len(rbs[NodeItemTransaction]))
@@ -289,13 +289,13 @@ func TestGetNodeTransactionsHandlerWithMultipleHashes(t *testing.T) {
 
 		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(common.MustJSONMarshal(postData)))
 		req.Header.Set("Content-Type", "application/json")
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, 1, len(rbs))
 		require.Equal(t, 2, len(rbs[NodeItemTransaction]))
@@ -325,13 +325,13 @@ func TestGetNodeTransactionsHandlerInTransactionPool(t *testing.T) {
 		u.RawQuery = query.Encode()
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 
 		rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, 1, len(rbs))
 		require.Equal(t, 1, len(rbs[NodeItemTransaction]))
@@ -361,16 +361,16 @@ func TestGetNodeTransactionsHandlerTooManyHashes(t *testing.T) {
 		u.RawQuery = query.Encode()
 
 		req, err := http.NewRequest("GET", u.String(), nil)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
 		body, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
 		responseError := errors.Error{}
 		err = json.Unmarshal(body, &responseError)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		require.Equal(t, errors.ErrorInvalidQueryString.Code, responseError.Code)
 	}

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -101,7 +101,7 @@ func TestProposedTransactionWithDuplicatedOperations(t *testing.T) {
 	blt := p.MakeBallot(0)
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{
@@ -124,7 +124,7 @@ func TestProposedTransactionWithoutTransactions(t *testing.T) {
 	blt := p.MakeBallot(0)
 
 	err := blt.IsWellFormed(networkID, common.NewConfig())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var ballotMessage common.NetworkMessage
 	{
@@ -145,7 +145,7 @@ func TestProposedTransactionWithoutTransactions(t *testing.T) {
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err = common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},
@@ -158,7 +158,7 @@ func TestProposedTransactionWithoutTransactions(t *testing.T) {
 		Log:            p.nr.Log(),
 	}
 	err = common.RunChecker(checker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ballot.VotingYES, checker.VotingHole)
 }
 
@@ -171,11 +171,11 @@ func TestProposedTransactionWithTransactions(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	{
 		err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var ballotMessage common.NetworkMessage
@@ -197,7 +197,7 @@ func TestProposedTransactionWithTransactions(t *testing.T) {
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},
@@ -210,7 +210,7 @@ func TestProposedTransactionWithTransactions(t *testing.T) {
 		Log:            p.nr.Log(),
 	}
 	err = common.RunChecker(checker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ballot.VotingYES, checker.VotingHole)
 }
 
@@ -226,7 +226,7 @@ func TestProposedTransactionDifferentSigning(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // sign different source with `Ballot.Proposer()`
@@ -261,7 +261,7 @@ func TestProposedTransactionWithTransactionsButWrongTxs(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	{
 		err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
@@ -286,7 +286,7 @@ func TestProposedTransactionWithWrongOperationBodyCollectTxFeeBlockData(t *testi
 
 		{
 			err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		{
 			err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
@@ -306,7 +306,7 @@ func TestProposedTransactionWithWrongOperationBodyCollectTxFeeBlockData(t *testi
 
 		{
 			err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		{
 			err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
@@ -326,7 +326,7 @@ func TestProposedTransactionWithWrongOperationBodyCollectTxFeeBlockData(t *testi
 
 		{
 			err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		{
 			err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
@@ -369,7 +369,7 @@ func TestProposedTransactionWithWrongOperationBodyInflationFeeBlockData(t *testi
 
 		{
 			err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		{
 			err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
@@ -389,7 +389,7 @@ func TestProposedTransactionWithWrongOperationBodyInflationFeeBlockData(t *testi
 
 		{
 			err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		{
 			err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
@@ -409,7 +409,7 @@ func TestProposedTransactionWithWrongOperationBodyInflationFeeBlockData(t *testi
 
 		{
 			err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-			require.Nil(t, err)
+			require.NoError(t, err)
 		}
 		{
 			err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
@@ -454,12 +454,12 @@ func TestProposedTransactionWithInflationWrongAmount(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{
 		err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var ballotMessage common.NetworkMessage
@@ -481,7 +481,7 @@ func TestProposedTransactionWithInflationWrongAmount(t *testing.T) {
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},
@@ -532,11 +532,11 @@ func TestProposedTransactionWithCollectTxFeeWrongCommonAddress(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	{
 		err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var ballotMessage common.NetworkMessage
@@ -558,7 +558,7 @@ func TestProposedTransactionWithCollectTxFeeWrongCommonAddress(t *testing.T) {
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},
@@ -591,11 +591,11 @@ func TestProposedTransactionWithInflationWrongCommonAddress(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	{
 		err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var ballotMessage common.NetworkMessage
@@ -617,7 +617,7 @@ func TestProposedTransactionWithInflationWrongCommonAddress(t *testing.T) {
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},
@@ -654,11 +654,11 @@ func TestProposedTransactionWithBiggerTransactionFeeThanCollected(t *testing.T) 
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 	{
 		err := blt.ProposerTransaction().IsWellFormedWithBallot(networkID, *blt, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	var ballotMessage common.NetworkMessage
@@ -680,7 +680,7 @@ func TestProposedTransactionWithBiggerTransactionFeeThanCollected(t *testing.T) 
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checker := &BallotChecker{
 		DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},
@@ -693,7 +693,7 @@ func TestProposedTransactionWithBiggerTransactionFeeThanCollected(t *testing.T) 
 		Log:            p.nr.Log(),
 	}
 	err = common.RunChecker(checker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, ballot.VotingNO, checker.VotingHole)
 }
 
@@ -715,18 +715,18 @@ func TestProposedTransactionStoreWithZeroAmount(t *testing.T) {
 			p.nr.Log(),
 			p.nr.Log(),
 		)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	afterCommonAccount, _ := block.GetBlockAccount(p.nr.Storage(), p.commonAccount.Address)
 
 	inflationAmount, err := common.CalculateInflation(p.initialBalance)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, previousCommonAccount.Balance+inflationAmount, afterCommonAccount.Balance)
 
 	bt, err := block.GetBlockTransaction(p.nr.Storage(), blt.ProposerTransaction().GetHash())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, blt.ProposerTransaction().GetHash(), bt.Hash)
 	require.Equal(t, blt.ProposerTransaction().Source(), bt.Source)
@@ -752,7 +752,7 @@ func TestProposedTransactionStoreWithZeroAmount(t *testing.T) {
 		require.Equal(t, string(operation.TypeCollectTxFee), string(bos[0].Type))
 
 		opbFromBlockInterface, err := operation.UnmarshalBodyJSON(bos[0].Type, bos[0].Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		opbFromBlock := opbFromBlockInterface.(operation.CollectTxFee)
 
 		opb, _ := blt.ProposerTransaction().CollectTxFee()
@@ -768,7 +768,7 @@ func TestProposedTransactionStoreWithZeroAmount(t *testing.T) {
 		require.Equal(t, string(operation.TypeInflation), string(bos[1].Type))
 
 		opbFromBlockInterface, err := operation.UnmarshalBodyJSON(bos[1].Type, bos[1].Body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		opbFromBlock := opbFromBlockInterface.(operation.Inflation)
 
 		opb, _ := blt.ProposerTransaction().Inflation()
@@ -797,13 +797,13 @@ func TestProposedTransactionStoreWithAmount(t *testing.T) {
 			p.nr.Log(),
 			p.nr.Log(),
 		)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	afterCommonAccount, _ := block.GetBlockAccount(p.nr.Storage(), p.commonAccount.Address)
 
 	inflationAmount, err := common.CalculateInflation(p.initialBalance)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, previousCommonAccount.Balance+opb.Amount+inflationAmount, afterCommonAccount.Balance)
 }
 
@@ -815,7 +815,7 @@ func TestProposedTransactionWithNormalOperations(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // with create-account operation
@@ -843,7 +843,7 @@ func TestProposedTransactionWithWrongNumberOfOperations(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // more than 2
@@ -928,7 +928,7 @@ func TestCheckInflationBlockIncrease(t *testing.T) {
 	)
 
 	inflationAmount, err := common.CalculateInflation(nr.InitialBalance)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var previous common.Amount
 	for blockHeight := uint64(1); blockHeight < 5; blockHeight++ {
@@ -970,7 +970,7 @@ func TestProposedTransactionReachedBlockHeightEndOfInflation(t *testing.T) {
 			VotingHole:     ballot.VotingNOTYET,
 		}
 		err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		checker := &BallotChecker{
 			DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},
@@ -983,7 +983,7 @@ func TestProposedTransactionReachedBlockHeightEndOfInflation(t *testing.T) {
 			Log:            p.nr.Log(),
 		}
 		err = common.RunChecker(checker, common.DefaultDeferFunc)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // Height = common.BlockHeightEndOfInflation + 1
@@ -1014,7 +1014,7 @@ func TestProposedTransactionReachedBlockHeightEndOfInflation(t *testing.T) {
 			VotingHole:     ballot.VotingNOTYET,
 		}
 		err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		checker := &BallotChecker{
 			DefaultChecker: common.DefaultChecker{Funcs: DefaultHandleINITBallotCheckerFuncs},

--- a/lib/node/runner/checker_message_test.go
+++ b/lib/node/runner/checker_message_test.go
@@ -35,20 +35,20 @@ func TestMessageChecker(t *testing.T) {
 	}
 
 	err = TransactionUnmarshal(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, checker.Transaction, validTx)
 
 	err = HasTransaction(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = SaveTransactionHistory(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	var found bool
 	found, err = block.ExistsBlockTransactionHistory(checker.Storage, checker.Transaction.GetHash())
 	require.True(t, found)
 
 	err = PushIntoTransactionPool(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.True(t, checker.TransactionPool.Has(validTx.GetHash()))
 
 	// TransactionBroadcast(checker) is not suitable in unittest
@@ -60,7 +60,7 @@ func TestMessageChecker(t *testing.T) {
 	require.Equal(t, err, errors.ErrorNewButKnownMessage)
 
 	err = PushIntoTransactionPool(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var CheckerFuncs = []common.CheckerFunc{
 		TransactionUnmarshal,
@@ -100,7 +100,7 @@ func TestMessageCheckerWithInvalidHash(t *testing.T) {
 	}
 
 	err = TransactionUnmarshal(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	checker.Message.Data = []byte{}
 	err = TransactionUnmarshal(checker)

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -257,7 +257,7 @@ func TestGetMissingTransactionAllMissing(t *testing.T) {
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var checkerFuncs = []common.CheckerFunc{
 		BallotAlreadyVoted,
@@ -278,7 +278,7 @@ func TestGetMissingTransactionAllMissing(t *testing.T) {
 	}
 
 	err = common.RunChecker(checker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// check consensus node runner has all missing transactions.
 	for _, hash := range blt.Transactions() {
@@ -321,7 +321,7 @@ func TestGetMissingTransactionProposerAlsoMissing(t *testing.T) {
 		VotingHole:     ballot.VotingNOTYET,
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	var checkerFuncs = []common.CheckerFunc{
 		BallotAlreadyVoted,
@@ -462,14 +462,14 @@ func TestRegularIncomingBallots(t *testing.T) {
 	// send `INIT` ballot
 	blt := p.makeBallot(ballot.StateINIT)
 	_, err := p.runChecker(*blt)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(cm.Messages())) // this check node broadcast the new SIGN ballot
 
 	received := cm.Messages()[0].(ballot.Ballot)
 	require.Equal(t, blt.H.ProposerSignature, received.H.ProposerSignature)
 
 	_, err = p.runChecker(received)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(cm.Messages())) // this check node does not broadcast
 }
 
@@ -492,11 +492,11 @@ func TestIrregularIncomingBallots(t *testing.T) {
 	signBallot.Sign(p.nodes[1].Keypair(), networkID)
 
 	_, err := p.runChecker(*signBallot)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 0, len(cm.Messages()))
 
 	_, err = p.runChecker(*initBallot)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, len(cm.Messages()))
 
 	// check the broadcasted ballot is valid `SIGN` ballot

--- a/lib/node/runner/isaac_simulation_test.go
+++ b/lib/node/runner/isaac_simulation_test.go
@@ -36,7 +36,7 @@ func TestISAACSimulationProposer(t *testing.T) {
 	// Generate proposed ballot in nr
 	roundNumber := uint64(0)
 	_, err = nr.proposeNewBallot(roundNumber)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	b := nr.Consensus().LatestBlock()
 	round := round.Round{
@@ -51,34 +51,34 @@ func TestISAACSimulationProposer(t *testing.T) {
 
 	ballotSIGN1 := GenerateBallot(proposer, round, tx, ballot.StateSIGN, nodes[1], conf)
 	err = ReceiveBallot(nr, ballotSIGN1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotSIGN2 := GenerateBallot(proposer, round, tx, ballot.StateSIGN, nodes[2], conf)
 	err = ReceiveBallot(nr, ballotSIGN2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotSIGN3 := GenerateBallot(proposer, round, tx, ballot.StateSIGN, nodes[3], conf)
 	err = ReceiveBallot(nr, ballotSIGN3)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotSIGN4 := GenerateBallot(proposer, round, tx, ballot.StateSIGN, nodes[4], conf)
 	err = ReceiveBallot(nr, ballotSIGN4)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	rr := nr.Consensus().RunningRounds[round.Index()]
 	require.Equal(t, 4, len(rr.Voted[proposer.Address()].GetResult(ballot.StateSIGN)))
 
 	ballotACCEPT0 := GenerateBallot(proposer, round, tx, ballot.StateACCEPT, nodes[0], conf)
 	err = ReceiveBallot(nr, ballotACCEPT0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotACCEPT1 := GenerateBallot(proposer, round, tx, ballot.StateACCEPT, nodes[1], conf)
 	err = ReceiveBallot(nr, ballotACCEPT1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotACCEPT2 := GenerateBallot(proposer, round, tx, ballot.StateACCEPT, nodes[2], conf)
 	err = ReceiveBallot(nr, ballotACCEPT2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotACCEPT3 := GenerateBallot(proposer, round, tx, ballot.StateACCEPT, nodes[3], conf)
 	err = ReceiveBallot(nr, ballotACCEPT3)

--- a/lib/node/runner/isaac_simulation_unfreezing_test.go
+++ b/lib/node/runner/isaac_simulation_unfreezing_test.go
@@ -76,7 +76,7 @@ func TestUnfreezingSimulation(t *testing.T) {
 	nr.TransactionPool.Add(tx6)
 	roundNumber := uint64(0)
 	_, err := nr.proposeNewBallot(roundNumber)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.False(t, nr.TransactionPool.Has(tx6.GetHash()))
 
@@ -116,7 +116,7 @@ func MakeConsensusAndBlock(t *testing.T, tx transaction.Transaction, nr *NodeRun
 	// Generate proposed ballot in nodeRunner
 	roundNumber := uint64(0)
 	_, err = nr.proposeNewBallot(roundNumber)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	b := nr.Consensus().LatestBlock()
 	round := round.Round{
@@ -132,18 +132,18 @@ func MakeConsensusAndBlock(t *testing.T, tx transaction.Transaction, nr *NodeRun
 
 	ballotSIGN1 := GenerateBallot(proposer, round, tx, ballot.StateSIGN, nodes[1], conf)
 	err = ReceiveBallot(nr, ballotSIGN1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotSIGN2 := GenerateBallot(proposer, round, tx, ballot.StateSIGN, nodes[2], conf)
 	err = ReceiveBallot(nr, ballotSIGN2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	rr := nr.Consensus().RunningRounds[round.Index()]
 	require.Equal(t, 2, len(rr.Voted[proposer.Address()].GetResult(ballot.StateSIGN)))
 
 	ballotACCEPT1 := GenerateBallot(proposer, round, tx, ballot.StateACCEPT, nodes[1], conf)
 	err = ReceiveBallot(nr, ballotACCEPT1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotACCEPT2 := GenerateBallot(proposer, round, tx, ballot.StateACCEPT, nodes[2], conf)
 	err = ReceiveBallot(nr, ballotACCEPT2)

--- a/lib/node/runner/isaac_voting_empty_transaction_test.go
+++ b/lib/node/runner/isaac_voting_empty_transaction_test.go
@@ -41,7 +41,7 @@ func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
 
 	// Generate proposed ballot in nr
 	_, err := nr.proposeNewBallot(0)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	round := round.Round{
 		Number:      0,
@@ -55,15 +55,15 @@ func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
 
 	ballotSIGN1 := GenerateEmptyTxBallot(proposer, round, ballot.StateSIGN, nodes[1], conf)
 	err = ReceiveBallot(nr, ballotSIGN1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotSIGN2 := GenerateEmptyTxBallot(proposer, round, ballot.StateSIGN, nodes[2], conf)
 	err = ReceiveBallot(nr, ballotSIGN2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotSIGN3 := GenerateEmptyTxBallot(proposer, round, ballot.StateSIGN, nodes[3], conf)
 	err = ReceiveBallot(nr, ballotSIGN3)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	runningRounds := nr.Consensus().RunningRounds
 
@@ -76,15 +76,15 @@ func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
 
 	ballotACCEPT1 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[1], conf)
 	err = ReceiveBallot(nr, ballotACCEPT1)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotACCEPT2 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[2], conf)
 	err = ReceiveBallot(nr, ballotACCEPT2)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotACCEPT3 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[3], conf)
 	err = ReceiveBallot(nr, ballotACCEPT3)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	ballotACCEPT4 := GenerateEmptyTxBallot(proposer, round, ballot.StateACCEPT, nodes[4], conf)
 	err = ReceiveBallot(nr, ballotACCEPT4)

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -286,10 +286,10 @@ func TestExpiredBallotCheckProposer(t *testing.T) {
 	}
 
 	err := BallotVote(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = BallotIsSameProposer(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	// The createNodeRunnerForTesting has FixedSelector{localNode.Address()} so the proposer is always nr(nodes[0]).
 	// The invalidBallot has nodes[1] as a proposer so it is invalid.
@@ -309,7 +309,7 @@ func TestExpiredBallotCheckProposer(t *testing.T) {
 	require.Nil(t, BallotVote(checker))
 
 	err = BallotIsSameProposer(checker)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, ballot.VotingNO, checker.VotingHole)
 }

--- a/lib/node/runner/util_test.go
+++ b/lib/node/runner/util_test.go
@@ -22,13 +22,13 @@ func TestGetGenesisAccount(t *testing.T) {
 	block.MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
 
 	fetchedGenesisAccount, err := GetGenesisAccount(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, genesisAccount.Address, fetchedGenesisAccount.Address)
 	require.Equal(t, genesisAccount.Balance, fetchedGenesisAccount.Balance)
 	require.Equal(t, genesisAccount.SequenceID, fetchedGenesisAccount.SequenceID)
 
 	fetchedCommonAccount, err := GetCommonAccount(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, commonAccount.Address, fetchedCommonAccount.Address)
 	require.Equal(t, commonAccount.Balance, fetchedCommonAccount.Balance)
 	require.Equal(t, commonAccount.SequenceID, fetchedCommonAccount.SequenceID)
@@ -47,6 +47,6 @@ func TestGetInitialBalance(t *testing.T) {
 	block.MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
 
 	fetchedInitialBalance, err := GetGenesisBalance(st)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, initialBalance, fetchedInitialBalance)
 }

--- a/lib/sync/fetcher_test.go
+++ b/lib/sync/fetcher_test.go
@@ -41,9 +41,9 @@ func TestBlockFetcher(t *testing.T) {
 		allConnected: []string{kp.Address()},
 		getNodeFunc: func(addr string) node.Node {
 			ep, err := common.NewEndpointFromString("https://node1?NodeName=n1")
-			require.Nil(t, err)
+			require.NoError(t, err)
 			v, err := node.NewValidator(kp.Address(), ep, "n1")
-			require.Nil(t, err)
+			require.NoError(t, err)
 			return v
 		},
 	}

--- a/lib/sync/validator_test.go
+++ b/lib/sync/validator_test.go
@@ -31,6 +31,6 @@ func TestValidator(t *testing.T) {
 
 	{
 		err := v.Validate(ctx, si)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }

--- a/lib/transaction/operation/create_account_test.go
+++ b/lib/transaction/operation/create_account_test.go
@@ -18,7 +18,7 @@ func TestCreateAccountOperation(t *testing.T) {
 			Amount: common.Amount(common.BaseReserve),
 		}
 		err := o.IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 
 	{ // insufficient Amount
@@ -36,6 +36,6 @@ func TestCreateAccountOperation(t *testing.T) {
 			Amount: common.Amount(common.BaseReserve + 1),
 		}
 		err := o.IsWellFormed(networkID, conf)
-		require.Nil(t, err)
+		require.NoError(t, err)
 	}
 }

--- a/lib/transaction/operation/operation_test.go
+++ b/lib/transaction/operation/operation_test.go
@@ -30,24 +30,24 @@ func TestMakeHashOfOperationBodyPayment(t *testing.T) {
 func TestIsWellFormedOperation(t *testing.T) {
 	op := TestMakeOperation(-1)
 	err := op.IsWellFormed(networkID, common.NewConfig())
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestIsWellFormedOperationLowerAmount(t *testing.T) {
 	obp := TestMakeOperationBodyPayment(0)
 	err := obp.IsWellFormed(networkID, common.NewConfig())
-	require.NotNil(t, err)
+	require.Error(t, err)
 }
 
 func TestSerializeOperation(t *testing.T) {
 	op := TestMakeOperation(-1)
 	b, err := op.Serialize()
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, len(b) > 0, true)
 
 	var o Operation
 	err = json.Unmarshal(b, &o)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }
 
 func TestOperationBodyCongressVoting(t *testing.T) {
@@ -62,7 +62,7 @@ func TestOperationBodyCongressVoting(t *testing.T) {
 	require.Equal(t, hashed, expected)
 
 	err := op.IsWellFormed(networkID, common.NewConfig())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 }
 
@@ -84,6 +84,6 @@ func TestOperationBodyCongressVotingResult(t *testing.T) {
 	require.Equal(t, hashed, expected)
 
 	err := op.IsWellFormed(networkID, common.NewConfig())
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 }

--- a/tests/client/account_test.go
+++ b/tests/client/account_test.go
@@ -41,26 +41,26 @@ func TestAccount(t *testing.T) {
 		)
 
 		genesisAccount, err := c.LoadAccount(genesisAddr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		genesisBalance, err := strconv.ParseUint(genesisAccount.Balance, 10, 64)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		ob := operation.NewCreateAccount(account1Addr, common.Amount(genesisToAccount1), "")
 		o, err := operation.NewOperation(ob)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		tx, err := transaction.NewTransaction(genesisAddr, uint64(genesisAccount.SequenceID), o)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		sender, err := keypair.Parse(genesisSecret)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		tx.Sign(sender, []byte(NETWORK_ID))
 
 		body, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = c.SubmitTransaction(body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		var e error
 		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
@@ -83,14 +83,14 @@ func TestAccount(t *testing.T) {
 		require.Nil(t, e)
 
 		targetBalance, err := strconv.ParseUint(targetAccount.Balance, 10, 64)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, uint64(genesisToAccount1), targetBalance)
 
 		genesisAccount, err = c.LoadAccount(genesisAddr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		genesisBalance2, err := strconv.ParseUint(genesisAccount.Balance, 10, 64)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, genesisBalance-genesisToAccount1-fee, genesisBalance2)
 	}
 
@@ -101,25 +101,25 @@ func TestAccount(t *testing.T) {
 		)
 
 		senderAccount, err := c.LoadAccount(account1Addr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		senderBalance, err := strconv.ParseUint(senderAccount.Balance, 10, 64)
 
 		ob := operation.NewCreateAccount(account2Addr, common.Amount(account1ToAccount2), "")
 		o, err := operation.NewOperation(ob)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		tx, err := transaction.NewTransaction(account1Addr, uint64(senderAccount.SequenceID), o)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		sender, err := keypair.Parse(account1Secret)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		tx.Sign(sender, []byte(NETWORK_ID))
 
 		body, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = c.SubmitTransaction(body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		var e error
 		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
@@ -142,14 +142,14 @@ func TestAccount(t *testing.T) {
 		require.Nil(t, e)
 
 		targetBalance, err := strconv.ParseUint(account2Account.Balance, 10, 64)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, uint64(account1ToAccount2), targetBalance)
 
 		senderAccount, err = c.LoadAccount(account1Addr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		senderBalance2, err := strconv.ParseUint(senderAccount.Balance, 10, 64)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, senderBalance-account1ToAccount2-fee, senderBalance2)
 
 	}
@@ -161,25 +161,25 @@ func TestAccount(t *testing.T) {
 		)
 
 		senderAccount, err := c.LoadAccount(account1Addr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		senderBalance, err := strconv.ParseUint(senderAccount.Balance, 10, 64)
 
 		ob := operation.NewPayment(account2Addr, common.Amount(account1ToAccount2))
 		o, err := operation.NewOperation(ob)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		tx, err := transaction.NewTransaction(account1Addr, uint64(senderAccount.SequenceID), o)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		sender, err := keypair.Parse(account1Secret)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		tx.Sign(sender, []byte(NETWORK_ID))
 
 		body, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = c.SubmitTransaction(body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		var e error
 		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
@@ -202,14 +202,14 @@ func TestAccount(t *testing.T) {
 		require.Nil(t, e)
 
 		targetBalance, err := strconv.ParseUint(account2Account.Balance, 10, 64)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, uint64(account1ToAccount2*2), targetBalance)
 
 		senderAccount, err = c.LoadAccount(account1Addr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		senderBalance2, err := strconv.ParseUint(senderAccount.Balance, 10, 64)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, senderBalance-account1ToAccount2-fee, senderBalance2)
 
 	}

--- a/tests/client/congressvoting_test.go
+++ b/tests/client/congressvoting_test.go
@@ -1,16 +1,17 @@
 package client
 
 import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/client"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"
-	"encoding/json"
 	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"testing"
-	"time"
 )
 
 func TestCongressVoting(t *testing.T) {
@@ -26,24 +27,24 @@ func TestCongressVoting(t *testing.T) {
 
 	{
 		genesisAccount, err := c.LoadAccount(genesisAddr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		ob := operation.NewCongressVoting([]byte("dummy"), 10, 20)
 		o, err := operation.NewOperation(ob)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		tx, err := transaction.NewTransaction(genesisAddr, uint64(genesisAccount.SequenceID), o)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		sender, err := keypair.Parse(genesisSecret)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		tx.Sign(sender, []byte(NETWORK_ID))
 
 		body, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		pt, err := c.SubmitTransaction(body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		require.Equal(t, pt.Status, block.TransactionHistoryStatusSubmitted)
 
 		var e error
@@ -57,11 +58,11 @@ func TestCongressVoting(t *testing.T) {
 		require.Nil(t, e)
 
 		opage, err := c.LoadOperationsByAccount(genesisAddr, client.Q{Key: client.QueryType, Value: "congress-voting"})
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		for _, obody := range opage.Embedded.Records {
 			b, err := json.Marshal(obody.Body)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			var cv client.CongressVoting
 			json.Unmarshal(b, &cv)
 			require.Equal(t, ob.Contract, cv.Contract)
@@ -88,7 +89,7 @@ func TestCongressVotingResult(t *testing.T) {
 
 	{
 		genesisAccount, err := c.LoadAccount(genesisAddr)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		ob := operation.NewCongressVotingResult(
 			"dummy1",
@@ -101,20 +102,20 @@ func TestCongressVotingResult(t *testing.T) {
 			10,
 		)
 		o, err := operation.NewOperation(ob)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		tx, err := transaction.NewTransaction(genesisAddr, uint64(genesisAccount.SequenceID), o)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		sender, err := keypair.Parse(genesisSecret)
-		require.Nil(t, err)
+		require.NoError(t, err)
 		tx.Sign(sender, []byte(NETWORK_ID))
 
 		body, err := tx.Serialize()
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		_, err = c.SubmitTransaction(body)
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		var e error
 		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
@@ -127,11 +128,11 @@ func TestCongressVotingResult(t *testing.T) {
 		require.Nil(t, e)
 
 		opage, err := c.LoadOperationsByAccount(genesisAddr, client.Q{Key: client.QueryType, Value: "congress-voting-result"})
-		require.Nil(t, err)
+		require.NoError(t, err)
 
 		for _, obody := range opage.Embedded.Records {
 			b, err := json.Marshal(obody.Body)
-			require.Nil(t, err)
+			require.NoError(t, err)
 			var cvr client.CongressVotingResult
 			json.Unmarshal(b, &cvr)
 			require.Equal(t, ob.BallotStamps.Hash, cvr.BallotStamps.Hash)


### PR DESCRIPTION
### Background
When there is no err in `err`, `require.NoError(t, err)` is more intuitive than `require.Nil(t, err)`
I often make mistakes when checking errors with `Nil()` or `NotNil()`

### Solution
require.Nil(t, err) -> require.NoError(t, err)
require.NotNil(t, err) -> require.Error(t, err)
