### PR TITLE
HTTP cache middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,8 @@ require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/ethereum/go-ethereum v1.8.13
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	github.com/go-redis/cache v6.3.5+incompatible
+	github.com/go-redis/redis v6.14.2+incompatible
 	github.com/go-stack/stack v1.7.0 // indirect
 	github.com/golang/protobuf v1.2.0 // indirect
 	github.com/golang/snappy v0.0.0-20170215233205-553a64147049 // indirect
@@ -42,6 +44,7 @@ require (
 	github.com/stretchr/testify v1.2.2
 	github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd
 	github.com/ulule/limiter v2.2.0+incompatible
+	github.com/vmihailenco/msgpack v4.0.1+incompatible
 	golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5
 	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	golang.org/x/sys v0.0.0-20180501092740-78d5f264b493 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/handlers v1.4.0
 	github.com/gorilla/mux v1.6.2
+	github.com/hashicorp/golang-lru v0.5.0
 	github.com/hpcloud/tail v1.0.0 // indirect
 	github.com/inconshreveable/log15 v0.0.0-20180818164646-67afb5ed74ec
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/gorilla/handlers v1.4.0 h1:XulKRWSQK5uChr4pEgSE4Tc/OcmnU9GJuSwdog/tZs
 github.com/gorilla/handlers v1.4.0/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCOH9wdo=
+github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/log15 v0.0.0-20171019012758-0decfc6c20d9 h1:LmBUkXNSSmEV5hExb65hKje7sDuuDug3xsPAba7x5fw=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/ethereum/go-ethereum v1.8.13 h1:AYgNAj97NBZIyNThOV0Wt8aTs+A+g3SmS/3eb
 github.com/ethereum/go-ethereum v1.8.13/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/go-redis/cache v6.3.5+incompatible h1:4OUyoXXYRRQ6tKA4ue3TlPUkBzk3occzjtXBZBxCzgs=
+github.com/go-redis/cache v6.3.5+incompatible/go.mod h1:XNnMdvlNjcZvHjsscEozHAeOeSE5riG9Fj54meG4WT4=
+github.com/go-redis/redis v6.14.2+incompatible h1:UE9pLhzmWf+xHNmZsoccjXosPicuiNaInPgym8nzfg0=
+github.com/go-redis/redis v6.14.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-stack/stack v1.7.0 h1:S04+lLfST9FvL8dl4R31wVUC/paZp/WQZbLmUgWboGw=
 github.com/go-stack/stack v1.7.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
@@ -82,6 +86,8 @@ github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd h1:WuVJ5mLz1bggtr
 github.com/syndtr/goleveldb v0.0.0-20180331014930-714f901b98fd/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/ulule/limiter v2.2.0+incompatible h1:1SeOVtEtaMckX/1yBlsok6LLZjiUrZ33kF5FITMl3MU=
 github.com/ulule/limiter v2.2.0+incompatible/go.mod h1:VJx/ZNGmClQDS5F6EmsGqK8j3jz1qJYZ6D9+MdAD+kw=
+github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
+github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5 h1:ylIG3jIeS45kB0W95N19kS62fwermjMYLIyybf8xh9M=
 golang.org/x/net v0.0.0-20180420171651-5f9ae10d9af5/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f h1:wMNYb4v58l5UBM7MYRLPG6ZhfOqbKu7X5eyFl8ZhKvA=

--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -24,6 +24,9 @@ type Config struct {
 	// Those fields are not consensus-related
 	RateLimitRuleAPI  RateLimitRule
 	RateLimitRuleNode RateLimitRule
+
+	HTTPCacheAdapter  string
+	HTTPCachePoolSize int
 }
 
 func NewConfig(networkID []byte) Config {
@@ -41,6 +44,8 @@ func NewConfig(networkID []byte) Config {
 
 	p.RateLimitRuleAPI = NewRateLimitRule(RateLimitAPI)
 	p.RateLimitRuleNode = NewRateLimitRule(RateLimitNode)
+
+	p.HTTPCachePoolSize = HTTPCachePoolSize
 
 	return p
 }

--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -25,8 +25,9 @@ type Config struct {
 	RateLimitRuleAPI  RateLimitRule
 	RateLimitRuleNode RateLimitRule
 
-	HTTPCacheAdapter  string
-	HTTPCachePoolSize int
+	HTTPCacheAdapter    string
+	HTTPCachePoolSize   int
+	HTTPCacheRedisAddrs map[string]string
 }
 
 func NewConfig(networkID []byte) Config {

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -35,8 +35,8 @@ const (
 	BlockHeightEndOfInflation uint64 = 36000000
 
 	HTTPCacheMemoryAdapterName = "mem"
-	//HTTPCacheRedisAdapterName = "redis"
-	HTTPCachePoolSize = 10000
+	HTTPCacheRedisAdapterName  = "redis"
+	HTTPCachePoolSize          = 10000
 )
 
 var (
@@ -69,5 +69,9 @@ var (
 		Limit:  100,
 	}
 
-	HTTPCacheAdapterNames = map[string]bool{HTTPCacheMemoryAdapterName: true, "": true}
+	HTTPCacheAdapterNames = map[string]bool{
+		HTTPCacheMemoryAdapterName: true,
+		HTTPCacheRedisAdapterName:  true,
+		"":                         true, // default value is nop cache
+	}
 )

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -33,6 +33,10 @@ const (
 
 	// BlockHeightEndOfInflation sets the block height of inflation end.
 	BlockHeightEndOfInflation uint64 = 36000000
+
+	HTTPCacheMemoryAdapterName = "mem"
+	//HTTPCacheRedisAdapterName = "redis"
+	HTTPCachePoolSize = 10000
 )
 
 var (
@@ -64,4 +68,6 @@ var (
 		Period: 1 * time.Second,
 		Limit:  100,
 	}
+
+	HTTPCacheAdapterNames = map[string]bool{HTTPCacheMemoryAdapterName: true, "": true}
 )

--- a/lib/network/httpcache/client.go
+++ b/lib/network/httpcache/client.go
@@ -12,6 +12,7 @@ import (
 	logging "github.com/inconshreveable/log15"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/network/httputils"
 )
 
 type Client struct {
@@ -114,6 +115,9 @@ func (c *Client) WrapHandlerFunc(handlerFunc http.HandlerFunc) http.HandlerFunc 
 }
 
 func (c *Client) handleCache(next http.Handler, w http.ResponseWriter, r *http.Request) bool {
+	if httputils.IsEventStream(r) {
+		return false
+	}
 	if ok := c.methods[r.Method]; !ok {
 		return false
 	}

--- a/lib/network/httpcache/client.go
+++ b/lib/network/httpcache/client.go
@@ -1,0 +1,146 @@
+package httpcache
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	adapter     Adapter
+	ttl         *time.Duration
+	methods     map[string]bool
+	statusCodes map[int]*time.Duration
+}
+
+type ClientOption func(c *Client) error
+
+func NewClient(opts ...ClientOption) (*Client, error) {
+	c := &Client{
+		methods:     map[string]bool{"GET": true},
+		statusCodes: map[int]*time.Duration{},
+		ttl:         nil,
+	}
+
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			return nil, err
+		}
+	}
+
+	if c.adapter == nil {
+		return nil, errors.New("cache client adapter is nil")
+	}
+
+	return c, nil
+}
+
+func WithAdapter(a Adapter) ClientOption {
+	return func(c *Client) error {
+		c.adapter = a
+		return nil
+	}
+}
+
+func WithExpire(ttl time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.ttl = &ttl
+		return nil
+	}
+}
+
+func WithMethods(methods ...string) ClientOption {
+	return func(c *Client) error {
+		for _, m := range methods {
+			c.methods[m] = true
+		}
+		return nil
+	}
+}
+
+func WithStatusCode(code int, ttl time.Duration) ClientOption {
+	return func(c *Client) error {
+		c.statusCodes[code] = &ttl
+		return nil
+	}
+}
+
+func (c *Client) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if ok := c.handleCache(next, w, r); !ok {
+			next.ServeHTTP(w, r)
+		}
+	})
+}
+
+func (c *Client) handleCache(next http.Handler, w http.ResponseWriter, r *http.Request) bool {
+	if ok := c.methods[r.Method]; ok {
+		sortURLParams(r.URL)
+		key := r.URL.String()
+		resp, ok := c.adapter.Get(key)
+		if ok {
+			if resp.Expiration == nil || resp.Expiration.After(time.Now()) {
+				for k, v := range resp.Header {
+					w.Header().Set(k, strings.Join(v, ","))
+				}
+				w.Write(resp.Value)
+				return true
+			}
+			c.adapter.Remove(key)
+		}
+		rec := httptest.NewRecorder()
+		next.ServeHTTP(rec, r)
+		var (
+			result              = rec.Result()
+			statusCode          = result.StatusCode
+			value               = rec.Body.Bytes()
+			expiration, caching = c.cachingExpiration(statusCode)
+		)
+		if caching {
+			resp := &Response{
+				Value:      value,
+				Header:     result.Header,
+				Expiration: expiration,
+			}
+			c.adapter.Set(key, resp, expiration)
+		}
+		for k, v := range result.Header {
+			w.Header().Set(k, strings.Join(v, ","))
+		}
+		w.WriteHeader(statusCode)
+		w.Write(value)
+		return true
+	}
+	return false
+}
+
+func (c *Client) cachingExpiration(code int) (*time.Time, bool) {
+	if ttl, ok := c.statusCodes[code]; ok {
+		return expiration(ttl), true
+	} else if code < 400 {
+		return expiration(c.ttl), true
+	}
+	return nil, false
+}
+
+func expiration(ttl *time.Duration) *time.Time {
+	if ttl != nil {
+		t := time.Now().Add(*ttl)
+		return &t
+	}
+	return nil
+}
+
+func sortURLParams(u *url.URL) {
+	params := u.Query()
+	for _, p := range params {
+		sort.Slice(p, func(i, j int) bool {
+			return p[i] < p[j]
+		})
+	}
+	u.RawQuery = params.Encode()
+}

