### PR TITLE
Use MessageType in messages and remove T in Tx

### DIFF
--- a/cmd/sebak/cmd/wallet/payment.go
+++ b/cmd/sebak/cmd/wallet/payment.go
@@ -188,7 +188,6 @@ func makeTransactionCreateAccount(kpSource keypair.KP, kpDest keypair.KP, amount
 	}
 
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
@@ -232,7 +231,6 @@ func makeTransactionPayment(kpSource keypair.KP, kpDest keypair.KP, amount commo
 	}
 
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),

--- a/cmd/sebak/cmd/wallet/unfreezeRequest.go
+++ b/cmd/sebak/cmd/wallet/unfreezeRequest.go
@@ -136,7 +136,6 @@ func makeTransactionUnfreezingRequest(kpSource keypair.KP, seqid uint64) transac
 	}
 
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),

--- a/lib/ballot/ballot.go
+++ b/lib/ballot/ballot.go
@@ -49,7 +49,7 @@ func NewBallotFromJSON(data []byte) (b Ballot, err error) {
 	return
 }
 
-func (b Ballot) GetType() string {
+func (b Ballot) GetType() common.MessageType {
 	return common.BallotMessage
 }
 

--- a/lib/block/genesis.go
+++ b/lib/block/genesis.go
@@ -92,7 +92,6 @@ func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, c
 	}
 
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.GenesisBlockConfirmedTime,
 			Hash:    txBody.MakeHashString(),

--- a/lib/common/message.go
+++ b/lib/common/message.go
@@ -6,9 +6,9 @@ import (
 )
 
 const (
-	ConnectMessage                 = "connect"
+	ConnectMessage     MessageType = "connect"
 	TransactionMessage MessageType = "transaction"
-	BallotMessage                  = "ballot"
+	BallotMessage      MessageType = "ballot"
 )
 
 type MessageType string
@@ -18,7 +18,7 @@ func (t MessageType) String() string {
 }
 
 type Message interface {
-	GetType() string
+	GetType() MessageType
 	GetHash() string
 	Serialize() ([]byte, error)
 	IsWellFormed([]byte, Config) error

--- a/lib/network/memory_test.go
+++ b/lib/network/memory_test.go
@@ -12,13 +12,12 @@ import (
 )
 
 type DummyMessage struct {
-	T    string
 	Hash string
 	Data string
 }
 
 func NewDummyMessage(data string) DummyMessage {
-	d := DummyMessage{T: "dummy-message", Data: data}
+	d := DummyMessage{Data: data}
 	d.UpdateHash()
 
 	return d
@@ -28,8 +27,8 @@ func (m DummyMessage) IsWellFormed([]byte, common.Config) error {
 	return nil
 }
 
-func (m DummyMessage) GetType() string {
-	return m.T
+func (m DummyMessage) GetType() common.MessageType {
+	return common.MessageType("dummy-message")
 }
 
 func (m DummyMessage) Equal(n common.Message) bool {

--- a/lib/network/validator_connection_manager.go
+++ b/lib/network/validator_connection_manager.go
@@ -201,7 +201,7 @@ func (c *ValidatorConnectionManager) Broadcast(message common.Message) {
 				var response []byte
 				if message.GetType() == common.BallotMessage {
 					response, err = client.SendBallot(message)
-				} else if message.GetType() == string(common.TransactionMessage) {
+				} else if message.GetType() == common.TransactionMessage {
 					response, err = client.SendMessage(message)
 				} else {
 					panic("invalid message")

--- a/lib/node/runner/checker_ballot_transaction_test.go
+++ b/lib/node/runner/checker_ballot_transaction_test.go
@@ -34,7 +34,6 @@ func TestValidateTxPaymentMissingBlockAccount(t *testing.T) {
 	defer st.Close()
 
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 		},
@@ -99,7 +98,6 @@ func TestValidateTxWrongSequenceID(t *testing.T) {
 	bat.MustSave(st)
 
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 		},
@@ -144,7 +142,6 @@ func TestValidateTxOverBalance(t *testing.T) {
 
 	opbody := operation.Payment{Target: kpt.Address(), Amount: bas.Balance}
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 		},
@@ -201,7 +198,6 @@ func TestValidateOpCreateExistsAccount(t *testing.T) {
 	bas.MustSave(st)
 
 	tx := transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 		},

--- a/lib/node/runner/node_runner_memory_network_test.go
+++ b/lib/node/runner/node_runner_memory_network_test.go
@@ -20,7 +20,6 @@ func makeTransaction(kp *keypair.Full) (tx transaction.Transaction) {
 	}
 
 	tx = transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
@@ -50,7 +49,6 @@ func makeTransactionPayment(kpSource *keypair.Full, target string, amount common
 	}
 
 	tx = transaction.Transaction{
-		T: "transaction",
 		H: transaction.Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),

--- a/lib/transaction/test.go
+++ b/lib/transaction/test.go
@@ -72,7 +72,6 @@ func MakeTransactionCreateAccount(kpSource *keypair.Full, target string, amount 
 	}
 
 	tx = Transaction{
-		T: "transaction",
 		H: Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
@@ -101,7 +100,6 @@ func MakeTransactionCreateFrozenAccount(kpSource *keypair.Full, target string, a
 	}
 
 	tx = Transaction{
-		T: "transaction",
 		H: Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
@@ -129,7 +127,6 @@ func MakeTransactionUnfreezingRequest(kpSource *keypair.Full) (tx Transaction) {
 	}
 
 	tx = Transaction{
-		T: "transaction",
 		H: Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
@@ -158,7 +155,6 @@ func MakeTransactionUnfreezing(kpSource *keypair.Full, target string, amount com
 	}
 
 	tx = Transaction{
-		T: "transaction",
 		H: Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -14,7 +14,6 @@ import (
 // TODO versioning
 
 type Transaction struct {
-	T string
 	H Header
 	B Body
 }
@@ -56,7 +55,6 @@ func (t *Transaction) UnmarshalJSON(b []byte) (err error) {
 		return
 	}
 
-	t.T = tj.T
 	t.H = tj.H
 	t.B = tj.B
 	t.H.Hash = t.B.MakeHashString()
@@ -77,7 +75,6 @@ func NewTransaction(source string, sequenceID uint64, ops ...operation.Operation
 	}
 
 	tx = Transaction{
-		T: "transaction",
 		H: Header{
 			Created: common.NowISO8601(),
 			Hash:    txBody.MakeHashString(),
@@ -117,8 +114,8 @@ func (tx Transaction) IsWellFormed(networkID []byte, conf common.Config) (err er
 	return
 }
 
-func (tx Transaction) GetType() string {
-	return tx.T
+func (tx Transaction) GetType() common.MessageType {
+	return common.TransactionMessage
 }
 
 func (tx Transaction) Equal(m common.Message) bool {


### PR DESCRIPTION
Because of code consistency
The other messages(ballot, operation) don't have T.