### PR TITLE
Stop broadcasting the incoming transaction in `/node/message`

### DIFF
--- a/lib/node/runner/api/transaction_post.go
+++ b/lib/node/runner/api/transaction_post.go
@@ -1,15 +1,14 @@
 package api
 
 import (
-	"boscoin.io/sebak/lib/errors"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/transaction"
-	"bufio"
-	"bytes"
-	"encoding/json"
-	"io"
-	"net/http"
 )
 
 type TeeReadCloser struct {
@@ -28,32 +27,27 @@ func NewTeeReadCloser(origin io.ReadCloser, w io.Writer) io.ReadCloser {
 	}
 }
 
-func (api NetworkHandlerAPI) PostTransactionsHandler(w http.ResponseWriter, r *http.Request, handler http.HandlerFunc) {
-	var bufferResponse bytes.Buffer
-	writer := bufio.NewWriter(&bufferResponse)
-	interceptedResponseWriter := httputils.NewResponseWriterInterceptor(w, writer)
+func (api NetworkHandlerAPI) PostTransactionsHandler(
+	w http.ResponseWriter,
+	r *http.Request,
+	handler func([]byte, []common.CheckerFunc) (transaction.Transaction, error),
+	funcs []common.CheckerFunc,
+) {
+	defer r.Body.Close()
 
-	var bufferRequest bytes.Buffer
-	r.Body = NewTeeReadCloser(r.Body, &bufferRequest)
-
-	handler(interceptedResponseWriter, r)
-	writer.Flush()
-
-	if interceptedResponseWriter.StatusCode() != http.StatusOK {
-		var errResponse errors.Error
-		if err := json.Unmarshal(bufferResponse.Bytes(), &errResponse); err != nil {
-			// Just bypass
-			w.WriteHeader(interceptedResponseWriter.StatusCode())
-			w.Write(bufferResponse.Bytes())
-			return
-		}
-		httputils.WriteJSONError(w, &errResponse)
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		httputils.WriteJSONError(w, err)
 		return
 	}
 
 	var tx transaction.Transaction
-	json.Unmarshal(bufferRequest.Bytes(), &tx)
-	if err := httputils.WriteJSON(w, 200, resource.NewTransactionPost(tx)); err != nil {
-		http.Error(w, "Error reading request body", http.StatusInternalServerError)
+	if tx, err = handler(body, funcs); err != nil {
+		httputils.WriteJSONError(w, err)
+		return
+	}
+
+	if err = httputils.WriteJSON(w, 200, resource.NewTransactionPost(tx)); err != nil {
+		httputils.WriteJSONError(w, err)
 	}
 }

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -111,7 +111,7 @@ var HandleTransactionCheckerFuncsWithoutBroadcast = []common.CheckerFunc{
 	PushIntoTransactionPool,
 }
 
-func (api NetworkHandlerNode) ReceiveTransaction(body []byte, funcs []common.CheckerFunc) (tx transaction.Transaction, err error) {
+func (api NetworkHandlerNode) ReceiveTransaction(body []byte, funcs []common.CheckerFunc) (transaction.Transaction, error) {
 	message := common.NetworkMessage{Type: common.TransactionMessage, Data: body}
 	checker := &MessageChecker{
 		DefaultChecker:  common.DefaultChecker{Funcs: funcs},
@@ -125,17 +125,15 @@ func (api NetworkHandlerNode) ReceiveTransaction(body []byte, funcs []common.Che
 		Conf:            api.conf,
 	}
 
-	err = common.RunChecker(checker, common.DefaultDeferFunc)
-
+	err := common.RunChecker(checker, common.DefaultDeferFunc)
 	if err != nil {
 		if len(checker.Transaction.H.Hash) > 0 {
 			block.SaveTransactionHistory(api.storage, checker.Transaction, block.TransactionHistoryStatusRejected)
 		}
-		return
+		return transaction.Transaction{}, err
 	}
 
-	tx = checker.Transaction
-	return
+	return checker.Transaction, nil
 }
 
 func (api NetworkHandlerNode) MessageHandler(w http.ResponseWriter, r *http.Request) {

--- a/lib/node/runner/api_node.go
+++ b/lib/node/runner/api_node.go
@@ -102,18 +102,19 @@ var HandleTransactionCheckerFuncs = []common.CheckerFunc{
 	BroadcastTransaction,
 }
 
-func (api NetworkHandlerNode) MessageHandler(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+var HandleTransactionCheckerFuncsWithoutBroadcast = []common.CheckerFunc{
+	TransactionUnmarshal,
+	HasTransaction,
+	SaveTransactionHistory,
+	MessageHasSameSource,
+	MessageValidate,
+	PushIntoTransactionPool,
+}
 
-	body, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		http.Error(w, "Error reading request body", http.StatusInternalServerError)
-		return
-	}
-
+func (api NetworkHandlerNode) ReceiveTransaction(body []byte, funcs []common.CheckerFunc) (tx transaction.Transaction, err error) {
 	message := common.NetworkMessage{Type: common.TransactionMessage, Data: body}
 	checker := &MessageChecker{
-		DefaultChecker:  common.DefaultChecker{Funcs: HandleTransactionCheckerFuncs},
+		DefaultChecker:  common.DefaultChecker{Funcs: funcs},
 		Consensus:       api.consensus,
 		TransactionPool: api.transactionPool,
 		Storage:         api.storage,
@@ -124,10 +125,29 @@ func (api NetworkHandlerNode) MessageHandler(w http.ResponseWriter, r *http.Requ
 		Conf:            api.conf,
 	}
 
-	if err = common.RunChecker(checker, common.DefaultDeferFunc); err != nil {
+	err = common.RunChecker(checker, common.DefaultDeferFunc)
+
+	if err != nil {
 		if len(checker.Transaction.H.Hash) > 0 {
 			block.SaveTransactionHistory(api.storage, checker.Transaction, block.TransactionHistoryStatusRejected)
 		}
+		return
+	}
+
+	tx = checker.Transaction
+	return
+}
+
+func (api NetworkHandlerNode) MessageHandler(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Error reading request body", http.StatusInternalServerError)
+		return
+	}
+
+	if _, err = api.ReceiveTransaction(body, HandleTransactionCheckerFuncsWithoutBroadcast); err != nil {
 		http.Error(w, err.Error(), httputils.StatusCode(err))
 		return
 	}

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -254,7 +254,10 @@ func (nr *NodeRunner) Ready() {
 
 	TransactionsHandler := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
-			apiHandler.PostTransactionsHandler(w, r, nodeHandler.MessageHandler)
+			apiHandler.PostTransactionsHandler(
+				w, r,
+				nodeHandler.ReceiveTransaction, HandleTransactionCheckerFuncs,
+			)
 			return
 		}
 

--- a/tests/node/default_runner.sh
+++ b/tests/node/default_runner.sh
@@ -20,7 +20,7 @@ for JSONFILE in $(find . -name "*.json" -type f | sort); do
          --request POST \
          --header "Content-Type: application/json" \
          --data "$(cat ${JSONFILE})" \
-         https://127.0.0.1:${PORT}/node/message \
+         https://127.0.0.1:${PORT}/api/v1/transactions \
          >/dev/null 2>&1
     # Intermediate checks
     if [ -f ${JSONFILE}.check ]; then


### PR DESCRIPTION
### Github Issue
Resolves #639

### Background

See #639 

### Solution

* The existing `api.PostTransaction()` and `runner.MessageHandler()` will use `NetworkHandlerNode.ReceiveTransaction()`
* `NetworkHandlerNode.ReceiveTransaction()` takes `[]common.CheckerFunc` as argument
* `api.PostTransaction()` will use `HandleTransactionCheckerFuncs`(broadcasting version)
* `api.PostTransaction()` will use `HandleTransactionCheckerFuncsWithoutBroadcast`(not broadcasting version)