--- a/lib/network/httpcache/client.go
+++ b/lib/network/httpcache/client.go
@@ -87,6 +87,7 @@ func (c *Client) handleCache(next http.Handler, w http.ResponseWriter, r *http.R
 				for k, v := range resp.Header {
 					w.Header().Set(k, strings.Join(v, ","))
 				}
+				w.WriteHeader(resp.StatusCode)
 				w.Write(resp.Value)
 				return true
 			}
@@ -103,6 +104,7 @@ func (c *Client) handleCache(next http.Handler, w http.ResponseWriter, r *http.R
 		if caching {
 			resp := &Response{
 				Value:      value,
+				StatusCode: statusCode,
 				Header:     result.Header,
 				Expiration: expiration,
 			}

--- a/lib/network/httpcache/client.go
+++ b/lib/network/httpcache/client.go
@@ -102,7 +102,7 @@ func (c *Client) Middleware(next http.Handler) http.Handler {
 	})
 }
 
-func (c *Client) HandlerFunc(handlerFunc http.HandlerFunc) http.HandlerFunc {
+func (c *Client) WrapHandlerFunc(handlerFunc http.HandlerFunc) http.HandlerFunc {
 	next := http.HandlerFunc(handlerFunc)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if ok := c.handleCache(next, w, r); !ok {

--- a/lib/network/httpcache/client_test.go
+++ b/lib/network/httpcache/client_test.go
@@ -15,11 +15,11 @@ func TestMiddleware(t *testing.T) {
 	a.Set("http://foo?bar=1", &Response{
 		Value:      []byte("value 1"),
 		StatusCode: 200,
-	}, nil)
+	}, time.Time{})
 	a.Set("http://foo.bar?bar=1&foo=1", &Response{
 		Value:      []byte("value 2"),
 		StatusCode: 200,
-	}, nil)
+	}, time.Time{})
 
 	c, err := NewClient(
 		WithAdapter(a),
@@ -95,6 +95,71 @@ func TestMiddleware(t *testing.T) {
 
 			require.Equal(t, w.Code, tt.code)
 			require.Equal(t, w.Body.String(), tt.body)
+		})
+	}
+}
+
+func TestExpiration(t *testing.T) {
+	type TestCase struct {
+		name            string
+		code            int
+		options         []ClientOption
+		expectedTime    time.Time
+		expectedCaching bool
+	}
+
+	a := NewMemCacheAdapter(10)
+
+	tests := []TestCase{
+		{
+			name:            "nottl-200",
+			code:            200,
+			options:         []ClientOption{WithAdapter(a)},
+			expectedTime:    time.Time{},
+			expectedCaching: true,
+		},
+		{
+			name: "2s-500-cache",
+			code: 500,
+			options: []ClientOption{
+				WithAdapter(a),
+				WithStatusCode(500, 2*time.Second),
+			},
+			expectedTime:    time.Now().Add(1 * time.Second),
+			expectedCaching: true,
+		},
+		{
+			name: "2s-500-nocache",
+			code: 500,
+			options: []ClientOption{
+				WithAdapter(a),
+			},
+			expectedCaching: false,
+		},
+		{
+			name: "no-expir",
+			code: 200,
+			options: []ClientOption{
+				WithAdapter(a),
+			},
+			expectedCaching: true,
+			expectedTime:    time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, err := NewClient(tt.options...)
+			require.NoError(t, err)
+
+			expiration, caching := c.cachingExpiration(tt.code)
+			require.Equal(t, caching, tt.expectedCaching)
+
+			if tt.expectedTime.IsZero() {
+				require.True(t, expiration.IsZero())
+			} else {
+				require.True(t, tt.expectedTime.Before(expiration))
+			}
 		})
 	}
 }

