### PR TITLE
Save Transaction before `finishBallot()`

### DIFF
--- a/lib/block/genesis.go
+++ b/lib/block/genesis.go
@@ -117,9 +117,12 @@ func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, c
 		return
 	}
 
-	raw, _ := tx.Serialize()
-	bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx, raw)
+	bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx)
 	if err = bt.Save(st); err != nil {
+		return
+	}
+
+	if _, err = SaveTransactionPool(st, tx); err != nil {
 		return
 	}
 

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -3,12 +3,12 @@ package block
 import (
 	"testing"
 
-	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 
-	"boscoin.io/sebak/lib/transaction"
 	"github.com/stretchr/testify/require"
+
+	"boscoin.io/sebak/lib/transaction"
 )
 
 func TestNewBlockOperationFromOperation(t *testing.T) {
@@ -102,7 +102,7 @@ func TestBlockOperationSaveByTransaction(t *testing.T) {
 
 	_, tx := transaction.TestMakeTransaction(networkID, 10)
 	block := TestMakeNewBlockWithPrevBlock(GetLatestBlock(st), []string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, common.MustJSONMarshal(tx))
+	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 	err := bt.Save(st)
 	require.NoError(t, err)
 

--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -43,7 +43,7 @@ type BlockTransaction struct {
 	blockHeight uint64
 }
 
-func NewBlockTransactionFromTransaction(blockHash string, blockHeight uint64, confirmed string, tx transaction.Transaction, message []byte) BlockTransaction {
+func NewBlockTransactionFromTransaction(blockHash string, blockHeight uint64, confirmed string, tx transaction.Transaction) BlockTransaction {
 	var opHashes []string
 	for _, op := range tx.B.Operations {
 		opHashes = append(opHashes, NewBlockOperationKey(op.MakeHashString(), tx.GetHash()))
@@ -61,7 +61,6 @@ func NewBlockTransactionFromTransaction(blockHash string, blockHeight uint64, co
 
 		Confirmed: confirmed,
 		Created:   tx.H.Created,
-		Message:   message,
 
 		transaction: tx,
 
@@ -159,7 +158,7 @@ func (bt *BlockTransaction) Save(st *storage.LevelDBBackend) (err error) {
 	observer.BlockTransactionObserver.Trigger(event, bt)
 	bt.isSaved = true
 
-	if err = SaveTransactionHistory(st, bt.transaction, bt.Message, TransactionHistoryStatusConfirmed); err != nil {
+	if err = SaveTransactionHistory(st, bt.transaction, TransactionHistoryStatusConfirmed); err != nil {
 		return
 	}
 

--- a/lib/block/transaction_history.go
+++ b/lib/block/transaction_history.go
@@ -32,22 +32,20 @@ type BlockTransactionHistory struct {
 	Time    string `json:"time"`
 	Created string `json:"created"`
 	Status  string `json:"status"`
-	Message string `json:"message"`
 }
 
-func NewTransactionHistoryFromTransaction(tx transaction.Transaction, message []byte) BlockTransactionHistory {
+func NewTransactionHistoryFromTransaction(tx transaction.Transaction) BlockTransactionHistory {
 	return BlockTransactionHistory{
 		Hash:    tx.H.Hash,
 		Source:  tx.B.Source,
 		Created: tx.H.Created,
-		Message: string(message),
 	}
 }
 
-func SaveTransactionHistory(st *storage.LevelDBBackend, tx transaction.Transaction, message []byte, status string) (err error) {
+func SaveTransactionHistory(st *storage.LevelDBBackend, tx transaction.Transaction, status string) (err error) {
 	bth, err := GetBlockTransactionHistory(st, tx.H.Hash)
 	if err != nil {
-		bth = NewTransactionHistoryFromTransaction(tx, message)
+		bth = NewTransactionHistoryFromTransaction(tx)
 	}
 	if bth.Status != "" && bth.Status != TransactionHistoryStatusSubmitted {
 		// Only TransactionHistoryStatusSubmitted can be changed

--- a/lib/block/transaction_pool.go
+++ b/lib/block/transaction_pool.go
@@ -1,0 +1,109 @@
+package block
+
+import (
+	"fmt"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
+)
+
+// TransactionPool is not `transaction.Pool`; this contains the all the valid
+// transactions. The unconfirmed transactions of `TransactionPool` can be
+// removed, but confirmed transactions must be here.
+//
+// NOTE The sync process must store the confirmed transactions.
+type TransactionPool struct {
+	Hash    string `json:"hash"`
+	Message []byte `json:"message"`
+
+	transaction transaction.Transaction
+}
+
+func NewTransactionPool(tx transaction.Transaction) (tp TransactionPool, err error) {
+	var b []byte
+	if b, err = common.EncodeJSONValue(tx); err != nil {
+		return
+	}
+
+	return TransactionPool{
+		Hash:    tx.GetHash(),
+		Message: b,
+	}, nil
+}
+
+func GetTransactionPoolKey(hash string) string {
+	return fmt.Sprintf("%s%s", common.TransactionPoolPrefix, hash)
+}
+
+func (tp TransactionPool) Save(st *storage.LevelDBBackend) (err error) {
+	key := GetTransactionPoolKey(tp.Hash)
+
+	var exists bool
+	if exists, err = st.Has(key); exists || err != nil {
+		if exists {
+			return errors.BlockAlreadyExists
+		}
+		return
+	}
+
+	if err = st.New(key, tp); err != nil {
+		return
+	}
+
+	return nil
+}
+
+func (tp TransactionPool) Serialize() ([]byte, error) {
+	return common.EncodeJSONValue(tp)
+}
+
+func (tp TransactionPool) String() string {
+	encoded, _ := common.EncodeJSONValue(tp)
+	return string(encoded)
+}
+
+func (tp TransactionPool) Transaction() transaction.Transaction {
+	if tp.transaction.IsEmpty() {
+		var tx transaction.Transaction
+		if err := common.DecodeJSONValue(tp.Message, &tx); err != nil {
+			return tx
+		}
+
+		tp.transaction = tx
+	}
+
+	return tp.transaction
+}
+
+func ExistsTransactionPool(st *storage.LevelDBBackend, hash string) (bool, error) {
+	return st.Has(GetTransactionPoolKey(hash))
+}
+
+func GetTransactionPool(st *storage.LevelDBBackend, hash string) (tp TransactionPool, err error) {
+	err = st.Get(GetTransactionPoolKey(hash), &tp)
+	return
+}
+
+func DeleteTransactionPool(st *storage.LevelDBBackend, hash string) error {
+	return st.Remove(GetTransactionPoolKey(hash))
+}
+
+func SaveTransactionPool(st *storage.LevelDBBackend, tx transaction.Transaction) (tp TransactionPool, err error) {
+	if tp, err = NewTransactionPool(tx); err != nil {
+		return
+	}
+
+	err = tp.Save(st)
+	if err == nil {
+		return
+	}
+
+	if err == errors.BlockAlreadyExists {
+		err = nil
+		return
+	}
+
+	return
+}

--- a/lib/block/transaction_pool_test.go
+++ b/lib/block/transaction_pool_test.go
@@ -1,0 +1,47 @@
+package block
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
+)
+
+func TestTransactionPool(t *testing.T) {
+	st := storage.NewTestStorage()
+
+	_, tx := transaction.TestMakeTransaction(networkID, 1)
+
+	var tp TransactionPool
+	var err error
+	tp, err = NewTransactionPool(tx)
+	require.NoError(t, err)
+
+	{ // save
+		err = tp.Save(st)
+		require.NoError(t, err)
+	}
+
+	{ // get
+		rtp, err := GetTransactionPool(st, tx.GetHash())
+		require.NoError(t, err)
+		require.Equal(t, rtp.Hash, tx.GetHash())
+
+		b, _ := common.EncodeJSONValue(tx)
+		require.Equal(t, rtp.Message, b)
+	}
+
+	{ // delete
+		err = DeleteTransactionPool(st, tx.GetHash())
+		require.NoError(t, err)
+	}
+
+	{ // get; it must be failed
+		_, err := GetTransactionPool(st, tx.GetHash())
+		require.Error(t, err, errors.StorageRecordDoesNotExist)
+	}
+}

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -14,9 +14,8 @@ import (
 
 func TestNewBlockTransaction(t *testing.T) {
 	_, tx := transaction.TestMakeTransaction(networkID, 1)
-	a, _ := tx.Serialize()
 	block := TestMakeNewBlock([]string{tx.GetHash()})
-	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 
 	require.Equal(t, bt.Hash, tx.H.Hash)
 	require.Equal(t, bt.SequenceID, tx.B.SequenceID)
@@ -33,7 +32,6 @@ func TestNewBlockTransaction(t *testing.T) {
 		require.Equal(t, opHash, opHashes[i])
 	}
 	require.Equal(t, bt.Amount, tx.TotalAmount(true))
-	require.Equal(t, bt.Message, a)
 }
 
 func TestBlockTransactionSaveAndGet(t *testing.T) {
@@ -92,8 +90,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 		err := bt.Save(st)
 		require.NoError(t, err)
 	}
@@ -109,8 +106,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 		err := bt.Save(st)
 		require.NoError(t, err)
 	}
@@ -175,8 +171,7 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 		err := bt.Save(st)
 		require.NoError(t, err)
 	}
@@ -255,8 +250,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 
 	block := TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 		bt.MustSave(st)
 	}
 
@@ -272,8 +266,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 		bt.MustSave(st)
 	}
 
@@ -288,8 +281,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 
 	block = TestMakeNewBlock(txHashes)
 	for _, tx := range txs {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 		bt.MustSave(st)
 	}
 
@@ -331,8 +323,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 
 	block0 := TestMakeNewBlock(txHashes0)
 	for _, tx := range txs0 {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block0.Hash, block0.Height, block0.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block0.Hash, block0.Height, block0.Confirmed, tx)
 		bt.MustSave(st)
 	}
 
@@ -348,8 +339,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 
 	block1 := TestMakeNewBlock(txHashes1)
 	for _, tx := range txs1 {
-		a, _ := tx.Serialize()
-		bt := NewBlockTransactionFromTransaction(block1.Hash, block1.Height, block1.Confirmed, tx, a)
+		bt := NewBlockTransactionFromTransaction(block1.Hash, block1.Height, block1.Confirmed, tx)
 		bt.MustSave(st)
 	}
 
@@ -416,8 +406,7 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		block := TestMakeNewBlock(txHashes)
 		block.Height++
 		for _, tx := range txs {
-			a, _ := tx.Serialize()
-			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 			bt.MustSave(st)
 		}
 		transactionOrder = append(transactionOrder, createdOrder...)
@@ -438,8 +427,7 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 
 		block := TestMakeNewBlock(txHashes)
 		for _, tx := range txs {
-			a, _ := tx.Serialize()
-			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+			bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 			bt.MustSave(st)
 		}
 
@@ -500,6 +488,5 @@ func makeNewBlockTransaction(networkID []byte, n int) BlockTransaction {
 	_, tx := transaction.TestMakeTransaction(networkID, n)
 
 	block := TestMakeNewBlock([]string{tx.GetHash()})
-	a, _ := tx.Serialize()
-	return NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx, a)
+	return NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 }

--- a/lib/common/prefix.go
+++ b/lib/common/prefix.go
@@ -18,4 +18,5 @@ const (
 	BlockAccountPrefixCreated             = string(0x31)
 	BlockAccountSequenceIDPrefix          = string(0x32)
 	BlockAccountSequenceIDByAddressPrefix = string(0x33)
+	TransactionPoolPrefix                 = string(0x40)
 )

--- a/lib/node/runner/api/resource/resource_test.go
+++ b/lib/node/runner/api/resource/resource_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResourceAccount(t *testing.T) {
@@ -42,9 +43,7 @@ func TestResourceAccount(t *testing.T) {
 	// Transaction
 	{
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
-		a, err := tx.Serialize()
-		require.NoError(t, err)
-		bt := block.NewBlockTransactionFromTransaction("dummy", 0, common.NowISO8601(), tx, a)
+		bt := block.NewBlockTransactionFromTransaction("dummy", 0, common.NowISO8601(), tx)
 		bt.MustSave(storage)
 
 		rt := NewTransaction(&bt)
@@ -70,11 +69,9 @@ func TestResourceAccount(t *testing.T) {
 	// Operation
 	{
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 1)
-		a, err := tx.Serialize()
-		require.NoError(t, err)
-		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
+		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx)
 		bt.MustSave(storage)
-		bo, err := block.GetBlockOperation(storage, bt.Operations[0])
+		bo, _ := block.GetBlockOperation(storage, bt.Operations[0])
 
 		ro := NewOperation(&bo)
 		r := ro.Resource()
@@ -95,12 +92,11 @@ func TestResourceAccount(t *testing.T) {
 	// List
 	{
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 3)
-		a, err := tx.Serialize()
-		require.NoError(t, err)
-		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx, a)
+		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx)
 		bt.MustSave(storage)
 
 		var rol []Resource
+		var err error
 		for _, boHash := range bt.Operations {
 			var bo block.BlockOperation
 			bo, err = block.GetBlockOperation(storage, boHash)

--- a/lib/node/runner/api/resource/transaction_history.go
+++ b/lib/node/runner/api/resource/transaction_history.go
@@ -3,8 +3,9 @@ package resource
 import (
 	"strings"
 
-	"boscoin.io/sebak/lib/block"
 	"github.com/nvellon/hal"
+
+	"boscoin.io/sebak/lib/block"
 )
 
 type TransactionHistory struct {
@@ -25,7 +26,6 @@ func (t TransactionHistory) GetMap() hal.Entry {
 		"confirmed": t.bt.Time,
 		"created":   t.bt.Created,
 		"status":    t.bt.Status,
-		"message":   t.bt.Message,
 	}
 }
 func (t TransactionHistory) Resource() *hal.Resource {

--- a/lib/node/runner/api/test.go
+++ b/lib/node/runner/api/test.go
@@ -5,11 +5,12 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/gorilla/mux"
+	"github.com/stellar/go/keypair"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
-	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
 )
 
 var networkID []byte = []byte("sebak-test-network")
@@ -101,11 +102,7 @@ func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, []bl
 		return nil, nil, err
 	}
 	for _, tx := range txs {
-		a, err := tx.Serialize()
-		if err != nil {
-			return nil, nil, err
-		}
-		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx)
 		err = bt.Save(storage)
 		if err != nil {
 			return nil, nil, err
@@ -131,11 +128,7 @@ func prepareTxsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full
 
 	theBlock := block.TestMakeNewBlockWithPrevBlock(block.GetLatestBlock(st), txHashes)
 	for _, tx := range txs {
-		a, err := tx.Serialize()
-		if err != nil {
-			return nil, nil, err
-		}
-		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx, a)
+		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx)
 		btList = append(btList, bt)
 	}
 	return kp, btList, nil
@@ -148,13 +141,9 @@ func prepareTxWithoutSave(st *storage.LevelDBBackend) (*keypair.Full, *transacti
 	}
 
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
-	a, err := tx.Serialize()
-	if err != nil {
-		return nil, nil, nil, err
-	}
 
 	theBlock := block.TestMakeNewBlockWithPrevBlock(block.GetLatestBlock(st), []string{tx.GetHash()})
-	bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx, a)
+	bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx)
 	return kp, &tx, &bt, nil
 }
 

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -10,13 +10,14 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/transaction"
-	"github.com/stellar/go/keypair"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetOperationsByTxHashHandler(t *testing.T) {
@@ -79,7 +80,7 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	require.NoError(t, err)
 
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 10, kp)
-	bt := block.NewBlockTransactionFromTransaction("block-hash", 1, common.NowISO8601(), tx, nil)
+	bt := block.NewBlockTransactionFromTransaction("block-hash", 1, common.NowISO8601(), tx)
 
 	boMap := make(map[string]block.BlockOperation)
 	for _, op := range tx.B.Operations {

--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -121,10 +121,14 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 		if options.Mode == GetBlocksOptionsModeFull {
 			var err error
 			var tx block.BlockTransaction
+			var tp block.TransactionPool
 
 			if tx, err = block.GetBlockTransaction(nh.storage, b.ProposerTransaction); err != nil {
 				nh.renderNodeItem(w, NodeItemError, err)
+			} else if tp, err = block.GetTransactionPool(nh.storage, tx.Hash); err != nil {
+				nh.renderNodeItem(w, NodeItemError, err)
 			} else {
+				tx.Message = tp.Message
 				nh.renderNodeItem(w, NodeItemBlockTransaction, tx)
 			}
 			for _, t := range b.Transactions {

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -57,8 +57,7 @@ func (p *HelperTestGetBlocksHandler) createBlock() block.Block {
 	bk.MustSave(p.st)
 
 	for _, tx := range txs {
-		b, _ := tx.Serialize()
-		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx, b)
+		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx)
 		btx.MustSave(p.st)
 	}
 

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -126,7 +126,7 @@ func (api NetworkHandlerNode) MessageHandler(w http.ResponseWriter, r *http.Requ
 
 	if err = common.RunChecker(checker, common.DefaultDeferFunc); err != nil {
 		if len(checker.Transaction.H.Hash) > 0 {
-			block.SaveTransactionHistory(api.storage, checker.Transaction, body, block.TransactionHistoryStatusRejected)
+			block.SaveTransactionHistory(api.storage, checker.Transaction, block.TransactionHistoryStatusRejected)
 		}
 		http.Error(w, err.Error(), httputils.StatusCode(err))
 		return

--- a/lib/node/runner/api_transaction.go
+++ b/lib/node/runner/api_transaction.go
@@ -48,25 +48,9 @@ func (nh NetworkHandlerNode) GetNodeTransactionsHandler(w http.ResponseWriter, r
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-SEBAK-RESULT-COUNT", string(len(hashes)))
 
-	unknown := map[string]struct{}{}
-
-	// check in `Pool`
+	// check in `block.TransactionPool`
 	for _, hash := range hashes {
-		if tx, found := nh.transactionPool.Get(hash); !found {
-			unknown[hash] = struct{}{}
-			continue
-		} else {
-			nh.renderNodeItem(w, NodeItemTransaction, tx)
-		}
-	}
-
-	// check in `BlockTransaction`
-	for _, hash := range hashes {
-		if _, found := unknown[hash]; !found {
-			continue
-		}
-
-		if exists, err := block.ExistsBlockTransaction(nh.storage, hash); err != nil {
+		if exists, err := block.ExistsTransactionPool(nh.storage, hash); err != nil {
 			nh.renderNodeItem(w, NodeItemError, err)
 			return
 		} else if !exists {
@@ -74,7 +58,7 @@ func (nh NetworkHandlerNode) GetNodeTransactionsHandler(w http.ResponseWriter, r
 			continue
 		}
 
-		btx, err := block.GetBlockTransaction(nh.storage, hash)
+		btx, err := block.GetTransactionPool(nh.storage, hash)
 		if err != nil {
 			nh.renderNodeItem(w, NodeItemError, err)
 			return

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -82,6 +82,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 	for j := 0; j < 3; j++ {
 		_, tx := transaction.TestMakeTransaction(networkID, 2)
 		p.TransactionPool.Add(tx)
+		block.SaveTransactionPool(p.st, tx)
 	}
 
 	return
@@ -100,6 +101,7 @@ func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
 		txHashes = append(txHashes, tx.GetHash())
 		txs = append(txs, tx)
 		p.transactionHashes = append(p.transactionHashes, tx.GetHash())
+		block.SaveTransactionPool(p.st, tx)
 	}
 
 	latest := block.GetLatestBlock(p.st)
@@ -109,8 +111,7 @@ func (p *HelperTestGetNodeTransactionsHandler) createBlock() block.Block {
 	bk.MustSave(p.st)
 
 	for _, tx := range txs {
-		b, _ := tx.Serialize()
-		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx, b)
+		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx)
 		if err := btx.Save(p.st); err != nil {
 			panic(err)
 		}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"io"
 
 	logging "github.com/inconshreveable/log15"
@@ -337,8 +336,14 @@ func BallotCheckResult(c common.Checker, args ...interface{}) (err error) {
 func getMissingTransaction(checker *BallotChecker) (err error) {
 	// get missing transactions
 	var unknown []string
+	var exists bool
 	for _, hash := range checker.Ballot.Transactions() {
 		if checker.NodeRunner.TransactionPool.Has(hash) {
+			continue
+		}
+		if exists, err = block.ExistsTransactionPool(checker.NodeRunner.Storage(), hash); err != nil {
+			return
+		} else if exists {
 			continue
 		}
 		unknown = append(unknown, hash)
@@ -393,8 +398,16 @@ func getMissingTransaction(checker *BallotChecker) (err error) {
 		receivedTransaction = append(receivedTransaction, tx)
 	}
 
+	var bs *storage.LevelDBBackend
+	bs, err = checker.NodeRunner.Storage().OpenBatch()
 	for _, tx := range receivedTransaction {
-		checker.NodeRunner.TransactionPool.Add(tx)
+		if _, err = block.SaveTransactionPool(bs, tx); err != nil {
+			return
+		}
+	}
+	if err = bs.Commit(); err != nil {
+		bs.Discard()
+		return
 	}
 
 	return
@@ -647,8 +660,12 @@ func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *
 	for _, hash := range pTxHashes {
 		tx, found := transactionPool.Get(hash)
 		if !found {
-			err = errors.TransactionNotFound
-			return nil, err
+			var tp block.TransactionPool
+			if tp, err = block.GetTransactionPool(st, hash); err != nil {
+				err = errors.TransactionNotFound
+				return nil, err
+			}
+			tx = tp.Transaction()
 		}
 		proposedTransactions = append(proposedTransactions, &tx)
 	}
@@ -689,9 +706,7 @@ func isValidRound(st *storage.LevelDBBackend, r voting.Basis, log logging.Logger
 
 func FinishTransactions(blk block.Block, transactions []*transaction.Transaction, st *storage.LevelDBBackend) (err error) {
 	for _, tx := range transactions {
-		raw, _ := json.Marshal(tx)
-
-		bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, *tx, raw)
+		bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, *tx)
 		if err = bt.Save(st); err != nil {
 			return
 		}
@@ -823,8 +838,7 @@ func FinishProposerTransaction(st *storage.LevelDBBackend, blk block.Block, ptx 
 		}
 	}
 
-	raw, _ := json.Marshal(ptx.Transaction)
-	bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, ptx.Transaction, raw)
+	bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, ptx.Transaction)
 	if err = bt.Save(st); err != nil {
 		return
 	}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -843,6 +843,10 @@ func FinishProposerTransaction(st *storage.LevelDBBackend, blk block.Block, ptx 
 		return
 	}
 
+	if _, err = block.SaveTransactionPool(st, ptx.Transaction); err != nil {
+		return
+	}
+
 	return
 }
 

--- a/lib/node/runner/checker_message.go
+++ b/lib/node/runner/checker_message.go
@@ -93,7 +93,7 @@ func SaveTransactionHistory(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	if err = block.SaveTransactionHistory(checker.Storage, checker.Transaction, checker.Message.Data, block.TransactionHistoryStatusSubmitted); err != nil {
+	if err = block.SaveTransactionHistory(checker.Storage, checker.Transaction, block.TransactionHistoryStatusSubmitted); err != nil {
 		return
 	}
 
@@ -133,6 +133,10 @@ func PushIntoTransactionPool(c common.Checker, args ...interface{}) (err error) 
 
 	tx := checker.Transaction
 	checker.TransactionPool.Add(tx)
+
+	if _, err = block.SaveTransactionPool(checker.Storage, tx); err != nil {
+		return
+	}
 
 	checker.Log.Debug("push transaction into TransactionPool")
 

--- a/lib/sync/fetcher_test.go
+++ b/lib/sync/fetcher_test.go
@@ -51,6 +51,9 @@ func TestBlockFetcher(t *testing.T) {
 	bk := block.GetLatestBlock(st)
 	tx, err := block.GetBlockTransaction(st, bk.Transactions[0])
 	require.NoError(t, err)
+	tp, err := block.GetTransactionPool(st, tx.Hash)
+	require.NoError(t, err)
+	tx.Message = tp.Message
 
 	apiHandlerFunc := func(req *http.Request) (*http.Response, error) {
 		w := httptest.NewRecorder()

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -123,7 +123,7 @@ func (v *BlockValidator) finishBlock(ctx context.Context, syncInfo *SyncInfo) er
 		return err
 	}
 	for _, tx := range syncInfo.Txs {
-		if _, err := block.SaveTransactionPool(ts, *tx); err != nil {
+		if _, err := block.SaveTransactionPool(bs, *tx); err != nil {
 			return err
 		}
 	}

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -122,6 +122,11 @@ func (v *BlockValidator) finishBlock(ctx context.Context, syncInfo *SyncInfo) er
 		bs.Discard()
 		return err
 	}
+	for _, tx := range syncInfo.Txs {
+		if _, err := block.SaveTransactionPool(ts, *tx); err != nil {
+			return err
+		}
+	}
 
 	ptx := syncInfo.Ptx
 	if err := runner.FinishProposerTransaction(bs, blk, *ptx, v.logger); err != nil {

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -134,6 +134,10 @@ func (tx Transaction) Source() string {
 	return tx.B.Source
 }
 
+func (tx Transaction) IsEmpty() bool {
+	return len(tx.H.Hash) < 1
+}
+
 // TotalAmount returns the sum of Amount of operations.
 //
 // Returns:


### PR DESCRIPTION
### Background
This is similar patch with #615 , performance concerns. To reduce the stored data size in `finishBallot()`, the `finishBallot()` will be short.

### Solution

This patch will save the incoming(or missing) transactions at when it is received. The all new transactions will be saved in `block.TransactionPool` and the existing `block.BlockTransaction` will store the transaction message(`block.BlockTransaction.Message`)

The major changes,

* New transaction receives, node will store it in `transaction.Pool` and `block.TransactionPool`
* `block.BlockTransaction` does not store the transaction message
* But `block.BlockTransaction.Message` field remains; the syncer will use it.

The benchmark shows the impressive result,

```
   1-10  :    0.0084 ->   0.0070 = +16.6587%
   1-200 :    0.0368 ->   0.0304 = +17.4210%
   1-400 :    0.0619 ->   0.0562 =  +9.1992%
   1-600 :    0.0943 ->   0.0797 = +15.4941%
   1-800 :    0.1302 ->   0.1043 = +19.8780%
   1-1000:    0.1442 ->   0.1324 =  +8.1985%
 200-10  :    0.4585 ->   0.3780 = +17.5610%
 200-200 :    7.0370 ->   6.6254 =  +5.8486%
 200-400 :   15.8702 ->  14.2655 = +10.1113%
 200-600 :   29.5182 ->  23.8177 = +19.3118%
 200-800 :   39.6077 ->  35.9260 =  +9.2954%
 200-1000:   55.0134 ->  52.8791 =  +3.8795%
 400-10  :    0.8044 ->   0.7926 =  +1.4646%
 400-200 :   15.0261 ->  14.1604 =  +5.7614%
 400-400 :   37.4619 ->  36.1464 =  +3.5116%
 400-600 :   79.4453 ->  68.6406 = +13.6001%
 400-800 :  127.7502 -> 112.0587 = +12.2830%
 400-1000:  190.2821 -> 171.1239 = +10.0683%
 600-10  :    1.6413 ->   1.3571 = +17.3160%
 600-200 :   34.9841 ->  25.5032 = +27.1006%
 600-400 :   93.4457 ->  71.3401 = +23.6560%
 600-600 :  163.4086 -> 144.0558 = +11.8432%
 600-800 :  336.7421 -> 257.9777 = +23.3901%
```
The first number is the number of transactions and the second is number of operations in each transaction. The detailed result can be found at https://gist.github.com/spikeekips/c5151b786da5729d07f48dac07766fe1 .