### PR TITLE
Move all dependency to keypair within Sebak

### DIFF
--- a/cmd/sebak/cmd/genesis.go
+++ b/cmd/sebak/cmd/genesis.go
@@ -8,11 +8,11 @@ import (
 
 	logging "github.com/inconshreveable/log15"
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/keypair"
 
 	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/storage"
 )
 

--- a/cmd/sebak/cmd/key/generate.go
+++ b/cmd/sebak/cmd/key/generate.go
@@ -4,15 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"html/template"
+	"io"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/keypair"
-
-	"io"
 
 	"boscoin.io/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/lib/common/keypair"
 )
 
 var (
@@ -114,7 +113,7 @@ Network Passphrase: "{{ .networkPassphrase}}"{{ end }}
 
 func generateKP(seedOrNetworkPassphrase string, fromSeed bool) (full *keypair.Full, err error) {
 	if len(seedOrNetworkPassphrase) == 0 {
-		full, err = keypair.Random()
+		full, err = keypair.RandomCanFail()
 	} else if fromSeed {
 		var kp keypair.KP
 

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -13,12 +13,12 @@ import (
 	isatty "github.com/mattn/go-isatty"
 	"github.com/oklog/run"
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/keypair"
 	"github.com/ulule/limiter"
 	"golang.org/x/net/http2"
 
 	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network"

--- a/cmd/sebak/cmd/wallet/payment.go
+++ b/cmd/sebak/cmd/wallet/payment.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/keypair"
 
 	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"

--- a/cmd/sebak/cmd/wallet/unfreezeRequest.go
+++ b/cmd/sebak/cmd/wallet/unfreezeRequest.go
@@ -9,11 +9,11 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/stellar/go/keypair"
 
 	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"

--- a/lib/ballot/ballot.go
+++ b/lib/ballot/ballot.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/stellar/go/keypair"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/voting"
 )
@@ -193,7 +193,7 @@ func (b *Ballot) SignByProposer(kp keypair.KP, networkID []byte) {
 
 	b.B.Proposed.Confirmed = common.NowISO8601()
 	hash := common.MustMakeObjectHash(b.B.Proposed)
-	signature, _ := common.MakeSignature(kp, networkID, string(hash))
+	signature, _ := keypair.MakeSignature(kp, networkID, string(hash))
 	b.H.ProposerSignature = base58.Encode(signature)
 }
 
@@ -205,7 +205,7 @@ func (b *Ballot) Sign(kp keypair.KP, networkID []byte) {
 	b.B.Confirmed = common.NowISO8601()
 	b.B.Source = kp.Address()
 	b.H.Hash = b.B.MakeHashString()
-	signature, _ := common.MakeSignature(kp, networkID, b.H.Hash)
+	signature, _ := keypair.MakeSignature(kp, networkID, b.H.Hash)
 	b.H.Signature = base58.Encode(signature)
 
 	return

--- a/lib/ballot/ballot_test.go
+++ b/lib/ballot/ballot_test.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/transaction"
@@ -21,8 +21,8 @@ var networkID []byte = []byte("sebak-test-network")
 
 func TestErrorBallotHasOverMaxTransactionsInBallot(t *testing.T) {
 
-	kp, _ := keypair.Random()
-	commonKP, _ := keypair.Random()
+	kp := keypair.Random()
+	commonKP := keypair.Random()
 	endpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	node, _ := node.NewLocalNode(kp, endpoint, "")
 
@@ -68,8 +68,8 @@ func TestErrorBallotHasOverMaxTransactionsInBallot(t *testing.T) {
 }
 
 func TestBallotBadConfirmedTime(t *testing.T) {
-	kp, _ := keypair.Random()
-	commonKP, _ := keypair.Random()
+	kp := keypair.Random()
+	commonKP := keypair.Random()
 	endpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	node, _ := node.NewLocalNode(kp, endpoint, "")
 
@@ -77,7 +77,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 
 	updateBallot := func(ballot *Ballot) {
 		ballot.H.Hash = ballot.B.MakeHashString()
-		signature, _ := common.MakeSignature(kp, networkID, ballot.H.Hash)
+		signature, _ := keypair.MakeSignature(kp, networkID, ballot.H.Hash)
 		ballot.H.Signature = base58.Encode(signature)
 	}
 
@@ -146,7 +146,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 }
 
 func TestBallotEmptyHash(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	node, _ := node.NewLocalNode(kp, &common.Endpoint{}, "")
 	r := voting.Basis{}
 	b := NewBallot(node.Address(), node.Address(), r, []string{})
@@ -158,13 +158,13 @@ func TestBallotEmptyHash(t *testing.T) {
 // TestBallotProposerTransaction checks; the proposed Ballot must have the
 // proposed transaction.
 func TestBallotProposerTransaction(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	endpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	node, _ := node.NewLocalNode(kp, endpoint, "")
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
-	commonKP, _ := keypair.Random()
+	commonKP := keypair.Random()
 
 	conf := common.NewConfig()
 	{ // without ProposerTransaction
@@ -200,7 +200,7 @@ func TestBallotProposerTransaction(t *testing.T) {
 }
 
 func TestNewBallot(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
 	n, _ := node.NewLocalNode(kp, nodeEndpoint, "")
@@ -219,21 +219,20 @@ func TestIsBallotWellFormed(t *testing.T) {
 	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
 
-	nodeKP, _ := keypair.Random()
+	nodeKP := keypair.Random()
 	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
 
-	proposerKP, _ := keypair.Random()
+	proposerKP := keypair.Random()
 	p, _ := node.NewLocalNode(proposerKP, proposerEndpoint, "")
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
 	initialBalance := common.Amount(common.BaseReserve)
-	kpNewAccount, _ := keypair.Random()
-	tx := transaction.MakeTransactionCreateAccount(nodeKP, kpNewAccount.Address(), initialBalance)
+	tx := transaction.MakeTransactionCreateAccount(nodeKP, keypair.Random().Address(), initialBalance)
 
 	wellBallot := NewBallot(n.Address(), p.Address(), basis, []string{tx.GetHash()})
 
-	commonKP, _ := keypair.Random()
+	commonKP := keypair.Random()
 	commonAccount := block.NewBlockAccount(commonKP.Address(), 0)
 
 	opi, _ := NewInflationFromBallot(*wellBallot, commonAccount.Address, initialBalance)
@@ -263,17 +262,16 @@ func TestIsExpiredBallotWellFormed(t *testing.T) {
 	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
 
-	nodeKP, _ := keypair.Random()
+	nodeKP := keypair.Random()
 	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
 
-	proposerKP, _ := keypair.Random()
+	proposerKP := keypair.Random()
 	p, _ := node.NewLocalNode(proposerKP, proposerEndpoint, "")
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
 	initialBalance := common.Amount(common.BaseReserve)
-	kpNewAccount, _ := keypair.Random()
-	tx := transaction.MakeTransactionCreateAccount(nodeKP, kpNewAccount.Address(), initialBalance)
+	tx := transaction.MakeTransactionCreateAccount(nodeKP, keypair.Random().Address(), initialBalance)
 
 	b := NewBallot(n.Address(), p.Address(), basis, []string{tx.GetHash()})
 
@@ -292,21 +290,20 @@ func TestIsExpiredBallotWithProposerTransactionWellFormed(t *testing.T) {
 	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
 	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
 
-	nodeKP, _ := keypair.Random()
+	nodeKP := keypair.Random()
 	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
 
-	proposerKP, _ := keypair.Random()
+	proposerKP := keypair.Random()
 	p, _ := node.NewLocalNode(proposerKP, proposerEndpoint, "")
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
 	initialBalance := common.Amount(common.BaseReserve)
-	kpNewAccount, _ := keypair.Random()
-	tx := transaction.MakeTransactionCreateAccount(nodeKP, kpNewAccount.Address(), initialBalance)
+	tx := transaction.MakeTransactionCreateAccount(nodeKP, keypair.Random().Address(), initialBalance)
 
 	b := NewBallot(n.Address(), p.Address(), basis, []string{tx.GetHash()})
 
-	commonKP, _ := keypair.Random()
+	commonKP := keypair.Random()
 	commonAccount := block.NewBlockAccount(commonKP.Address(), 0)
 
 	opi, _ := NewInflationFromBallot(*b, commonAccount.Address, initialBalance)

--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -6,10 +6,11 @@ import (
 	"time"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction/operation"
-	"github.com/stellar/go/keypair"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,13 +106,13 @@ func TestMakeGenesisBlock(t *testing.T) {
 	st := storage.NewTestStorage()
 	defer st.Close()
 
-	genesisKP, _ := keypair.Random()
+	genesisKP := keypair.Random()
 	balance := common.Amount(100)
 	genesisAccount := NewBlockAccount(genesisKP.Address(), balance)
 	err := genesisAccount.Save(st)
 	require.NoError(t, err)
 
-	commonKP, _ := keypair.Random()
+	commonKP := keypair.Random()
 	commonAccount := NewBlockAccount(commonKP.Address(), 0)
 	err = commonAccount.Save(st)
 	require.NoError(t, err)
@@ -170,13 +171,13 @@ func TestMakeGenesisBlockOverride(t *testing.T) {
 	defer st.Close()
 
 	{ // create genesis block
-		kp, _ := keypair.Random()
+		kp := keypair.Random()
 		balance := common.Amount(100)
 		account := NewBlockAccount(kp.Address(), balance)
 		err := account.Save(st)
 		require.NoError(t, err)
 
-		commonKP, _ := keypair.Random()
+		commonKP := keypair.Random()
 		commonAccount := NewBlockAccount(commonKP.Address(), 0)
 		err = commonAccount.Save(st)
 		require.NoError(t, err)
@@ -187,13 +188,13 @@ func TestMakeGenesisBlockOverride(t *testing.T) {
 	}
 
 	{ // try again to create genesis block
-		kp, _ := keypair.Random()
+		kp := keypair.Random()
 		balance := common.Amount(100)
 		account := NewBlockAccount(kp.Address(), balance)
 		err := account.Save(st)
 		require.NoError(t, err)
 
-		commonKP, _ := keypair.Random()
+		commonKP := keypair.Random()
 		commonAccount := NewBlockAccount(commonKP.Address(), 0)
 		err = commonAccount.Save(st)
 		require.NoError(t, err)
@@ -208,12 +209,12 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 	defer st.Close()
 
 	// create genesis block
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	balance := common.Amount(100)
 	account := NewBlockAccount(kp.Address(), balance)
 	account.MustSave(st)
 
-	commonKP, _ := keypair.Random()
+	commonKP := keypair.Random()
 	commonAccount := NewBlockAccount(commonKP.Address(), 0)
 	commonAccount.MustSave(st)
 
@@ -248,12 +249,12 @@ func TestMakeGenesisBlockFindCommonAccount(t *testing.T) {
 	defer st.Close()
 
 	// create genesis block
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	balance := common.Amount(100)
 	genesisAccount := NewBlockAccount(kp.Address(), balance)
 	genesisAccount.MustSave(st)
 
-	commonKP, _ := keypair.Random()
+	commonKP := keypair.Random()
 	commonAccount := NewBlockAccount(commonKP.Address(), 0)
 	commonAccount.MustSave(st)
 

--- a/lib/block/genesis.go
+++ b/lib/block/genesis.go
@@ -8,9 +8,8 @@ package block
 import (
 	"fmt"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -1,9 +1,8 @@
 package block
 
 import (
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/voting"
@@ -12,8 +11,7 @@ import (
 var networkID []byte = []byte("sebak-test-network")
 
 func TestMakeBlockAccount() *BlockAccount {
-	kp, _ := keypair.Random()
-	address := kp.Address()
+	address := keypair.Random().Address()
 	balance := common.Amount(common.BaseReserve)
 
 	return NewBlockAccount(address, balance)
@@ -25,15 +23,8 @@ var (
 )
 
 func init() {
-	var err error
-	GenesisKP, err = keypair.Random()
-	if err != nil {
-		panic(err)
-	}
-	CommonKP, err = keypair.Random()
-	if err != nil {
-		panic(err)
-	}
+	GenesisKP = keypair.Random()
+	CommonKP = keypair.Random()
 }
 
 //
@@ -101,7 +92,7 @@ func (b *BlockOperation) MustSave(st *storage.LevelDBBackend) {
 }
 
 func TestMakeNewBlock(transactions []string) Block {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 
 	return *NewBlock(
 		kp.Address(),
@@ -118,7 +109,7 @@ func TestMakeNewBlock(transactions []string) Block {
 }
 
 func TestMakeNewBlockWithPrevBlock(prevBlock Block, txs []string) Block {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 
 	return *NewBlock(
 		kp.Address(),

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -3,10 +3,10 @@ package block
 import (
 	"testing"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
@@ -71,8 +71,8 @@ func TestBlockTransactionSaveExisting(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionSource(t *testing.T) {
-	kp, _ := keypair.Random()
-	kpAnother, _ := keypair.Random()
+	kp := keypair.Random()
+	kpAnother := keypair.Random()
 	st := storage.NewTestStorage()
 
 	numTxs := 10
@@ -154,7 +154,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionConfirmed(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	st := storage.NewTestStorage()
 
 	numTxs := 10
@@ -232,8 +232,8 @@ func TestBlockTransactionMultipleSave(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
-	kp, _ := keypair.Random()
-	kpAnother, _ := keypair.Random()
+	kp := keypair.Random()
+	kpAnother := keypair.Random()
 	st := storage.NewTestStorage()
 
 	numTxs := 5
@@ -306,7 +306,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	st := storage.NewTestStorage()
 
 	numTxs := 5
@@ -383,7 +383,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	st := storage.NewTestStorage()
 
 	numTxs := 5

--- a/lib/common/keypair/keypair.go
+++ b/lib/common/keypair/keypair.go
@@ -1,0 +1,25 @@
+//
+// Encapsulate Stellar's keypair package
+//
+// Provides additional wrapper and convenience functions,
+// suited for usage within Sebak
+//
+package keypair
+
+import (
+	stellar "github.com/stellar/go/keypair"
+)
+
+// Aliases to stellar types
+type Full = stellar.Full
+type KP = stellar.KP
+
+// Aliases to stellar functions
+var Master = stellar.Master
+var Parse = stellar.Parse
+var RandomCanFail = stellar.Random
+
+// MakeSignature makes signature from given hash string
+func MakeSignature(kp KP, networkID []byte, hash string) ([]byte, error) {
+	return kp.Sign(append(networkID, []byte(hash)...))
+}

--- a/lib/common/keypair/test.go
+++ b/lib/common/keypair/test.go
@@ -1,0 +1,17 @@
+// Provides utilities to use in test code
+package keypair
+
+import (
+	stellar "github.com/stellar/go/keypair"
+)
+
+//
+// Create a new keypair to be used by test code
+//
+func Random() *Full {
+	if kp, err := stellar.Random(); err != nil {
+		panic(err)
+	} else {
+		return kp
+	}
+}

--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -10,7 +10,6 @@ import (
 	"sort"
 
 	uuid "github.com/satori/go.uuid"
-	"github.com/stellar/go/keypair"
 )
 
 const MaxUintEncodeByte = 8
@@ -141,11 +140,6 @@ func IsStringMapEqualWithHash(a, b map[string]bool) bool {
 	bHash := MustMakeObjectHash(b)
 
 	return bytes.Equal(aHash, bHash)
-}
-
-// MakeSignature makes signature from given hash string
-func MakeSignature(kp keypair.KP, networkID []byte, hash string) ([]byte, error) {
-	return kp.Sign(append(networkID, []byte(hash)...))
 }
 
 func EncodeUint64ToByteSlice(i uint64) [MaxUintEncodeByte]byte {

--- a/lib/network/test.go
+++ b/lib/network/test.go
@@ -4,9 +4,8 @@
 package network
 
 import (
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/node"
-
-	"github.com/stellar/go/keypair"
 )
 
 //
@@ -18,11 +17,8 @@ import (
 //
 func CreateMemoryNetwork(prev *MemoryNetwork) (*keypair.Full, *MemoryNetwork, *node.LocalNode) {
 	mn := prev.NewMemoryNetwork()
-
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	localNode, _ := node.NewLocalNode(kp, mn.Endpoint(), "")
-
 	mn.SetLocalNode(localNode)
-
 	return kp, mn, localNode
 }

--- a/lib/node/local_node.go
+++ b/lib/node/local_node.go
@@ -13,9 +13,8 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 )
 
 type LocalNode struct {

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNodeStateChange(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
@@ -28,7 +28,7 @@ func TestNodeStateChange(t *testing.T) {
 }
 
 func TestNodeMarshalJSON(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
@@ -52,7 +52,7 @@ func TestNodeMarshalJSON(t *testing.T) {
 }
 
 func TestNodeMarshalJSONWithValidator(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 
 	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
@@ -63,8 +63,8 @@ func TestNodeMarshalJSONWithValidator(t *testing.T) {
 	endpoint3, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5002?NodeName=n3"))
 	require.Equal(t, nil, err)
 
-	kp2, _ := keypair.Random()
-	kp3, _ := keypair.Random()
+	kp2 := keypair.Random()
+	kp3 := keypair.Random()
 
 	validator1, _ := NewValidator(kp2.Address(), endpoint2, "v1")
 	validator2, _ := NewValidator(kp3.Address(), endpoint3, "v2")

--- a/lib/node/runner/api/account_test.go
+++ b/lib/node/runner/api/account_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 
 	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network/httputils"
-	"github.com/stellar/go/keypair"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,7 +41,7 @@ func TestGetAccountHandler(t *testing.T) {
 	}
 
 	{ // unknown address
-		unknownKey, _ := keypair.Random()
+		unknownKey := keypair.Random()
 		url := strings.Replace(GetAccountHandlerPattern, "{id}", unknownKey.Address(), -1)
 		req, _ := http.NewRequest("GET", ts.URL+url, nil)
 		resp, err := ts.Client().Do(req)
@@ -110,8 +111,7 @@ func TestGetNonExistentAccountHandler(t *testing.T) {
 
 	{
 		// Do a Request
-		kp, _ := keypair.Random()
-		url := strings.Replace(GetAccountHandlerPattern, "{id}", kp.Address(), -1)
+		url := strings.Replace(GetAccountHandlerPattern, "{id}", keypair.Random().Address(), -1)
 		respBody := request(ts, url, false)
 		reader := bufio.NewReader(respBody)
 		readByte, err := ioutil.ReadAll(reader)

--- a/lib/node/runner/api/node_info_test.go
+++ b/lib/node/runner/api/node_info_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/version"
 )
@@ -23,7 +23,7 @@ func TestAPIGetNodeInfoHandler(t *testing.T) {
 	defer st.Close()
 
 	endpoint, _ := common.ParseEndpoint("http://1.2.3.4:5678")
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	localNode, _ := node.NewLocalNode(kp, endpoint, "")
 
 	nv := node.NodeVersion{

--- a/lib/node/runner/api/test.go
+++ b/lib/node/runner/api/test.go
@@ -6,9 +6,9 @@ import (
 	"net/http/httptest"
 
 	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
 
 	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 )
@@ -51,10 +51,7 @@ func prepareOps(storage *storage.LevelDBBackend, count int) (*keypair.Full, []bl
 	return kp, boList
 }
 func prepareOpsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full, []block.BlockOperation) {
-	kp, err := keypair.Random()
-	if err != nil {
-		panic(err)
-	}
+	kp := keypair.Random()
 	var txs []transaction.Transaction
 	var txHashes []string
 	var boList []block.BlockOperation
@@ -79,10 +76,7 @@ func prepareOpsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full
 }
 
 func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, []block.BlockTransaction) {
-	kp, err := keypair.Random()
-	if err != nil {
-		panic(err)
-	}
+	kp := keypair.Random()
 	var txs []transaction.Transaction
 	var txHashes []string
 	var btList []block.BlockTransaction
@@ -103,10 +97,7 @@ func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, []bl
 }
 
 func prepareTxsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full, []block.BlockTransaction) {
-	kp, err := keypair.Random()
-	if err != nil {
-		panic(err)
-	}
+	kp := keypair.Random()
 	var txs []transaction.Transaction
 	var txHashes []string
 	var btList []block.BlockTransaction
@@ -125,11 +116,7 @@ func prepareTxsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full
 }
 
 func prepareTxWithoutSave(st *storage.LevelDBBackend) (*keypair.Full, *transaction.Transaction, *block.BlockTransaction) {
-	kp, err := keypair.Random()
-	if err != nil {
-		panic(err)
-	}
-
+	kp := keypair.Random()
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
 
 	theBlock := block.TestMakeNewBlockWithPrevBlock(block.GetLatestBlock(st), []string{tx.GetHash()})

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -10,11 +10,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/transaction"
@@ -71,9 +71,7 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	kp, err := keypair.Random()
-	require.NoError(t, err)
-
+	kp := keypair.Random()
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 10, kp)
 	bt := block.NewBlockTransactionFromTransaction("block-hash", 1, common.NowISO8601(), tx)
 

--- a/lib/node/runner/api_message_handler_test.go
+++ b/lib/node/runner/api_message_handler_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node/runner/api"
@@ -62,7 +62,7 @@ func (p *HelperTestNodeMessageHandler) URL(urlValues url.Values) (u *url.URL) {
 }
 
 func (p *HelperTestNodeMessageHandler) makeTransaction() (tx transaction.Transaction) {
-	receiverKP, _ := keypair.Random()
+	receiverKP := keypair.Random()
 	tx = transaction.MakeTransactionCreateAccount(p.genesisKeypair, receiverKP.Address(), common.BaseReserve)
 	tx.B.SequenceID = p.genesisAccount.SequenceID
 	tx.Sign(p.genesisKeypair, networkID)

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -18,11 +18,11 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
@@ -79,7 +79,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Netw
 		return
 	}
 
-	kp, _ = keypair.Random()
+	kp = keypair.Random()
 	localNode, _ := node.NewLocalNode(kp, endpoint, "")
 	localNode.AddValidators(localNode.ConvertToValidator())
 
@@ -217,9 +217,8 @@ func TestGetNodeInfoHandler(t *testing.T) {
 	st := storage.NewTestStorage()
 	defer st.Close()
 
-	kp, _ := keypair.Random()
 	endpoint, _ := common.NewEndpointFromString("http://localhost:12345")
-	localNode, _ := node.NewLocalNode(kp, endpoint, "")
+	localNode, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
 	localNode.AddValidators(localNode.ConvertToValidator())
 	isaac, _ := consensus.NewISAAC(
 		networkID,

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network"
@@ -42,7 +42,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 	p.st = block.InitTestBlockchain()
 	p.blocks = append(p.blocks, block.GetGenesis(p.st))
 
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	endpoint, _ := common.NewEndpointFromString(
 		fmt.Sprintf("http://localhost:12345"),
 	)
@@ -71,7 +71,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 
 	p.server = httptest.NewServer(p.router)
 
-	p.genesisKeypair, _ = keypair.Random()
+	p.genesisKeypair = keypair.Random()
 	p.genesisAccount = block.NewBlockAccount(p.genesisKeypair.Address(), common.MaximumBalance)
 	p.genesisAccount.MustSave(p.st)
 

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/node"
@@ -58,11 +58,11 @@ func (p *ballotCheckerProposedTransaction) MakeBallot(numberOfTxs int) (blt *bal
 	}
 
 	for i := 0; i < numberOfTxs; i++ {
-		kpA, _ := keypair.Random()
+		kpA := keypair.Random()
 		accountA := block.NewBlockAccount(kpA.Address(), common.Amount(common.BaseReserve))
 		accountA.MustSave(p.nr.Storage())
 
-		kpB, _ := keypair.Random()
+		kpB := keypair.Random()
 
 		tx := transaction.MakeTransactionCreateAccount(kpA, kpB.Address(), common.Amount(1))
 		tx.B.SequenceID = accountA.SequenceID
@@ -232,7 +232,7 @@ func TestProposedTransactionDifferentSigning(t *testing.T) {
 	}
 
 	{ // sign different source with `Ballot.Proposer()`
-		newKP, _ := keypair.Random()
+		newKP := keypair.Random()
 		ptx := blt.ProposerTransaction()
 		ptx.B.Source = newKP.Address()
 		ptx.Sign(newKP, networkID)
@@ -522,7 +522,7 @@ func TestProposedTransactionWithCollectTxFeeWrongCommonAddress(t *testing.T) {
 	p.Prepare()
 
 	// with wrong `CollectTxFee.Amount` count
-	wrongKP, _ := keypair.Random()
+	wrongKP := keypair.Random()
 	blt := p.MakeBallot(4)
 	opb, _ := blt.ProposerTransaction().CollectTxFee()
 	opb.Target = wrongKP.Address()
@@ -581,7 +581,7 @@ func TestProposedTransactionWithInflationWrongCommonAddress(t *testing.T) {
 	p.Prepare()
 
 	// with wrong `CollectTxFee.Amount` count
-	wrongKP, _ := keypair.Random()
+	wrongKP := keypair.Random()
 	blt := p.MakeBallot(4)
 	opb, _ := blt.ProposerTransaction().Inflation()
 	opb.Target = wrongKP.Address()
@@ -824,7 +824,7 @@ func TestProposedTransactionWithNormalOperations(t *testing.T) {
 		ptx := blt.ProposerTransaction()
 		op := ptx.B.Operations[1]
 
-		kp, _ := keypair.Random()
+		kp := keypair.Random()
 		opb := operation.NewCreateAccount(kp.Address(), common.Amount(1), "")
 		newOp, _ := operation.NewOperation(opb)
 		ptx.B.Operations = []operation.Operation{op, newOp}
@@ -851,7 +851,7 @@ func TestProposedTransactionWithWrongNumberOfOperations(t *testing.T) {
 	{ // more than 2
 		ptx := blt.ProposerTransaction()
 
-		kp, _ := keypair.Random()
+		kp := keypair.Random()
 		opb := operation.NewCreateAccount(kp.Address(), common.Amount(1), "")
 		newOp, _ := operation.NewOperation(opb)
 		ptx.B.Operations = append(ptx.B.Operations, newOp)

--- a/lib/node/runner/checker_ballot_transaction_test.go
+++ b/lib/node/runner/checker_ballot_transaction_test.go
@@ -16,19 +16,19 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 )
 
 // Test with some missing block accounts
 func TestValidateTxPaymentMissingBlockAccount(t *testing.T) {
-	kps, _ := keypair.Random()
-	kpt, _ := keypair.Random()
+	kps := keypair.Random()
+	kpt := keypair.Random()
 
 	st := storage.NewTestStorage()
 	defer st.Close()
@@ -80,8 +80,8 @@ func TestValidateTxPaymentMissingBlockAccount(t *testing.T) {
 
 // Check for correct sequence ID
 func TestValidateTxWrongSequenceID(t *testing.T) {
-	kps, _ := keypair.Random()
-	kpt, _ := keypair.Random()
+	kps := keypair.Random()
+	kpt := keypair.Random()
 
 	st := storage.NewTestStorage()
 	defer st.Close()
@@ -123,8 +123,8 @@ func TestValidateTxWrongSequenceID(t *testing.T) {
 
 // Check sending the whole balance
 func TestValidateTxOverBalance(t *testing.T) {
-	kps, _ := keypair.Random()
-	kpt, _ := keypair.Random()
+	kps := keypair.Random()
+	kpt := keypair.Random()
 
 	st := storage.NewTestStorage()
 	defer st.Close()
@@ -180,8 +180,8 @@ func TestValidateTxOverBalance(t *testing.T) {
 
 // Test creating an already existing account
 func TestValidateOpCreateExistsAccount(t *testing.T) {
-	kps, _ := keypair.Random()
-	kpt, _ := keypair.Random()
+	kps := keypair.Random()
+	kpt := keypair.Random()
 
 	st := storage.NewTestStorage()
 	defer st.Close()

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -4,12 +4,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/transaction"
@@ -29,7 +29,7 @@ func TestOnlyValidTransactionInTransactionPool(t *testing.T) {
 	rootAccount, _ := block.GetBlockAccount(nodeRunner.Storage(), rootKP.Address())
 
 	TestMakeBlockAccount := func(balance common.Amount) (account *block.BlockAccount, kp *keypair.Full) {
-		kp, _ = keypair.Random()
+		kp = keypair.Random()
 		account = block.NewBlockAccount(kp.Address(), balance)
 
 		return
@@ -195,11 +195,11 @@ func (g *getMissingTransactionTesting) MakeBallot(numberOfTxs int) (blt *ballot.
 	var txHashes []string
 	var txs []transaction.Transaction
 	for i := 0; i < numberOfTxs; i++ {
-		kpA, _ := keypair.Random()
+		kpA := keypair.Random()
 		accountA := block.NewBlockAccount(kpA.Address(), common.Amount(common.BaseReserve)*2)
 		accountA.MustSave(g.proposerNR.Storage())
 
-		kpB, _ := keypair.Random()
+		kpB := keypair.Random()
 
 		tx := transaction.MakeTransactionCreateAccount(kpA, kpB.Address(), common.BaseReserve)
 		tx.B.SequenceID = accountA.SequenceID
@@ -438,11 +438,11 @@ func (p *irregularIncomingBallot) makeBallot(state ballot.State) (blt *ballot.Ba
 		TotalTxs:  p.genesisBlock.TotalTxs,
 	}
 
-	p.keyA, _ = keypair.Random()
+	p.keyA = keypair.Random()
 	p.accountA = block.NewBlockAccount(p.keyA.Address(), common.Amount(common.BaseReserve)*2)
 	p.accountA.MustSave(p.nr.Storage())
 
-	kpB, _ := keypair.Random()
+	kpB := keypair.Random()
 
 	tx := transaction.MakeTransactionCreateAccount(p.keyA, kpB.Address(), common.BaseReserve)
 	tx.B.SequenceID = p.accountA.SequenceID

--- a/lib/node/runner/finish_ballot_test.go
+++ b/lib/node/runner/finish_ballot_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	logging "github.com/inconshreveable/log15"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
@@ -103,16 +103,16 @@ func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOpe
 		}
 
 		for i := 0; i < numberOfTransactions; i++ {
-			kpA, _ := keypair.Random()
+			kpA := keypair.Random()
 			accountA := block.NewBlockAccount(kpA.Address(), common.Amount(common.BaseReserve))
 			accountA.MustSave(nr.Storage())
 
-			kpB, _ := keypair.Random()
+			kpB := keypair.Random()
 			tx := transaction.MakeTransactionCreateAccount(kpA, kpB.Address(), common.Amount(1))
 
 			var ops []operation.Operation
 			for j := 0; j < numberOfOperations-1; j++ {
-				kpC, _ := keypair.Random()
+				kpC := keypair.Random()
 
 				opb := operation.NewCreateAccount(kpC.Address(), common.Amount(1), "")
 				op := operation.Operation{

--- a/lib/node/runner/node_runner_memory_network_test.go
+++ b/lib/node/runner/node_runner_memory_network_test.go
@@ -2,10 +2,9 @@ package runner
 
 import (
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/transaction/operation"
-
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/transaction"
-	"github.com/stellar/go/keypair"
+	"boscoin.io/sebak/lib/transaction/operation"
 )
 
 func makeTransaction(kp *keypair.Full) (tx transaction.Transaction) {

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
@@ -114,7 +114,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 	var nodes []*node.LocalNode
 	var ports []int
 	for i := 0; i < n; i++ {
-		kp, _ := keypair.Random()
+		kp := keypair.Random()
 		port := common.GetFreePort(ports...)
 		if port < 1 {
 			panic("failed to find free port")

--- a/lib/node/runner/test.go
+++ b/lib/node/runner/test.go
@@ -4,12 +4,12 @@ import (
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/voting"
-	"github.com/stellar/go/keypair"
 )
 
 var networkID []byte = []byte("sebak-test-network")
@@ -34,7 +34,7 @@ func MakeNodeRunner() (*NodeRunner, *node.LocalNode) {
 }
 
 func GetTransaction() (transaction.Transaction, []byte) {
-	kpNewAccount, _ := keypair.Random()
+	kpNewAccount := keypair.Random()
 
 	tx := transaction.MakeTransactionCreateAccount(block.GenesisKP, kpNewAccount.Address(), common.BaseReserve)
 	tx.B.SequenceID = uint64(0)
@@ -49,7 +49,7 @@ func GetTransaction() (transaction.Transaction, []byte) {
 
 func GetCreateAccountTransaction(sequenceID uint64, amount uint64) (transaction.Transaction, []byte, *keypair.Full) {
 	initialBalance := common.Amount(amount)
-	kpNewAccount, _ := keypair.Random()
+	kpNewAccount := keypair.Random()
 	tx := transaction.MakeTransactionCreateAccount(block.GenesisKP, kpNewAccount.Address(), initialBalance)
 	tx.B.SequenceID = sequenceID
 	tx.Sign(block.GenesisKP, networkID)
@@ -63,7 +63,7 @@ func GetCreateAccountTransaction(sequenceID uint64, amount uint64) (transaction.
 
 func GetFreezingTransaction(kpSource *keypair.Full, sequenceID uint64, amount uint64) (transaction.Transaction, []byte, *keypair.Full) {
 	initialBalance := common.Amount(amount)
-	kpNewAccount, _ := keypair.Random()
+	kpNewAccount := keypair.Random()
 
 	tx := transaction.MakeTransactionCreateFrozenAccount(kpSource, kpNewAccount.Address(), initialBalance, kpSource.Address())
 	tx.B.SequenceID = sequenceID

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -14,8 +14,7 @@ import (
 	"sync"
 
 	"boscoin.io/sebak/lib/common"
-
-	"github.com/stellar/go/keypair"
+	"boscoin.io/sebak/lib/common/keypair"
 )
 
 type ValidatorFromJSON struct {

--- a/lib/node/validator_test.go
+++ b/lib/node/validator_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 )
 
@@ -77,7 +77,7 @@ func TestParseValidatorFromURI(t *testing.T) {
 }
 
 func TestValidatorMarshalJSON(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 
 	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
@@ -106,7 +106,7 @@ func TestValidatorNewValidatorFromString(t *testing.T) {
 }
 
 func TestValidatorUnMarshalJSON(t *testing.T) {
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 
 	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
-	"github.com/stellar/go/keypair"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,11 +18,10 @@ func TestNewConfig(t *testing.T) {
 	_, nt, _ := network.CreateMemoryNetwork(nil)
 	cm := &mockConnectionManager{}
 
-	kp, _ := keypair.Random()
 	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
-	node, _ := node.NewLocalNode(kp, endpoint, "")
+	node, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
 	networkID := []byte("test-network")
 
 	cfg := NewConfig(networkID, node, st, nt, cm, common.NewConfig())

--- a/lib/sync/fetcher_test.go
+++ b/lib/sync/fetcher_test.go
@@ -9,11 +9,11 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/node/runner"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,7 +35,7 @@ func TestBlockFetcher(t *testing.T) {
 	st := block.InitTestBlockchain()
 	defer st.Close()
 
-	kp, _ := keypair.Random()
+	kp := keypair.Random()
 	_, nw, localNode := network.CreateMemoryNetwork(nil)
 	cm := &mockConnectionManager{
 		allConnected: []string{kp.Address()},

--- a/lib/transaction/checker.go
+++ b/lib/transaction/checker.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/stellar/go/keypair"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/transaction/operation"
 )

--- a/lib/transaction/operation/collect_tx_fee.go
+++ b/lib/transaction/operation/collect_tx_fee.go
@@ -3,9 +3,8 @@ package operation
 import (
 	"encoding/json"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 )
 

--- a/lib/transaction/operation/create_account.go
+++ b/lib/transaction/operation/create_account.go
@@ -3,9 +3,8 @@ package operation
 import (
 	"encoding/json"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 )
 

--- a/lib/transaction/operation/operation_inflation.go
+++ b/lib/transaction/operation/operation_inflation.go
@@ -4,9 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 )
 

--- a/lib/transaction/operation/operation_test.go
+++ b/lib/transaction/operation/operation_test.go
@@ -4,10 +4,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 )
 
 func TestMakeHashOfOperationBodyPayment(t *testing.T) {

--- a/lib/transaction/operation/payment.go
+++ b/lib/transaction/operation/payment.go
@@ -3,9 +3,8 @@ package operation
 import (
 	"encoding/json"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 )
 

--- a/lib/transaction/operation/test.go
+++ b/lib/transaction/operation/test.go
@@ -3,9 +3,8 @@ package operation
 import (
 	"math/rand"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 )
 
 var (
@@ -14,7 +13,7 @@ var (
 )
 
 func init() {
-	kp, _ = keypair.Random()
+	kp = keypair.Random()
 }
 
 func TestMakeOperationBodyPayment(amount int, addressList ...string) Payment {
@@ -22,7 +21,7 @@ func TestMakeOperationBodyPayment(amount int, addressList ...string) Payment {
 	if len(addressList) > 0 {
 		address = addressList[0]
 	} else {
-		kp, _ := keypair.Random()
+		kp := keypair.Random()
 		address = kp.Address()
 	}
 

--- a/lib/transaction/test.go
+++ b/lib/transaction/test.go
@@ -3,9 +3,8 @@ package transaction
 import (
 	"math/rand"
 
-	"github.com/stellar/go/keypair"
-
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/transaction/operation"
 )
 
@@ -15,11 +14,11 @@ var (
 )
 
 func init() {
-	kp, _ = keypair.Random()
+	kp = keypair.Random()
 }
 
 func TestMakeTransaction(networkID []byte, n int) (kp *keypair.Full, tx Transaction) {
-	kp, _ = keypair.Random()
+	kp = keypair.Random()
 
 	var ops []operation.Operation
 	for i := 0; i < n; i++ {

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/stellar/go/keypair"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/transaction/operation"
 )
@@ -183,7 +183,7 @@ func (tx Transaction) String() string {
 func (tx *Transaction) Sign(kp keypair.KP, networkID []byte) {
 	tx.B.Source = kp.Address()
 	tx.H.Hash = tx.B.MakeHashString()
-	signature, _ := common.MakeSignature(kp, networkID, tx.H.Hash)
+	signature, _ := keypair.MakeSignature(kp, networkID, tx.H.Hash)
 
 	tx.H.Signature = base58.Encode(signature)
 

--- a/lib/transaction/transaction_test.go
+++ b/lib/transaction/transaction_test.go
@@ -1,16 +1,15 @@
 package transaction
 
 import (
+	"encoding/json"
 	"testing"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
+	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/transaction/operation"
 
-	"encoding/json"
-
-	"boscoin.io/sebak/lib/errors"
 	"github.com/btcsuite/btcutil/base58"
-	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )


### PR DESCRIPTION
```
Keypair is at the core of Sebak, but currently the dependency is external,
and scattered around the packages.
By putting it in a central place, we'll reduce the impact of any upstream change.
Additionally, we can provide convenience functions (e.g. the non-erroring Random)
that are better suited to Sebak's needs.
```