--- a/lib/network/httpcache/client_test.go
+++ b/lib/network/httpcache/client_test.go
@@ -1,0 +1,67 @@
+package httpcache
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMiddleware(t *testing.T) {
+	a := NewMemCacheAdapter(10)
+	a.Set("http://foo?bar=1", &Response{
+		Value: []byte("value 1"),
+	}, nil)
+
+	c, err := NewClient(
+		WithAdapter(a),
+	)
+	require.NoError(t, err)
+
+	cnt := 0
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(fmt.Sprintf("new value:%v", cnt)))
+	})
+
+	handler := c.Middleware(testHandler)
+
+	tests := []struct {
+		name   string
+		url    string
+		method string
+		body   string
+		code   int
+	}{
+		{
+			"return cached resp",
+			"http://foo?bar=1",
+			"GET",
+			"value 1",
+			200,
+		},
+		{
+			"return nocached resp",
+			"http://foo?bar=2",
+			"GET",
+			"new value:2",
+			200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cnt++
+
+			r, err := http.NewRequest(tt.method, tt.url, nil)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, r)
+
+			require.Equal(t, w.Code, tt.code)
+			require.Equal(t, w.Body.String(), tt.body)
+		})
+	}
+}

--- a/lib/network/httpcache/config.go
+++ b/lib/network/httpcache/config.go
@@ -11,6 +11,14 @@ func NewAdapter(cfg common.Config) (Adapter, error) {
 		size := cfg.HTTPCachePoolSize
 		adapter := NewMemCacheAdapter(size)
 		return adapter, nil
+	case common.HTTPCacheRedisAdapterName:
+		opts := &RedisRingOptions{
+			Addrs: map[string]string{
+				"server": ":6379", // todo(anarcher): from config
+			},
+		}
+		adapter := NewRedisCacheAdapter(opts)
+		return adapter, nil
 	default:
 		return nil, errors.New("adapter not found")
 	}

