### PR TITLE
Improve api/blocks test code

### DIFF
--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -14,12 +14,12 @@ import (
 )
 
 func TestBlockConfirmedOrdering(t *testing.T) {
-	st := storage.NewTestStorage()
+	st := InitTestBlockchain()
 
-	var inserted []Block
-	for i := 0; i < 10; i++ {
-		bk := TestMakeNewBlock([]string{})
-		bk.Height = uint64(i)
+	genesis := GetLatestBlock(st)
+	inserted := []Block{genesis}
+	for i := genesis.Height + 1; i < 10; i++ {
+		bk := TestMakeNewBlockWithPrevBlock(inserted[len(inserted)-1], []string{})
 		bk.MustSave(st)
 		inserted = append(inserted, bk)
 	}

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -125,6 +125,8 @@ func TestMakeNewBlockWithPrevBlock(prevBlock Block, txs []string) Block {
 		voting.Basis{
 			Height:    prevBlock.Height,
 			BlockHash: prevBlock.Hash,
+			TotalTxs:  uint64(len(txs)),
+			TotalOps:  uint64(len(txs)),
 		},
 		"",
 		txs,

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -147,11 +147,3 @@ func TestMakeNewBlockOperation(networkID []byte, n int) (bos []BlockOperation) {
 
 	return
 }
-
-func TestMakeNewBlockTransaction(networkID []byte, n int) BlockTransaction {
-	_, tx := transaction.TestMakeTransaction(networkID, n)
-
-	block := TestMakeNewBlock([]string{tx.GetHash()})
-	a, _ := tx.Serialize()
-	return NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
-}

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -123,7 +123,7 @@ func TestMakeNewBlockWithPrevBlock(prevBlock Block, txs []string) Block {
 	return *NewBlock(
 		kp.Address(),
 		voting.Basis{
-			Height:    prevBlock.Height,
+			Height:    prevBlock.Height + 1,
 			BlockHash: prevBlock.Hash,
 			TotalTxs:  uint64(len(txs)),
 			TotalOps:  uint64(len(txs)),

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -39,7 +39,7 @@ func TestNewBlockTransaction(t *testing.T) {
 func TestBlockTransactionSaveAndGet(t *testing.T) {
 	st := storage.NewTestStorage()
 
-	bt := TestMakeNewBlockTransaction(networkID, 1)
+	bt := makeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestBlockTransactionSaveAndGet(t *testing.T) {
 func TestBlockTransactionSaveExisting(t *testing.T) {
 	st := storage.NewTestStorage()
 
-	bt := TestMakeNewBlockTransaction(networkID, 1)
+	bt := makeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
 	require.NoError(t, err)
 
@@ -224,7 +224,7 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 func TestBlockTransactionMultipleSave(t *testing.T) {
 	st := storage.NewTestStorage()
 
-	bt := TestMakeNewBlockTransaction(networkID, 1)
+	bt := makeNewBlockTransaction(networkID, 1)
 	err := bt.Save(st)
 	require.NoError(t, err)
 
@@ -494,4 +494,12 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 			require.Equal(t, bt.Hash, halfSaved[i].Hash)
 		}
 	}
+}
+
+func makeNewBlockTransaction(networkID []byte, n int) BlockTransaction {
+	_, tx := transaction.TestMakeTransaction(networkID, n)
+
+	block := TestMakeNewBlock([]string{tx.GetHash()})
+	a, _ := tx.Serialize()
+	return NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
 }

--- a/lib/node/runner/api/operation_test.go
+++ b/lib/node/runner/api/operation_test.go
@@ -24,7 +24,7 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, boList, err := prepareOps(storage, 10, nil)
+	kp, boList, err := prepareOps(storage, 10)
 	require.NoError(t, err)
 
 	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
@@ -72,7 +72,7 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, boList, err := prepareOps(storage, 10, nil)
+	kp, boList, err := prepareOps(storage, 10)
 	require.NoError(t, err)
 	ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
 	ba.MustSave(storage)
@@ -131,7 +131,7 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 	defer ts.Close()
 
 	boMap := make(map[string]block.BlockOperation)
-	kp, boList, err := prepareOpsWithoutSave(10, nil)
+	kp, boList, err := prepareOpsWithoutSave(10)
 	require.NoError(t, err)
 	for _, bo := range boList {
 		boMap[bo.Hash] = bo

--- a/lib/node/runner/api/operation_test.go
+++ b/lib/node/runner/api/operation_test.go
@@ -24,7 +24,7 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, boList, err := prepareOps(storage, 0, 10, nil)
+	kp, boList, err := prepareOps(storage, 10, nil)
 	require.NoError(t, err)
 
 	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
@@ -72,7 +72,7 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, boList, err := prepareOps(storage, 0, 10, nil)
+	kp, boList, err := prepareOps(storage, 10, nil)
 	require.NoError(t, err)
 	ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
 	ba.MustSave(storage)
@@ -131,7 +131,7 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 	defer ts.Close()
 
 	boMap := make(map[string]block.BlockOperation)
-	kp, boList, err := prepareOpsWithoutSave(0, 10, nil)
+	kp, boList, err := prepareOpsWithoutSave(10, nil)
 	require.NoError(t, err)
 	for _, bo := range boList {
 		boMap[bo.Hash] = bo

--- a/lib/node/runner/api/test.go
+++ b/lib/node/runner/api/test.go
@@ -36,8 +36,8 @@ func prepareAPIServer() (*httptest.Server, *storage.LevelDBBackend, error) {
 	return ts, storage, nil
 }
 
-func prepareOps(storage *storage.LevelDBBackend, count int, kp *keypair.Full) (*keypair.Full, []block.BlockOperation, error) {
-	kp, btList, err := prepareTxs(storage, count, kp)
+func prepareOps(storage *storage.LevelDBBackend, count int) (*keypair.Full, []block.BlockOperation, error) {
+	kp, btList, err := prepareTxs(storage, count)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,14 +52,11 @@ func prepareOps(storage *storage.LevelDBBackend, count int, kp *keypair.Full) (*
 
 	return kp, boList, nil
 }
-func prepareOpsWithoutSave(count int, kp *keypair.Full) (*keypair.Full, []block.BlockOperation, error) {
+func prepareOpsWithoutSave(count int) (*keypair.Full, []block.BlockOperation, error) {
 
-	var err error
-	if kp == nil {
-		kp, err = keypair.Random()
-		if err != nil {
-			return nil, nil, err
-		}
+	kp, err := keypair.Random()
+	if err != nil {
+		return nil, nil, err
 	}
 	var txs []transaction.Transaction
 	var txHashes []string
@@ -84,13 +81,10 @@ func prepareOpsWithoutSave(count int, kp *keypair.Full) (*keypair.Full, []block.
 	return kp, boList, nil
 }
 
-func prepareTxs(storage *storage.LevelDBBackend, count int, kp *keypair.Full) (*keypair.Full, []block.BlockTransaction, error) {
-	var err error
-	if kp == nil {
-		kp, err = keypair.Random()
-		if err != nil {
-			return nil, nil, err
-		}
+func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, []block.BlockTransaction, error) {
+	kp, err := keypair.Random()
+	if err != nil {
+		return nil, nil, err
 	}
 	var txs []transaction.Transaction
 	var txHashes []string
@@ -121,13 +115,10 @@ func prepareTxs(storage *storage.LevelDBBackend, count int, kp *keypair.Full) (*
 	return kp, btList, nil
 }
 
-func prepareTxsWithoutSave(count int, kp *keypair.Full) (*keypair.Full, []block.BlockTransaction, error) {
-	var err error
-	if kp == nil {
-		kp, err = keypair.Random()
-		if err != nil {
-			return nil, nil, err
-		}
+func prepareTxsWithoutSave(count int) (*keypair.Full, []block.BlockTransaction, error) {
+	kp, err := keypair.Random()
+	if err != nil {
+		return nil, nil, err
 	}
 	var txs []transaction.Transaction
 	var txHashes []string

--- a/lib/node/runner/api/test.go
+++ b/lib/node/runner/api/test.go
@@ -36,8 +36,8 @@ func prepareAPIServer() (*httptest.Server, *storage.LevelDBBackend, error) {
 	return ts, storage, nil
 }
 
-func prepareOps(storage *storage.LevelDBBackend, blockHeight uint64, count int, kp *keypair.Full) (*keypair.Full, []block.BlockOperation, error) {
-	kp, btList, err := prepareTxs(storage, blockHeight, count, kp)
+func prepareOps(storage *storage.LevelDBBackend, count int, kp *keypair.Full) (*keypair.Full, []block.BlockOperation, error) {
+	kp, btList, err := prepareTxs(storage, count, kp)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,7 +52,7 @@ func prepareOps(storage *storage.LevelDBBackend, blockHeight uint64, count int, 
 
 	return kp, boList, nil
 }
-func prepareOpsWithoutSave(blockHeight uint64, count int, kp *keypair.Full) (*keypair.Full, []block.BlockOperation, error) {
+func prepareOpsWithoutSave(count int, kp *keypair.Full) (*keypair.Full, []block.BlockOperation, error) {
 
 	var err error
 	if kp == nil {
@@ -71,7 +71,6 @@ func prepareOpsWithoutSave(blockHeight uint64, count int, kp *keypair.Full) (*ke
 	}
 
 	theBlock := block.TestMakeNewBlock(txHashes)
-	theBlock.Height += blockHeight
 	for _, tx := range txs {
 		for _, op := range tx.B.Operations {
 			bo, err := block.NewBlockOperationFromOperation(op, tx, theBlock.Height)
@@ -85,7 +84,7 @@ func prepareOpsWithoutSave(blockHeight uint64, count int, kp *keypair.Full) (*ke
 	return kp, boList, nil
 }
 
-func prepareTxs(storage *storage.LevelDBBackend, blockHeight uint64, count int, kp *keypair.Full) (*keypair.Full, []block.BlockTransaction, error) {
+func prepareTxs(storage *storage.LevelDBBackend, count int, kp *keypair.Full) (*keypair.Full, []block.BlockTransaction, error) {
 	var err error
 	if kp == nil {
 		kp, err = keypair.Random()
@@ -103,7 +102,6 @@ func prepareTxs(storage *storage.LevelDBBackend, blockHeight uint64, count int, 
 	}
 
 	theBlock := block.TestMakeNewBlock(txHashes)
-	theBlock.Height += blockHeight
 	err = theBlock.Save(storage)
 	if err != nil {
 		return nil, nil, err
@@ -123,7 +121,7 @@ func prepareTxs(storage *storage.LevelDBBackend, blockHeight uint64, count int, 
 	return kp, btList, nil
 }
 
-func prepareTxsWithoutSave(blockHeight uint64, count int, kp *keypair.Full) (*keypair.Full, []block.BlockTransaction, error) {
+func prepareTxsWithoutSave(count int, kp *keypair.Full) (*keypair.Full, []block.BlockTransaction, error) {
 	var err error
 	if kp == nil {
 		kp, err = keypair.Random()
@@ -141,7 +139,6 @@ func prepareTxsWithoutSave(blockHeight uint64, count int, kp *keypair.Full) (*ke
 	}
 
 	theBlock := block.TestMakeNewBlock(txHashes)
-	theBlock.Height += blockHeight
 	for _, tx := range txs {
 		a, err := tx.Serialize()
 		if err != nil {

--- a/lib/node/runner/api/transaction_test.go
+++ b/lib/node/runner/api/transaction_test.go
@@ -111,7 +111,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	_, btList, err := prepareTxs(storage, 0, 10, nil)
+	_, btList, err := prepareTxs(storage, 10, nil)
 	require.NoError(t, err)
 
 	var reader *bufio.Reader
@@ -154,7 +154,7 @@ func TestGetTransactionsHandlerStream(t *testing.T) {
 
 	kp, err := keypair.Random()
 	require.NoError(t, err)
-	_, btList, err := prepareTxsWithoutSave(0, 10, kp)
+	_, btList, err := prepareTxsWithoutSave(10, kp)
 	require.NoError(t, err)
 	btMap := make(map[string]block.BlockTransaction)
 	for _, bt := range btList {
@@ -212,7 +212,7 @@ func TestGetTransactionsByAccountHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, btList, err := prepareTxs(storage, 0, 10, nil)
+	kp, btList, err := prepareTxs(storage, 10, nil)
 	require.NoError(t, err)
 
 	// Do a Request
@@ -255,7 +255,7 @@ func TestGetTransactionsByAccountHandlerStream(t *testing.T) {
 	defer ts.Close()
 
 	btMap := make(map[string]block.BlockTransaction)
-	kp, btList, err := prepareTxsWithoutSave(0, 10, nil)
+	kp, btList, err := prepareTxsWithoutSave(10, nil)
 	require.NoError(t, err)
 	for _, bt := range btList {
 		btMap[bt.Hash] = bt
@@ -313,7 +313,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	_, btList, err := prepareTxs(storage, 0, 10, nil)
+	_, btList, err := prepareTxs(storage, 10, nil)
 	require.NoError(t, err)
 
 	requestFunction := func(url string) ([]interface{}, map[string]interface{}) {

--- a/lib/node/runner/api/transaction_test.go
+++ b/lib/node/runner/api/transaction_test.go
@@ -13,7 +13,6 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 )
 
@@ -111,7 +110,7 @@ func TestGetTransactionsHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	_, btList, err := prepareTxs(storage, 10, nil)
+	_, btList, err := prepareTxs(storage, 10)
 	require.NoError(t, err)
 
 	var reader *bufio.Reader
@@ -152,9 +151,7 @@ func TestGetTransactionsHandlerStream(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, err := keypair.Random()
-	require.NoError(t, err)
-	_, btList, err := prepareTxsWithoutSave(10, kp)
+	_, btList, err := prepareTxsWithoutSave(10)
 	require.NoError(t, err)
 	btMap := make(map[string]block.BlockTransaction)
 	for _, bt := range btList {
@@ -212,7 +209,7 @@ func TestGetTransactionsByAccountHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, btList, err := prepareTxs(storage, 10, nil)
+	kp, btList, err := prepareTxs(storage, 10)
 	require.NoError(t, err)
 
 	// Do a Request
@@ -255,7 +252,7 @@ func TestGetTransactionsByAccountHandlerStream(t *testing.T) {
 	defer ts.Close()
 
 	btMap := make(map[string]block.BlockTransaction)
-	kp, btList, err := prepareTxsWithoutSave(10, nil)
+	kp, btList, err := prepareTxsWithoutSave(10)
 	require.NoError(t, err)
 	for _, bt := range btList {
 		btMap[bt.Hash] = bt
@@ -313,7 +310,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	_, btList, err := prepareTxs(storage, 10, nil)
+	_, btList, err := prepareTxs(storage, 10)
 	require.NoError(t, err)
 
 	requestFunction := func(url string) ([]interface{}, map[string]interface{}) {

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -25,7 +25,7 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	_, btList, err := prepareTxs(storage, 0, 1, nil)
+	_, btList, err := prepareTxs(storage, 1, nil)
 	require.NoError(t, err)
 
 	bt := btList[0]

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -25,7 +25,7 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	_, btList, err := prepareTxs(storage, 1, nil)
+	_, btList, err := prepareTxs(storage, 1)
 	require.NoError(t, err)
 
 	bt := btList[0]


### PR DESCRIPTION
While working on frozen transaction, I realize most test code was breaking some of our invariants.
For example many places test code without a genesis block, which is a scenario we'll never have in a real-world scenario. Likewise, the blocks might not be correctly linked.
That makes any kind of change rather hard to do, as it ends up breaking seemingly unrelated places.
Here's a few improvement to test code which was actually breaking some of those invariants.