### PR TITLE
Fill the `block.total-ops` in node info API

### DIFF
--- a/lib/node/runner/api/node_info.go
+++ b/lib/node/runner/api/node_info.go
@@ -27,6 +27,7 @@ func (api NetworkHandlerAPI) GetNodeInfoHandler(w http.ResponseWriter, r *http.R
 			Height:   latestBlock.Height,
 			Hash:     latestBlock.Hash,
 			TotalTxs: latestBlock.TotalTxs,
+			TotalOps: latestBlock.TotalOps,
 		}
 	}
 

--- a/lib/node/runner/api/node_info_test.go
+++ b/lib/node/runner/api/node_info_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/mux"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/version"
-	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAPIGetNodeInfoHandler(t *testing.T) {
@@ -94,6 +95,7 @@ func TestAPIGetNodeInfoHandler(t *testing.T) {
 	require.Equal(t, latestBlock.Height, receivedNodeInfo.Block.Height)
 	require.Equal(t, latestBlock.Hash, receivedNodeInfo.Block.Hash)
 	require.Equal(t, latestBlock.TotalTxs, receivedNodeInfo.Block.TotalTxs)
+	require.Equal(t, latestBlock.TotalOps, receivedNodeInfo.Block.TotalOps)
 
 	js, _ := json.Marshal(policy)
 	rjs, _ := json.Marshal(receivedNodeInfo.Policy)


### PR DESCRIPTION
### Github Issue
Resolves #626 

### Background

See #626 