### PR TITLE
Support `leveldb.Batch` in `LevelDBBackend`

### DIFF
--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -79,5 +79,5 @@ var (
 	ErrorTooManyRequests                           = NewError(172, "too many requests; reached limit")
 	ErrorHTTPServerError                           = NewError(173, "Internal Server Error")
 	ErrorBlockTransactionHistoryDoesNotExists      = NewError(174, "transaction history does not exists in block")
-	ErrorNotCommittableBackend                     = NewError(175, "not CommittableBackend")
+	ErrorNotCommitableCore                         = NewError(175, "not CommittableBackend")
 )

--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -79,4 +79,5 @@ var (
 	ErrorTooManyRequests                           = NewError(172, "too many requests; reached limit")
 	ErrorHTTPServerError                           = NewError(173, "Internal Server Error")
 	ErrorBlockTransactionHistoryDoesNotExists      = NewError(174, "transaction history does not exists in block")
+	ErrorNotCommittableBackend                     = NewError(175, "not CommittableBackend")
 )

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -53,6 +53,7 @@ func (p *ballotCheckerProposedTransaction) MakeBallot(numberOfTxs int) (blt *bal
 		Height:    p.genesisBlock.Height,
 		BlockHash: p.genesisBlock.Hash,
 		TotalTxs:  p.genesisBlock.TotalTxs,
+		TotalOps:  p.genesisBlock.TotalOps,
 	}
 
 	for i := 0; i < numberOfTxs; i++ {

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -592,7 +592,7 @@ func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *
 	}
 
 	var ts *storage.LevelDBBackend
-	if ts, err = st.OpenTransaction(); err != nil {
+	if ts, err = st.OpenBatch(); err != nil {
 		return nil, err
 	}
 

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -573,7 +573,7 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) (err error) {
 		}
 
 		if err = bs.Commit(); err != nil {
-			if err != errors.ErrorNotCommittableBackend {
+			if err != errors.ErrorNotCommitableCore {
 				bs.Discard()
 				return
 			}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -553,16 +553,30 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) (err error) {
 		}
 
 		var theBlock *block.Block
+
+		var bs *storage.LevelDBBackend
+		if bs, err = checker.NodeRunner.Storage().OpenBatch(); err != nil {
+			return err
+		}
+
 		theBlock, err = finishBallot(
-			checker.NodeRunner.Storage(),
+			bs,
 			checker.Ballot,
 			checker.NodeRunner.TransactionPool,
 			checker.Log,
 			checker.NodeRunner.Log(),
 		)
 		if err != nil {
+			bs.Discard()
 			checker.Log.Error("failed to finish ballot", "error", err)
 			return
+		}
+
+		if err = bs.Commit(); err != nil {
+			if err != errors.ErrorNotCommittableBackend {
+				bs.Discard()
+				return
+			}
 		}
 
 		checker.Log.Debug("ballot was stored", "block", *theBlock)
@@ -591,11 +605,6 @@ func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *
 		return nil, err
 	}
 
-	var ts *storage.LevelDBBackend
-	if ts, err = st.OpenBatch(); err != nil {
-		return nil, err
-	}
-
 	var nOps int
 	for _, hash := range b.B.Proposed.Transactions {
 		tx, found := transactionPool.Get(hash)
@@ -618,8 +627,7 @@ func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *
 		b.ProposerConfirmed(),
 	)
 
-	if err = blk.Save(ts); err != nil {
-		ts.Discard()
+	if err = blk.Save(st); err != nil {
 		log.Error("failed to create new block", "block", blk, "error", err)
 		return nil, err
 	}
@@ -645,19 +653,12 @@ func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *
 		proposedTransactions = append(proposedTransactions, &tx)
 	}
 
