### PR TITLE
Cleanup API test code and remove unused getter

### DIFF
--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -103,10 +103,6 @@ func (bo BlockOperation) Serialize() (encoded []byte, err error) {
 	return
 }
 
-func (bo BlockOperation) Transaction() transaction.Transaction {
-	return bo.transaction
-}
-
 func GetBlockOperationKey(hash string) string {
 	return fmt.Sprintf("%s%s", common.BlockOperationPrefixHash, hash)
 }

--- a/lib/node/runner/api/account_test.go
+++ b/lib/node/runner/api/account_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestGetAccountHandler(t *testing.T) {
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 	// Make Dummy BlockAccount
@@ -28,8 +27,7 @@ func TestGetAccountHandler(t *testing.T) {
 	{
 		// Do a Request
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", ba.Address, -1)
-		respBody, err := request(ts, url, false)
-		require.NoError(t, err)
+		respBody := request(ts, url, false)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 
@@ -57,13 +55,11 @@ func TestGetAccountHandlerStream(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 	ba := block.TestMakeBlockAccount()
 	ba.MustSave(storage)
-	require.NoError(t, err)
 
 	key := ba.Address
 
@@ -87,8 +83,7 @@ func TestGetAccountHandlerStream(t *testing.T) {
 	var reader *bufio.Reader
 	{
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", key, -1)
-		respBody, err := request(ts, url, true)
-		require.NoError(t, err)
+		respBody := request(ts, url, true)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}
@@ -107,8 +102,7 @@ func TestGetAccountHandlerStream(t *testing.T) {
 // Test that getting an inexisting account returns an error
 func TestGetNonExistentAccountHandler(t *testing.T) {
 
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 
@@ -118,8 +112,7 @@ func TestGetNonExistentAccountHandler(t *testing.T) {
 		// Do a Request
 		kp, _ := keypair.Random()
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", kp.Address(), -1)
-		respBody, err := request(ts, url, false)
-		require.NoError(t, err)
+		respBody := request(ts, url, false)
 		reader := bufio.NewReader(respBody)
 		readByte, err := ioutil.ReadAll(reader)
 		require.NoError(t, err)

--- a/lib/node/runner/api/node_info_test.go
+++ b/lib/node/runner/api/node_info_test.go
@@ -75,8 +75,7 @@ func TestAPIGetNodeInfoHandler(t *testing.T) {
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
-	body, err := request(ts, GetNodeInfoPattern, false)
-	require.NoError(t, err)
+	body := request(ts, GetNodeInfoPattern, false)
 	data, err := ioutil.ReadAll(bufio.NewReader(body))
 	body.Close()
 
@@ -104,10 +103,9 @@ func TestAPIGetNodeInfoHandler(t *testing.T) {
 	// udpate localNode state
 	localNode.SetBooting()
 
-	body, err = request(ts, GetNodeInfoPattern, false)
-	require.NoError(t, err)
+	body = request(ts, GetNodeInfoPattern, false)
+	defer body.Close()
 	data, err = ioutil.ReadAll(bufio.NewReader(body))
-	body.Close()
 
 	receivedNodeInfo, _ = node.NewNodeInfoFromJSON(data)
 	require.Equal(t, localNode.State(), receivedNodeInfo.Node.State)

--- a/lib/node/runner/api/operation_test.go
+++ b/lib/node/runner/api/operation_test.go
@@ -19,13 +19,11 @@ import (
 )
 
 func TestGetOperationsByAccountHandler(t *testing.T) {
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, boList, err := prepareOps(storage, 10)
-	require.NoError(t, err)
+	kp, boList := prepareOps(storage, 10)
 
 	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
 	{
@@ -44,8 +42,7 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 
 	{
 		// Do a Request
-		respBody, err := request(ts, url, false)
-		require.NoError(t, err)
+		respBody := request(ts, url, false)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 		readByte, err := ioutil.ReadAll(reader)
@@ -67,13 +64,11 @@ func TestGetOperationsByAccountHandler(t *testing.T) {
 }
 
 func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, boList, err := prepareOps(storage, 10)
-	require.NoError(t, err)
+	kp, boList := prepareOps(storage, 10)
 	ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
 	ba.MustSave(storage)
 
@@ -81,8 +76,7 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 	url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
 	{
 		url := url + "?type=" + string(operation.TypeCreateAccount)
-		respBody, err := request(ts, url, false)
-		require.NoError(t, err)
+		respBody := request(ts, url, false)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 
@@ -97,8 +91,7 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 
 	{
 		url := url + "?type=" + string(operation.TypePayment)
-		respBody, err := request(ts, url, false)
-		require.NoError(t, err)
+		respBody := request(ts, url, false)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
 
@@ -125,14 +118,12 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 
 	boMap := make(map[string]block.BlockOperation)
-	kp, boList, err := prepareOpsWithoutSave(10, storage)
-	require.NoError(t, err)
+	kp, boList := prepareOpsWithoutSave(10, storage)
 	for _, bo := range boList {
 		boMap[bo.Hash] = bo
 	}
@@ -161,8 +152,7 @@ func TestGetOperationsByAccountHandlerStream(t *testing.T) {
 	var reader *bufio.Reader
 	{
 		url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
-		respBody, err := request(ts, url, true)
-		require.NoError(t, err)
+		respBody := request(ts, url, true)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -21,14 +21,11 @@ import (
 )
 
 func TestGetOperationsByTxHashHandler(t *testing.T) {
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 
-	_, btList, err := prepareTxs(storage, 1)
-	require.NoError(t, err)
-
+	_, btList := prepareTxs(storage, 1)
 	bt := btList[0]
 
 	{ // unknown transaction
@@ -43,8 +40,7 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 
 	// Do a Request
 	url := strings.Replace(GetTransactionOperationsHandlerPattern, "{id}", bt.Hash, -1)
-	respBody, err := request(ts, url, false)
-	require.NoError(t, err)
+	respBody := request(ts, url, false)
 	defer respBody.Close()
 	reader := bufio.NewReader(respBody)
 
@@ -71,8 +67,7 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	ts, storage, err := prepareAPIServer()
-	require.NoError(t, err)
+	ts, storage := prepareAPIServer()
 	defer storage.Close()
 	defer ts.Close()
 
@@ -111,8 +106,7 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	var reader *bufio.Reader
 	{
 		url := strings.Replace(GetTransactionOperationsHandlerPattern, "{id}", bt.Hash, -1)
-		respBody, err := request(ts, url, true)
-		require.NoError(t, err)
+		respBody := request(ts, url, true)
 		defer respBody.Close()
 		reader = bufio.NewReader(respBody)
 	}


### PR DESCRIPTION
```
For test utility, it is better to straight up panic than do an error checking.
Since those errors should never happen, and the overwhelming majority of the case
happens after a change to the code, it is better to have the error as close
to the place where it is detected as possible, which panic achieves.
```