### PR TITLE
Exclude `BlockOperation` from block API

### DIFF
--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -19,7 +19,6 @@ const (
 	NodeItemBlock            NodeItemDataType = "block"
 	NodeItemBlockHeader      NodeItemDataType = "block-header"
 	NodeItemBlockTransaction NodeItemDataType = "block-transaction"
-	NodeItemBlockOperation   NodeItemDataType = "block-operation"
 	NodeItemTransaction      NodeItemDataType = "transaction"
 	NodeItemError            NodeItemDataType = "error"
 )
@@ -122,7 +121,6 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 		if options.Mode == GetBlocksOptionsModeFull {
 			var err error
 			var tx block.BlockTransaction
-			var op block.BlockOperation
 
 			if tx, err = block.GetBlockTransaction(nh.storage, b.ProposerTransaction); err != nil {
 				nh.renderNodeItem(w, NodeItemError, err)
@@ -135,14 +133,6 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 					continue
 				}
 				nh.renderNodeItem(w, NodeItemBlockTransaction, tx)
-
-				for _, opHash := range tx.Operations {
-					if op, err = block.GetBlockOperation(nh.storage, opHash); err != nil {
-						nh.renderNodeItem(w, NodeItemError, err)
-						continue
-					}
-					nh.renderNodeItem(w, NodeItemBlockOperation, op)
-				}
 			}
 		}
 	}
@@ -177,10 +167,6 @@ func UnmarshalNodeItemResponse(d []byte) (itemType NodeItemDataType, b interface
 		b = t
 	case NodeItemBlockTransaction:
 		var t block.BlockTransaction
-		err = unmarshal(&t)
-		b = t
-	case NodeItemBlockOperation:
-		var t block.BlockOperation
 		err = unmarshal(&t)
 		b = t
 	case NodeItemTransaction:

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -593,39 +593,6 @@ func TestGetBlocksHandlerWithModeFull(t *testing.T) {
 			expectedNumberOfTransactions += len(b.Transactions)
 		}
 		require.Equal(t, expectedNumberOfTransactions, len(rbs[NodeItemBlockTransaction]))
-
-		var expectedNumberOfOperations int
-		var txInxdex int
-		var opInxdex int
-		for _, b := range p.blocks {
-			for _, txHash := range b.Transactions {
-				tx, _ := block.GetBlockTransaction(p.st, txHash)
-				expectedNumberOfOperations += len(tx.Operations)
-
-				rtx := rbs[NodeItemBlockTransaction][txInxdex].(block.BlockTransaction)
-				require.Equal(t, tx.Hash, rtx.Hash)
-
-				s, _ := tx.Serialize()
-				rs, _ := rtx.Serialize()
-				require.Equal(t, s, rs)
-
-				for _, opHash := range tx.Operations {
-					op, _ := block.GetBlockOperation(p.st, opHash)
-
-					rop := rbs[NodeItemBlockOperation][opInxdex].(block.BlockOperation)
-					require.Equal(t, op.Hash, rop.Hash)
-
-					s, _ := op.Serialize()
-					rs, _ := rop.Serialize()
-					require.Equal(t, s, rs)
-
-					opInxdex++
-				}
-
-				txInxdex++
-			}
-		}
-		require.Equal(t, expectedNumberOfOperations, len(rbs[NodeItemBlockOperation]))
 	}
 }
 


### PR DESCRIPTION
### Background

In full mode of block API(`/node/blocks`), this PR will not return `BlockOperation`s, because `Syncer` does not use this data.