-	if err = FinishTransactions(*blk, proposedTransactions, ts); err != nil {
-		ts.Discard()
+	if err = FinishTransactions(*blk, proposedTransactions, st); err != nil {
 		return nil, err
 	}
 
-	if err = FinishProposerTransaction(ts, *blk, b.ProposerTransaction(), log); err != nil {
+	if err = FinishProposerTransaction(st, *blk, b.ProposerTransaction(), log); err != nil {
 		log.Error("failed to finish proposer transaction", "block", blk, "ptx", b.ProposerTransaction(), "error", err)
-		ts.Discard()
-		return nil, err
-	}
-
-	if err = ts.Commit(); err != nil {
-		ts.Discard()
 		return nil, err
 	}
 
@@ -686,23 +687,23 @@ func isValidRound(st *storage.LevelDBBackend, r voting.Basis, log logging.Logger
 	return true, nil
 }
 
-func FinishTransactions(blk block.Block, transactions []*transaction.Transaction, ts *storage.LevelDBBackend) (err error) {
+func FinishTransactions(blk block.Block, transactions []*transaction.Transaction, st *storage.LevelDBBackend) (err error) {
 	for _, tx := range transactions {
 		raw, _ := json.Marshal(tx)
 
 		bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, *tx, raw)
-		if err = bt.Save(ts); err != nil {
+		if err = bt.Save(st); err != nil {
 			return
 		}
 		for _, op := range tx.B.Operations {
-			if err = finishOperation(ts, tx.B.Source, op, log); err != nil {
+			if err = finishOperation(st, tx.B.Source, op, log); err != nil {
 				log.Error("failed to finish operation", "block", blk, "bt", bt, "op", op, "error", err)
 				return err
 			}
 		}
 
 		var baSource *block.BlockAccount
-		if baSource, err = block.GetBlockAccount(ts, tx.B.Source); err != nil {
+		if baSource, err = block.GetBlockAccount(st, tx.B.Source); err != nil {
 			err = errors.ErrorBlockAccountDoesNotExists
 			return
 		}
@@ -711,7 +712,7 @@ func FinishTransactions(blk block.Block, transactions []*transaction.Transaction
 			return
 		}
 
-		if err = baSource.Save(ts); err != nil {
+		if err = baSource.Save(st); err != nil {
 			return
 		}
 

--- a/lib/node/runner/finish_ballot_test.go
+++ b/lib/node/runner/finish_ballot_test.go
@@ -310,8 +310,8 @@ func TestBenchmarkFinishBallot(t *testing.T) {
 	var err error
 
 	err = testFinishBallotWithBatch(false, 100, 100)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	err = testFinishBallotWithBatch(true, 100, 100)
-	require.Nil(t, err)
+	require.NoError(t, err)
 }

--- a/lib/node/runner/finish_ballot_test.go
+++ b/lib/node/runner/finish_ballot_test.go
@@ -1,0 +1,317 @@
+package runner
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	logging "github.com/inconshreveable/log15"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+
+	"boscoin.io/sebak/lib/ballot"
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus"
+	"boscoin.io/sebak/lib/consensus/round"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
+	"boscoin.io/sebak/lib/transaction/operation"
+)
+
+func createNodeRunnerForTestingWithFileStorage(n int, conf common.Config, recv chan struct{}) (*NodeRunner, []*node.LocalNode, string) {
+	var ns []*network.MemoryNetwork
+	var net *network.MemoryNetwork
+	var nodes []*node.LocalNode
+	for i := 0; i < n; i++ {
+		_, s, v := network.CreateMemoryNetwork(net)
+		net = s
+		ns = append(ns, s)
+		nodes = append(nodes, v)
+	}
+
+	for j := 0; j < n; j++ {
+		nodes[0].AddValidators(nodes[j].ConvertToValidator())
+	}
+
+	localNode := nodes[0]
+	policy, _ := consensus.NewDefaultVotingThresholdPolicy(67)
+
+	connectionManager := NewTestConnectionManager(
+		localNode,
+		ns[0],
+		policy,
+		recv,
+	)
+
+	st := &storage.LevelDBBackend{}
+	dir, err := ioutil.TempDir("", "sebak-test")
+	if err != nil {
+		panic(err)
+	}
+
+	{
+		var err error
+		config, _ := storage.NewConfigFromString(fmt.Sprintf("file://%s", dir))
+
+		if err = st.Init(config); err != nil {
+			panic(err)
+		}
+
+		block.MakeTestBlockchain(st)
+	}
+
+	is, _ := consensus.NewISAAC(networkID, localNode, policy, connectionManager, st, common.NewConfig(), nil)
+	is.SetProposerSelector(FixedSelector{localNode.Address()})
+
+	nr, err := NewNodeRunner(string(networkID), localNode, policy, ns[0], is, st, conf)
+	if err != nil {
+		panic(err)
+	}
+	nr.isaacStateManager.blockTimeBuffer = 0
+
+	return nr, nodes, dir
+}
+
+func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOperations int) error {
+	nr, localNodes, dir := createNodeRunnerForTestingWithFileStorage(1, common.NewConfig(), nil)
+	defer func() {
+		nr.Storage().Close()
+		os.RemoveAll(dir)
+	}()
+
+	proposerNode := localNodes[0]
+	nr.Consensus().SetProposerSelector(FixedSelector{proposerNode.Address()})
+
+	genesisBlock := block.GetGenesis(nr.Storage())
+	commonAccount, _ := GetCommonAccount(nr.Storage())
+	initialBalance, _ := GetGenesisBalance(nr.Storage())
+
+	var blt *ballot.Ballot
+	{
+		var txs []transaction.Transaction
+		var txHashes []string
+
+		rd := round.Round{
+			Number:      0,
+			BlockHeight: genesisBlock.Height,
+			BlockHash:   genesisBlock.Hash,
+			TotalTxs:    genesisBlock.TotalTxs,
+		}
+
+		for i := 0; i < numberOfTransactions; i++ {
+			kpA, _ := keypair.Random()
+			accountA := block.NewBlockAccount(kpA.Address(), common.Amount(common.BaseReserve))
+			accountA.MustSave(nr.Storage())
+
+			kpB, _ := keypair.Random()
+			tx := transaction.MakeTransactionCreateAccount(kpA, kpB.Address(), common.Amount(1))
+
+			var ops []operation.Operation
+			for j := 0; j < numberOfOperations-1; j++ {
+				kpC, _ := keypair.Random()
+
+				opb := operation.NewCreateAccount(kpC.Address(), common.Amount(1), "")
+				op := operation.Operation{
+					H: operation.Header{
+						Type: operation.TypeCreateAccount,
+					},
+					B: opb,
+				}
+				ops = append(ops, op)
+			}
+			tx.B.Operations = append(tx.B.Operations, ops...)
+			tx.B.SequenceID = accountA.SequenceID
+			tx.Sign(kpA, networkID)
+
+			txHashes = append(txHashes, tx.GetHash())
+			txs = append(txs, tx)
+			nr.TransactionPool.Add(tx)
+		}
+
+		blt = ballot.NewBallot(proposerNode.Address(), proposerNode.Address(), rd, txHashes)
+
+		opc, _ := ballot.NewCollectTxFeeFromBallot(*blt, commonAccount.Address, txs...)
+		opi, _ := ballot.NewInflationFromBallot(*blt, commonAccount.Address, initialBalance)
+		ptx, _ := ballot.NewProposerTransactionFromBallot(*blt, opc, opi)
+
+		blt.SetProposerTransaction(ptx)
+		blt.SetVote(ballot.StateINIT, ballot.VotingYES)
+		blt.Sign(proposerNode.Keypair(), networkID)
+	}
+
+	st := nr.Storage()
+	if withBatch {
+		st, _ = st.OpenBatch()
+	}
+
+	_, err := finishBallot(
+		st,
+		*blt,
+		nr.TransactionPool,
+		nr.Log(),
+		nr.Log(),
+	)
+
+	return err
+}
+
+func benchmarkFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOperations int, b *testing.B) {
+	SetLogging(logging.LvlError, common.DefaultLogHandler)
+	for i := 1; i < b.N+1; i++ {
+		testFinishBallotWithBatch(withBatch, numberOfTransactions, numberOfOperations)
+	}
+}
+
+func BenchmarkFinishBallotWithoutBatch_1_10(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 1, 10, b)
+}
+
+func BenchmarkFinishBallotWithBatch_1_10(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 1, 10, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_1_200(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 1, 200, b)
+}
+
+func BenchmarkFinishBallotWithBatch_1_200(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 1, 200, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_1_400(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 1, 400, b)
+}
+
+func BenchmarkFinishBallotWithBatch_1_400(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 1, 400, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_1_600(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 1, 600, b)
+}
+
+func BenchmarkFinishBallotWithBatch_1_600(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 1, 600, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_1_800(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 1, 800, b)
+}
+
+func BenchmarkFinishBallotWithBatch_1_800(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 1, 800, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_1_1000(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 1, 1000, b)
+}
+
+func BenchmarkFinishBallotWithBatch_1_1000(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 1, 1000, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_200_10(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 200, 10, b)
+}
+
+func BenchmarkFinishBallotWithBatch_200_10(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 200, 10, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_200_200(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 200, 200, b)
+}
+
+func BenchmarkFinishBallotWithBatch_200_200(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 200, 200, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_200_400(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 200, 400, b)
+}
+
+func BenchmarkFinishBallotWithBatch_200_400(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 200, 400, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_200_600(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 200, 600, b)
+}
+
+func BenchmarkFinishBallotWithBatch_200_600(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 200, 600, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_200_800(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 200, 800, b)
+}
+
+func BenchmarkFinishBallotWithBatch_200_800(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 200, 800, b)
+}
+
+func BenchmarkFinishBallotWithoutBatch_200_1000(b *testing.B) {
+	benchmarkFinishBallotWithBatch(false, 200, 1000, b)
+}
+
+func BenchmarkFinishBallotWithBatch_200_1000(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 200, 1000, b)
+}
+
+func BenchmarkFinishBallotWithBatch_400_10(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 400, 10, b)
+}
+
+func BenchmarkFinishBallotWithBatch_400_200(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 400, 200, b)
+}
+
+func BenchmarkFinishBallotWithBatch_400_400(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 400, 400, b)
+}
+
+func BenchmarkFinishBallotWithBatch_400_600(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 400, 600, b)
+}
+
+func BenchmarkFinishBallotWithBatch_400_800(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 400, 800, b)
+}
+
+func BenchmarkFinishBallotWithBatch_400_1000(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 400, 1000, b)
+}
+
+func BenchmarkFinishBallotWithBatch_600_10(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 600, 10, b)
+}
+
+func BenchmarkFinishBallotWithBatch_600_200(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 600, 200, b)
+}
+
+func BenchmarkFinishBallotWithBatch_600_400(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 600, 400, b)
+}
+
+func BenchmarkFinishBallotWithBatch_600_600(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 600, 600, b)
+}
+
+func BenchmarkFinishBallotWithBatch_600_800(b *testing.B) {
+	benchmarkFinishBallotWithBatch(true, 600, 800, b)
+}
+
+func TestBenchmarkFinishBallot(t *testing.T) {
+	var err error
+
+	err = testFinishBallotWithBatch(false, 100, 100)
+	require.Nil(t, err)
+
+	err = testFinishBallotWithBatch(true, 100, 100)
+	require.Nil(t, err)
+}

