### PR TITLE
Fix typo commitable -> committable

### DIFF
--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -79,5 +79,5 @@ var (
 	ErrorTooManyRequests                           = NewError(172, "too many requests; reached limit")
 	ErrorHTTPServerError                           = NewError(173, "Internal Server Error")
 	ErrorBlockTransactionHistoryDoesNotExists      = NewError(174, "transaction history does not exists in block")
-	ErrorNotCommittableCore                        = NewError(175, "not CommittableCore")
+	ErrorNotCommittable                            = NewError(175, "not Committable")
 )

--- a/lib/error/errors.go
+++ b/lib/error/errors.go
@@ -79,5 +79,5 @@ var (
 	ErrorTooManyRequests                           = NewError(172, "too many requests; reached limit")
 	ErrorHTTPServerError                           = NewError(173, "Internal Server Error")
 	ErrorBlockTransactionHistoryDoesNotExists      = NewError(174, "transaction history does not exists in block")
-	ErrorNotCommitableCore                         = NewError(175, "not CommittableBackend")
+	ErrorNotCommittableCore                        = NewError(175, "not CommittableCore")
 )

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -573,7 +573,7 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) (err error) {
 		}
 
 		if err = bs.Commit(); err != nil {
-			if err != errors.ErrorNotCommitableCore {
+			if err != errors.ErrorNotCommittableCore {
 				bs.Discard()
 				return
 			}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -573,7 +573,7 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) (err error) {
 		}
 
 		if err = bs.Commit(); err != nil {
-			if err != errors.ErrorNotCommittableCore {
+			if err != errors.ErrorNotCommittable {
 				bs.Discard()
 				return
 			}

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -97,10 +97,10 @@ func (st *LevelDBBackend) OpenBatch() (*LevelDBBackend, error) {
 }
 
 func (st *LevelDBBackend) Discard() error {
-	var committable CommitableCore
+	var committable CommittableCore
 	var ok bool
-	if committable, ok = st.Core.(CommitableCore); !ok {
-		return errors.ErrorNotCommitableCore
+	if committable, ok = st.Core.(CommittableCore); !ok {
+		return errors.ErrorNotCommittableCore
 	}
 
 	committable.Discard()
@@ -109,10 +109,10 @@ func (st *LevelDBBackend) Discard() error {
 }
 
 func (st *LevelDBBackend) Commit() error {
-	var committable CommitableCore
+	var committable CommittableCore
 	var ok bool
-	if committable, ok = st.Core.(CommitableCore); !ok {
-		return errors.ErrorNotCommitableCore
+	if committable, ok = st.Core.(CommittableCore); !ok {
+		return errors.ErrorNotCommittableCore
 	}
 
 	return setLevelDBCoreError(committable.Commit())

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -97,10 +97,10 @@ func (st *LevelDBBackend) OpenBatch() (*LevelDBBackend, error) {
 }
 
 func (st *LevelDBBackend) Discard() error {
-	var committable CommittableCore
+	var committable Committable
 	var ok bool
-	if committable, ok = st.Core.(CommittableCore); !ok {
-		return errors.ErrorNotCommittableCore
+	if committable, ok = st.Core.(Committable); !ok {
+		return errors.ErrorNotCommittable
 	}
 
 	committable.Discard()
@@ -109,10 +109,10 @@ func (st *LevelDBBackend) Discard() error {
 }
 
 func (st *LevelDBBackend) Commit() error {
-	var committable CommittableCore
+	var committable Committable
 	var ok bool
-	if committable, ok = st.Core.(CommittableCore); !ok {
-		return errors.ErrorNotCommittableCore
+	if committable, ok = st.Core.(Committable); !ok {
+		return errors.ErrorNotCommittable
 	}
 
 	return setLevelDBCoreError(committable.Commit())

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -95,7 +95,7 @@ func ParseConfig(s string) (u *Config, err error) {
 	return
 }
 
-type CommittableCore interface {
+type Committable interface {
 	Discard()
 	Commit() error
 }

--- a/lib/storage/storage.go
+++ b/lib/storage/storage.go
@@ -95,7 +95,7 @@ func ParseConfig(s string) (u *Config, err error) {
 	return
 }
 
-type CommitableCore interface {
+type CommittableCore interface {
 	Discard()
 	Commit() error
 }


### PR DESCRIPTION
Modify error type `ErrorNotCommitableCore` -> `ErrorNotCommittableCore`
Modify error message NewError(175, "not CommittableBackend") -> NewError(175, "not CommittableCore)