### PR TITLE
Fixed to find transactions from `transaction.Pool` and also `block.TransactionPool`

### DIFF
--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -458,14 +458,14 @@ func INITBallotValidateTransactions(c common.Checker, args ...interface{}) (err 
 	}
 
 	transactionsChecker := &BallotTransactionChecker{
-		DefaultChecker: common.DefaultChecker{Funcs: INITBallotTransactionCheckerFuncs},
-		NodeRunner:     checker.NodeRunner,
-		LocalNode:      checker.LocalNode,
-		NetworkID:      checker.NetworkID,
-		Ballot:         checker.Ballot,
-		Transactions:   checker.Ballot.Transactions(),
-		VotingHole:     voting.NOTYET,
-		transactions:   map[string]transaction.Transaction{},
+		DefaultChecker:    common.DefaultChecker{Funcs: INITBallotTransactionCheckerFuncs},
+		NodeRunner:        checker.NodeRunner,
+		LocalNode:         checker.LocalNode,
+		NetworkID:         checker.NetworkID,
+		Ballot:            checker.Ballot,
+		Transactions:      checker.Ballot.Transactions(),
+		VotingHole:        voting.NOTYET,
+		transactionsCache: map[string]transaction.Transaction{},
 	}
 
 	err = common.RunChecker(transactionsChecker, common.DefaultDeferFunc)

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -465,6 +465,7 @@ func INITBallotValidateTransactions(c common.Checker, args ...interface{}) (err 
 		Ballot:         checker.Ballot,
 		Transactions:   checker.Ballot.Transactions(),
 		VotingHole:     voting.NOTYET,
+		transactions:   map[string]transaction.Transaction{},
 	}
 
 	err = common.RunChecker(transactionsChecker, common.DefaultDeferFunc)

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -28,12 +28,12 @@ type BallotTransactionChecker struct {
 	ValidTransactions     []string
 	validTransactionsMap  map[string]bool
 	CheckTransactionsOnly bool
-	transactions          map[string]transaction.Transaction
+	transactionsCache     map[string]transaction.Transaction
 }
 
 func (b *BallotTransactionChecker) getTransaction(hash string) (tx transaction.Transaction, found bool, err error) {
 	b.RLock()
-	tx, found = b.transactions[hash]
+	tx, found = b.transactionsCache[hash]
 	b.RUnlock()
 
 	if found {
@@ -45,7 +45,7 @@ func (b *BallotTransactionChecker) getTransaction(hash string) (tx transaction.T
 
 	tx, found = b.NodeRunner.TransactionPool.Get(hash)
 	if found {
-		b.transactions[hash] = tx
+		b.transactionsCache[hash] = tx
 		return
 	}
 
@@ -60,7 +60,7 @@ func (b *BallotTransactionChecker) getTransaction(hash string) (tx transaction.T
 		return
 	}
 	tx = tp.Transaction()
-	b.transactions[hash] = tx
+	b.transactionsCache[hash] = tx
 
 	return
 }

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -538,7 +538,7 @@ func (nr *NodeRunner) proposeNewBallot(round uint64) (ballot.Ballot, error) {
 		Transactions:          availableTransactions,
 		CheckTransactionsOnly: true,
 		VotingHole:            voting.NOTYET,
-		transactions:          map[string]transaction.Transaction{},
+		transactionsCache:     map[string]transaction.Transaction{},
 	}
 
 	if err := common.RunChecker(transactionsChecker, common.DefaultDeferFunc); err != nil {

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -12,6 +12,10 @@ import (
 	"net/http/pprof"
 	"time"
 
+	ghandlers "github.com/gorilla/handlers"
+	logging "github.com/inconshreveable/log15"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
@@ -23,9 +27,6 @@ import (
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/voting"
-	ghandlers "github.com/gorilla/handlers"
-	logging "github.com/inconshreveable/log15"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 var DefaultHandleBaseBallotCheckerFuncs = []common.CheckerFunc{
@@ -537,6 +538,7 @@ func (nr *NodeRunner) proposeNewBallot(round uint64) (ballot.Ballot, error) {
 		Transactions:          availableTransactions,
 		CheckTransactionsOnly: true,
 		VotingHole:            voting.NOTYET,
+		transactions:          map[string]transaction.Transaction{},
 	}
 
 	if err := common.RunChecker(transactionsChecker, common.DefaultDeferFunc); err != nil {


### PR DESCRIPTION
### Background

After #620 , the missing transactions of ballot will be saved in `block.TransactionPool`. After getting the missing transactions, the `INITBallotValidateTransactions` does get the transactions only from `transaction.Pool`, excluding `block.TransactionPool`

### Solution

* added new method, `BallotTransactionChecker.getTransaction()`
* for performance reason, `BallotTransactionChecker.transaction` will cache it.