--- a/lib/network/httpcache/config.go
+++ b/lib/network/httpcache/config.go
@@ -1,0 +1,17 @@
+package httpcache
+
+import (
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
+)
+
+func NewAdapter(cfg common.Config) (Adapter, error) {
+	switch cfg.HTTPCacheAdapter {
+	case common.HTTPCacheMemoryAdapterName:
+		size := cfg.HTTPCachePoolSize
+		adapter := NewMemCacheAdapter(size)
+		return adapter, nil
+	default:
+		return nil, errors.New("adapter not found")
+	}
+}

--- a/lib/network/httpcache/config.go
+++ b/lib/network/httpcache/config.go
@@ -13,9 +13,7 @@ func NewAdapter(cfg common.Config) (Adapter, error) {
 		return adapter, nil
 	case common.HTTPCacheRedisAdapterName:
 		opts := &RedisRingOptions{
-			Addrs: map[string]string{
-				"server": ":6379", // todo(anarcher): from config
-			},
+			Addrs: cfg.HTTPCacheRedisAddrs,
 		}
 		adapter := NewRedisCacheAdapter(opts)
 		return adapter, nil

--- a/lib/network/httpcache/mem.go
+++ b/lib/network/httpcache/mem.go
@@ -1,0 +1,40 @@
+package httpcache
+
+import (
+	"time"
+
+	"github.com/hashicorp/golang-lru"
+)
+
+type MemCacheAdapter struct {
+	lruCache *lru.Cache
+}
+
+func NewMemCacheAdapter(size int) *MemCacheAdapter {
+	lruCache, err := lru.New(size)
+	if err != nil {
+		panic(err)
+	}
+
+	a := &MemCacheAdapter{
+		lruCache: lruCache,
+	}
+	return a
+}
+
+func (a *MemCacheAdapter) Get(key string) (*Response, bool) {
+	value, ok := a.lruCache.Get(key)
+	if ok {
+		res, ok := value.(*Response)
+		return res, ok
+	}
+	return nil, ok
+}
+
+func (a *MemCacheAdapter) Set(key string, resp *Response, expir *time.Time) {
+	a.lruCache.Add(key, resp)
+}
+
+func (a *MemCacheAdapter) Remove(key string) {
+	a.lruCache.Remove(key)
+}

--- a/lib/network/httpcache/mem.go
+++ b/lib/network/httpcache/mem.go
@@ -31,7 +31,7 @@ func (a *MemCacheAdapter) Get(key string) (*Response, bool) {
 	return nil, ok
 }
 
-func (a *MemCacheAdapter) Set(key string, resp *Response, expir *time.Time) {
+func (a *MemCacheAdapter) Set(key string, resp *Response, expir time.Time) {
 	a.lruCache.Add(key, resp)
 }
 

--- a/lib/network/httpcache/mem_test.go
+++ b/lib/network/httpcache/mem_test.go
@@ -1,0 +1,27 @@
+package httpcache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var _ Adapter = (*MemCacheAdapter)(nil)
+
+func TestMemCacheAdapter(t *testing.T) {
+	a := NewMemCacheAdapter(10)
+	now := time.Now()
+
+	key := "key"
+	resp := &Response{
+		Value:      []byte("hello"),
+		Expiration: &now,
+	}
+
+	a.Set(key, resp, &now)
+
+	cachedResp, ok := a.Get(key)
+	require.Equal(t, true, ok)
+	require.Equal(t, resp, cachedResp)
+}

--- a/lib/network/httpcache/mem_test.go
+++ b/lib/network/httpcache/mem_test.go
@@ -16,10 +16,10 @@ func TestMemCacheAdapter(t *testing.T) {
 	key := "key"
 	resp := &Response{
 		Value:      []byte("hello"),
-		Expiration: &now,
+		Expiration: now,
 	}
 
-	a.Set(key, resp, &now)
+	a.Set(key, resp, now)
 
 	cachedResp, ok := a.Get(key)
 	require.Equal(t, true, ok)

--- a/lib/network/httpcache/nop.go
+++ b/lib/network/httpcache/nop.go
@@ -1,0 +1,14 @@
+package httpcache
+
+import "net/http"
+
+type NopClient struct {
+}
+
+func (NopClient) WrapHandlerFunc(handlerFunc http.HandlerFunc) http.HandlerFunc {
+	return handlerFunc
+}
+
+func NewNopClient() *NopClient {
+	return &NopClient{}
+}

--- a/lib/network/httpcache/redis.go
+++ b/lib/network/httpcache/redis.go
@@ -1,0 +1,55 @@
+package httpcache
+
+import (
+	"time"
+
+	redisCache "github.com/go-redis/cache"
+	"github.com/go-redis/redis"
+	"github.com/vmihailenco/msgpack"
+)
+
+type RedisCacheAdapter struct {
+	store *redisCache.Codec
+}
+
+type RedisRingOptions redis.RingOptions
+
+func NewRedisCacheAdapter(opt *RedisRingOptions) *RedisCacheAdapter {
+	ropt := redis.RingOptions(*opt)
+	a := &RedisCacheAdapter{
+		&redisCache.Codec{
+			Redis: redis.NewRing(&ropt),
+			Marshal: func(v interface{}) ([]byte, error) {
+				return msgpack.Marshal(v)
+			},
+			Unmarshal: func(b []byte, v interface{}) error {
+				return msgpack.Unmarshal(b, v)
+			},
+		},
+	}
+	return a
+}
+
+func (a *RedisCacheAdapter) Get(key string) (*Response, bool) {
+	var resp Response
+	if err := a.store.Get(key, &resp); err != nil {
+		return nil, false
+	}
+	return &resp, true
+}
+
+func (a *RedisCacheAdapter) Set(key string, resp *Response, expir time.Time) {
+	var e time.Duration = 0
+	if !expir.IsZero() {
+		e = expir.Sub(time.Now())
+	}
+	a.store.Set(&redisCache.Item{
+		Key:        key,
+		Object:     resp,
+		Expiration: e,
+	})
+}
+
+func (a *RedisCacheAdapter) Remove(key string) {
+	a.store.Delete(key)
+}

--- a/lib/network/httpcache/redis_test.go
+++ b/lib/network/httpcache/redis_test.go
@@ -1,0 +1,35 @@
+package httpcache
+
+import (
+	"testing"
+	"time"
+)
+
+func TestRedisAdapter(t *testing.T) {
+	a := NewRedisCacheAdapter(&RedisRingOptions{
+		Addrs: map[string]string{
+			"server": ":6379",
+		},
+	})
+
+	tests := []struct {
+		name     string
+		key      string
+		response *Response
+	}{
+		{
+			name: "set response",
+			key:  "test1",
+			response: &Response{
+				Value:      []byte("value 1"),
+				Expiration: time.Now().Add(1 * time.Minute),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a.Set(tt.key, tt.response, time.Now().Add(1*time.Minute))
+		})
+	}
+}

--- a/lib/network/httpcache/types.go
+++ b/lib/network/httpcache/types.go
@@ -1,0 +1,18 @@
+package httpcache
+
+import (
+	"net/http"
+	"time"
+)
+
+type Adapter interface {
+	Get(key string) (*Response, bool)
+	Set(key string, response *Response, expiration *time.Time)
+	Remove(key string)
+}
+
+type Response struct {
+	Value      []byte
+	Header     http.Header
+	Expiration *time.Time
+}

--- a/lib/network/httpcache/types.go
+++ b/lib/network/httpcache/types.go
@@ -17,3 +17,7 @@ type Response struct {
 	Header     http.Header
 	Expiration time.Time
 }
+
+type Wrapper interface {
+	WrapHandlerFunc(handlerFunc http.HandlerFunc) http.HandlerFunc
+}

--- a/lib/network/httpcache/types.go
+++ b/lib/network/httpcache/types.go
@@ -7,7 +7,7 @@ import (
 
 type Adapter interface {
 	Get(key string) (*Response, bool)
-	Set(key string, response *Response, expiration *time.Time)
+	Set(key string, response *Response, expiration time.Time)
 	Remove(key string)
 }
 
@@ -15,5 +15,5 @@ type Response struct {
 	Value      []byte
 	StatusCode int
 	Header     http.Header
-	Expiration *time.Time
+	Expiration time.Time
 }

--- a/lib/network/httpcache/types.go
+++ b/lib/network/httpcache/types.go
@@ -13,6 +13,7 @@ type Adapter interface {
 
 type Response struct {
 	Value      []byte
+	StatusCode int
 	Header     http.Header
 	Expiration *time.Time
 }


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Fixes #390 

### Background

- https://github.com/bosnet/sebak/issues/390#issuecomment-434547476

```
adapter := cache.NewMemAdapter(10000)
cached  := cache.New(
    cache.WithExpire(1 *time.Second),
    cache.WithAdpater(adapter),
    cache.WithStatusCode(200), // infinite
    cache.WithStatusCode(201,10 * time.Minute), 
    cache.WithStatusCode(404,3 * time.Minute),
    cache.WithMethods("GET","HEAD"),
)
nr.network.AddHandler(
    apiHandler.HandlerURLPattern(api.GetTransactionOperationsHandlerPattern),
    cached.Middleware(apiHandler.GetOperationsByTxHashHandler),
).Methods("GET", "OPTIONS")
```

### Solution

-  [x]  Adapter interface & lru cache  (mem)
-  [x]  Test codes
-  [x]  Apply to handlers
-  [x]  Node options for cache response (e.g. cache pool size , cache adapter `mem`)
-  [x]  Support  Redis adapter 

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

