### PR TITLE
Allow the additional tags in 'Content-Type' header like 'charset'

### DIFF
--- a/lib/common/router.go
+++ b/lib/common/router.go
@@ -2,13 +2,23 @@ package common
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 )
 
 func PostAndJSONMatcher(r *http.Request, rm *mux.RouteMatch) bool {
 	if r.Method == "POST" {
-		if r.Header.Get("Content-Type") != "application/json" {
+		ct := r.Header.Get("Content-Type")
+		if len(strings.TrimSpace(ct)) < 1 {
+			return false
+		}
+		spl := strings.SplitN(ct, ";", 2)
+		if len(spl) == 2 {
+			ct = spl[0]
+		}
+
+		if strings.TrimSpace(ct) != "application/json" {
 			return false
 		}
 	}


### PR DESCRIPTION
### Github Issue
resolves #590 

### Background

Wallet client are suffering this problem, #590 

### Solution

`common.PostAndJSONMatcher()` patched.