--- a/lib/node/runner/finish_ballot_test.go
+++ b/lib/node/runner/finish_ballot_test.go
@@ -14,12 +14,12 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/consensus"
-	"boscoin.io/sebak/lib/consensus/round"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"
+	"boscoin.io/sebak/lib/voting"
 )
 
 func createNodeRunnerForTestingWithFileStorage(n int, conf common.Config, recv chan struct{}) (*NodeRunner, []*node.LocalNode, string) {
@@ -95,11 +95,11 @@ func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOpe
 		var txs []transaction.Transaction
 		var txHashes []string
 
-		rd := round.Round{
-			Number:      0,
-			BlockHeight: genesisBlock.Height,
-			BlockHash:   genesisBlock.Hash,
-			TotalTxs:    genesisBlock.TotalTxs,
+		rd := voting.Basis{
+			Round:     0,
+			Height:    genesisBlock.Height,
+			BlockHash: genesisBlock.Hash,
+			TotalTxs:  genesisBlock.TotalTxs,
 		}
 
 		for i := 0; i < numberOfTransactions; i++ {

--- a/lib/storage/batch.go
+++ b/lib/storage/batch.go
@@ -1,0 +1,130 @@
+package storage
+
+import (
+	"sync"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	leveldbIterator "github.com/syndtr/goleveldb/leveldb/iterator"
+	leveldbOpt "github.com/syndtr/goleveldb/leveldb/opt"
+	leveldbUtil "github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type BatchBackend struct {
+	sync.RWMutex
+
+	core  LevelDBCore
+	batch *leveldb.Batch
+
+	inserted map[string][]byte
+}
+
+func NewBatchBackend(core LevelDBCore) *BatchBackend {
+	return &BatchBackend{
+		core:     core,
+		batch:    &leveldb.Batch{},
+		inserted: map[string][]byte{},
+	}
+}
+
+func (bb *BatchBackend) convertKey(key []byte) string {
+	return string(key)
+}
+
+func (bb *BatchBackend) Has(key []byte, opt *leveldbOpt.ReadOptions) (bool, error) {
+	bb.RLock()
+	defer bb.RUnlock()
+
+	var found bool
+	if _, found = bb.inserted[bb.convertKey(key)]; found {
+		return true, nil
+	}
+
+	return bb.core.Has(key, opt)
+}
+
+func (bb *BatchBackend) Get(key []byte, opt *leveldbOpt.ReadOptions) (b []byte, err error) {
+	bb.RLock()
+	defer bb.RUnlock()
+
+	var found bool
+	if b, found = bb.inserted[bb.convertKey(key)]; found {
+		return
+	}
+
+	return bb.core.Get(key, opt)
+}
+
+// NewIterator does not work with `BatchBackend`
+func (bb *BatchBackend) NewIterator(r *leveldbUtil.Range, opt *leveldbOpt.ReadOptions) leveldbIterator.Iterator {
+	return bb.core.NewIterator(r, opt)
+}
+
+func (bb *BatchBackend) Put(key []byte, v []byte, opt *leveldbOpt.WriteOptions) error {
+	bb.Lock()
+	defer bb.Unlock()
+
+	bb.inserted[bb.convertKey(key)] = v
+	bb.batch.Put(key, v)
+
+	return nil
+}
+
+// Write will write the existing contents of `BatchBackend.batch` and then
+// argument, batch will be written.
+func (bb *BatchBackend) Write(batch *leveldb.Batch, opt *leveldbOpt.WriteOptions) (err error) {
+	bb.Lock()
+	defer bb.Unlock()
+
+	if err = bb.core.Write(bb.batch, opt); err != nil {
+		return
+	}
+
+	if batch != nil {
+		err = bb.core.Write(batch, opt)
+	}
+
+	return
+}
+
+func (bb *BatchBackend) Discard() {
+	bb.Lock()
+	defer bb.Unlock()
+
+	bb.clear()
+}
+
+func (bb *BatchBackend) Commit() (err error) {
+	bb.Lock()
+	defer bb.Unlock()
+
+	err = bb.core.Write(bb.batch, nil)
+	if err != nil {
+		return
+	}
+
+	bb.clear()
+
+	return
+}
+
+func (bb *BatchBackend) Delete(key []byte, opt *leveldbOpt.WriteOptions) error {
+	bb.Lock()
+	defer bb.Unlock()
+
+	delete(bb.inserted, bb.convertKey(key))
+	bb.batch.Delete(key)
+
+	return nil
+}
+
+func (bb *BatchBackend) Dump() []byte {
+	bb.RLock()
+	defer bb.RUnlock()
+
+	return bb.batch.Dump()
+}
+
+func (bb *BatchBackend) clear() {
+	bb.batch = &leveldb.Batch{}
+	bb.inserted = map[string][]byte{}
+}

--- a/lib/storage/batch.go
+++ b/lib/storage/batch.go
@@ -26,16 +26,12 @@ func NewBatchCore(core LevelDBCore) *BatchCore {
 	}
 }
 
-func (bb *BatchCore) convertKey(key []byte) string {
-	return string(key)
-}
-
 func (bb *BatchCore) Has(key []byte, opt *leveldbOpt.ReadOptions) (bool, error) {
 	bb.RLock()
 	defer bb.RUnlock()
 
 	var found bool
-	if _, found = bb.inserted[bb.convertKey(key)]; found {
+	if _, found = bb.inserted[string(key)]; found {
 		return true, nil
 	}
 
@@ -47,7 +43,7 @@ func (bb *BatchCore) Get(key []byte, opt *leveldbOpt.ReadOptions) (b []byte, err
 	defer bb.RUnlock()
 
 	var found bool
-	if b, found = bb.inserted[bb.convertKey(key)]; found {
+	if b, found = bb.inserted[string(key)]; found {
 		return
 	}
 
@@ -63,7 +59,7 @@ func (bb *BatchCore) Put(key []byte, v []byte, opt *leveldbOpt.WriteOptions) err
 	bb.Lock()
 	defer bb.Unlock()
 
-	bb.inserted[bb.convertKey(key)] = v
+	bb.inserted[string(key)] = v
 	bb.batch.Put(key, v)
 
 	return nil
@@ -111,7 +107,7 @@ func (bb *BatchCore) Delete(key []byte, opt *leveldbOpt.WriteOptions) error {
 	bb.Lock()
 	defer bb.Unlock()
 
-	delete(bb.inserted, bb.convertKey(key))
+	delete(bb.inserted, string(key))
 	bb.batch.Delete(key)
 
 	return nil

--- a/lib/storage/batch_test.go
+++ b/lib/storage/batch_test.go
@@ -1,0 +1,112 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"boscoin.io/sebak/lib/error"
+)
+
+func TestBatchBackendNew(t *testing.T) {
+	st := NewTestStorage()
+	defer st.Close()
+
+	fetched := map[int]string{}
+	key := "showme"
+	input := map[int]string{
+		90: "99",
+		91: "91",
+		92: "92",
+	}
+
+	bt, err := st.OpenBatch()
+	require.NoError(t, err)
+
+	{ // `Get` failed in both
+		{ // in normal LeveldbBatch
+			err := st.Get(key, &fetched)
+			require.Equal(t, errors.ErrorStorageRecordDoesNotExist, err)
+		}
+
+		{ // in BatchBackend
+			err := bt.Get(key, &fetched)
+			require.Equal(t, errors.ErrorStorageRecordDoesNotExist, err)
+		}
+	}
+
+	{ // `New` in BatchBackend, but it does not stored in LeveldbBatch
+		{ // in BatchBackend
+			err := bt.New(key, input)
+			require.NoError(t, err)
+		}
+
+		{ // in normal LeveldbBatch
+			err := st.Get(key, &fetched)
+			require.Equal(t, errors.ErrorStorageRecordDoesNotExist, err)
+		}
+	}
+
+	{ // `Get` must return the value of `New` in BatchBackend
+		err := bt.Get(key, &fetched)
+		require.NoError(t, err)
+
+		require.True(t, reflect.DeepEqual(input, fetched))
+	}
+
+	{ // `New` must be failed because already `New`ed
+		err = bt.New(key, input)
+		require.Equal(t, errors.ErrorStorageRecordAlreadyExists, err)
+	}
+
+	{ // `Commit` batch, it must be stored in LeveldbBatch
+		err := bt.Commit()
+		require.NoError(t, err)
+
+		err = st.Get(key, &fetched)
+		require.NoError(t, err)
+		require.True(t, reflect.DeepEqual(input, fetched))
+	}
+}
+
+func TestBatchBackendDelete(t *testing.T) {
+	st := NewTestStorage()
+	defer st.Close()
+
+	fetched := map[int]string{}
+	key := "showme"
+	input := map[int]string{
+		90: "99",
+		91: "91",
+		92: "92",
+	}
+
+	{
+		err := st.New(key, input)
+		require.NoError(t, err)
+	}
+
+	bt, _ := st.OpenBatch()
+
+	// `Delete` must be failed because already `New`ed
+	bt.Remove(key)
+
+	{ // in LeveldbBatch still have data
+		err := st.Get(key, &fetched)
+		require.NoError(t, err)
+
+		require.True(t, reflect.DeepEqual(input, fetched))
+	}
+
+	err := bt.Commit()
+	require.NoError(t, err)
+
+	{ // after `Commit`, it must be removed in LeveldbBatch and BatchBackend
+		err = bt.Get(key, &fetched)
+		require.Equal(t, errors.ErrorStorageRecordDoesNotExist, err)
+
+		err = st.Get(key, &fetched)
+		require.Equal(t, errors.ErrorStorageRecordDoesNotExist, err)
+	}
+}

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -85,14 +85,14 @@ func (st *LevelDBBackend) OpenTransaction() (*LevelDBBackend, error) {
 }
 
 func (st *LevelDBBackend) OpenBatch() (*LevelDBBackend, error) {
-	_, ok := st.Core.(*BatchBackend)
+	_, ok := st.Core.(*BatchCore)
 	if ok {
 		return nil, errors.New("this is already BatchBackend")
 	}
 
 	return &LevelDBBackend{
 		DB:   st.DB,
-		Core: NewBatchBackend(st.DB),
+		Core: NewBatchCore(st.DB),
 	}, nil
 }
 

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -97,10 +97,10 @@ func (st *LevelDBBackend) OpenBatch() (*LevelDBBackend, error) {
 }
 
 func (st *LevelDBBackend) Discard() error {
-	var committable CommittableBackend
+	var committable CommitableCore
 	var ok bool
-	if committable, ok = st.Core.(CommittableBackend); !ok {
-		return errors.ErrorNotCommittableBackend
+	if committable, ok = st.Core.(CommitableCore); !ok {
+		return errors.ErrorNotCommitableCore
 	}
 
 	committable.Discard()
@@ -109,10 +109,10 @@ func (st *LevelDBBackend) Discard() error {
 }
 
 func (st *LevelDBBackend) Commit() error {
-	var committable CommittableBackend
+	var committable CommitableCore
 	var ok bool
-	if committable, ok = st.Core.(CommittableBackend); !ok {
-		return errors.ErrorNotCommittableBackend
+	if committable, ok = st.Core.(CommitableCore); !ok {
+		return errors.ErrorNotCommitableCore
 	}
 
 	return setLevelDBCoreError(committable.Commit())

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -100,7 +100,7 @@ func (st *LevelDBBackend) Discard() error {
 	var committable CommittableBackend
 	var ok bool
 	if committable, ok = st.Core.(CommittableBackend); !ok {
-		return setLevelDBCoreError(errors.New("not CommittableBackend"))
+		return errors.ErrorNotCommittableBackend
 	}
 
 	committable.Discard()
@@ -112,7 +112,7 @@ func (st *LevelDBBackend) Commit() error {
 	var committable CommittableBackend
 	var ok bool
 	if committable, ok = st.Core.(CommittableBackend); !ok {
-		return setLevelDBCoreError(errors.New("not CommittableBackend"))
+		return errors.ErrorNotCommittableBackend
 	}
 
 	return setLevelDBCoreError(committable.Commit())

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -95,7 +95,7 @@ func ParseConfig(s string) (u *Config, err error) {
 	return
 }
 
-type CommittableBackend interface {
+type CommitableCore interface {
 	Discard()
 	Commit() error
 }

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -94,3 +94,8 @@ func ParseConfig(s string) (u *Config, err error) {
 
 	return
 }
+
+type CommittableBackend interface {
+	Discard()
+	Commit() error
+}


### PR DESCRIPTION
### Github Issue

related to #573 

### Background

Recently I found some slowness when `runner.finishBallot`. I assumed `leveldb.Transaction` is slower than `leveldb.Batch`.

### Solution

With `leveldb.Batch` there are some improvement for saving, especially `finishBalot()`. I wrote simple benchmark for `finishBallot`. This is the result,
```
$ time go test -timeout 1000h ./lib/node/runner... -v \
    -bench BenchmarkFinishBallotWith -run '^$' \
    | tee >(prettybench -no-passthrough)
goos: darwin
goarch: amd64
pkg: boscoin.io/sebak/lib/node/runner

===========================================================================+===========
 BenchmarkFinishBallotWithoutBatch_1_10-8     | 200  |      8703111 ns/op  |  
 BenchmarkFinishBallotWithBatch_1_10-8        | 200  |      8432652 ns/op  |  +3.1076%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_1_200-8    |  20  |     73501199 ns/op  |  
 BenchmarkFinishBallotWithBatch_1_200-8       |  50  |     36836526 ns/op  | +49.8830%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_1_400-8    |  20  |    111295178 ns/op  |  
 BenchmarkFinishBallotWithBatch_1_400-8       |  20  |     61944653 ns/op  | +44.3420%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_1_600-8    |  10  |    165450394 ns/op  |  
 BenchmarkFinishBallotWithBatch_1_600-8       |  20  |     94323325 ns/op  | +42.9899%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_1_800-8    |   5  |    216421041 ns/op  |  
 BenchmarkFinishBallotWithBatch_1_800-8       |  10  |    130150833 ns/op  | +39.8622%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_1_1000-8   |   5  |    267735515 ns/op  |  
 BenchmarkFinishBallotWithBatch_1_1000-8      |  10  |    144240689 ns/op  | +46.1256%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_200_10-8   |   2  |    718578099 ns/op  |  
 BenchmarkFinishBallotWithBatch_200_10-8      |   3  |    458517416 ns/op  | +36.1910%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_200_200-8  |   1  |  15948486347 ns/op  |  
 BenchmarkFinishBallotWithBatch_200_200-8     |   1  |   7036990911 ns/op  | +55.8767%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_200_400-8  |   1  |  36027407561 ns/op  |  
 BenchmarkFinishBallotWithBatch_200_400-8     |   1  |  15870237056 ns/op  | +55.9495%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_200_600-8  |   1  |  60989189227 ns/op  |  
 BenchmarkFinishBallotWithBatch_200_600-8     |   1  |  29518202778 ns/op  | +51.6009%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_200_800-8  |   1  |  75418588132 ns/op  |  
 BenchmarkFinishBallotWithBatch_200_800-8     |   1  |  39607720988 ns/op  | +47.4828%
----------------------------------------------+------+---------------------+-----------
 BenchmarkFinishBallotWithoutBatch_200_1000-8 |   1  | 101518575012 ns/op  |  
 BenchmarkFinishBallotWithBatch_200_1000-8    |   1  |  55013357793 ns/op  | +45.8095%
===========================================================================+===========


# Unknown spaces ㅜㅜㅜㅜㅜㅜ
=======================================================================================
 BenchmarkFinishBallotWithBatch_400_10-8      |   2  |    804385217 ns/op
 BenchmarkFinishBallotWithBatch_400_200-8     |   1  |  15026138629 ns/op
 BenchmarkFinishBallotWithBatch_400_400-8     |   1  |  37461945847 ns/op
 BenchmarkFinishBallotWithBatch_400_600-8     |   1  |  79445266393 ns/op
 BenchmarkFinishBallotWithBatch_400_800-8     |   1  | 127750238351 ns/op
 BenchmarkFinishBallotWithBatch_400_1000-8    |   1  | 190282134228 ns/op
 BenchmarkFinishBallotWithBatch_600_10-8      |   1  |   1641325406 ns/op
 BenchmarkFinishBallotWithBatch_600_200-8     |   1  |  34984065425 ns/op
 BenchmarkFinishBallotWithBatch_600_400-8     |   1  |  93445665848 ns/op
 BenchmarkFinishBallotWithBatch_600_600-8     |   1  | 163408571196 ns/op
 BenchmarkFinishBallotWithBatch_600_800-8     |   1  | 336742077297 ns/op
=======================================================================================
```
* `BenchmarkFinishBallotWithoutBatch_XXX` uses `leveldb.Transaction`
* `BenchmarkFinishBallotWithBatch_XXX` uses `leveldb.Batch`
* `BenchmarkFinishBallotWithBatch_600_800` means, `600` transactions and `800` operations in each transaction; this handles `240,000` operations in `finishBallot`

In most of cases the elapsed time reduced up to almost `45%` in `leveldb.Batch`.

> This benchmark test can be found at `lib/node/runner/finish_ballot_test.go`

The major changes are,

* new `LevelDBCore`, `BatchCore`; this almost acts like `leveldb.Transaction`
* `LevelDBBackend.OpenBatch()` returns new `LevelDBBackend` with `BatchCore`.
* batch `LevelDBBackend` handles data in memory(`leveldb.Batch`) and `Commit()` will actually write data in storage like `Transaction`
* `finishBallot` almost was not changed.

---
To make `finishBallot()` to be faster(#573), this PR will be helpful and the other way also be needed. At this time, the **`json.Marshal`** and **`json.Unmarshal`** seems to be so expensive. We need to find faster object serialization library to replace `json`.