### PR TITLE
Check 'fee' by operation type

### DIFF
--- a/lib/ballot/proposer_transaction.go
+++ b/lib/ballot/proposer_transaction.go
@@ -162,9 +162,6 @@ func (p ProposerTransaction) IsWellFormedWithBallot(networkID []byte, blt Ballot
 				err = errors.InvalidOperation
 				return
 			}
-		} else if opb.Amount < 1 {
-			err = errors.InvalidOperation
-			return
 		}
 	}
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1,13 +1,14 @@
 package client
 
 import (
-	"boscoin.io/sebak/lib/common"
 	"bufio"
 	"context"
 	"encoding/json"
 	"net/http"
 	neturl "net/url"
 	"strings"
+
+	"boscoin.io/sebak/lib/common"
 )
 
 const (

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -335,23 +335,6 @@ func TestProposedTransactionWithWrongOperationBodyCollectTxFeeBlockData(t *testi
 			require.Equal(t, errors.InvalidOperation, err)
 		}
 	}
-
-	{
-		// with wrong `CollectTxFee.Txs`; this will cause the
-		// insufficient collected fee.
-		blt := p.MakeBallot(4)
-		opb, _ := blt.ProposerTransaction().CollectTxFee()
-		opb.Txs = uint64(len(blt.Transactions()) + 1)
-		ptx := blt.ProposerTransaction()
-		ptx.B.Operations[0].B = opb
-		blt.SetProposerTransaction(ptx)
-		blt.Sign(p.proposerNode.Keypair(), networkID)
-
-		{
-			err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-			require.Equal(t, errors.InvalidOperation, err)
-		}
-	}
 }
 
 func TestProposedTransactionWithWrongOperationBodyInflationFeeBlockData(t *testing.T) {
@@ -427,6 +410,7 @@ func TestProposedTransactionWithCollectTxFeeWrongAmount(t *testing.T) {
 	// with wrong `CollectTxFee.Amount` count
 	blt := p.MakeBallot(4)
 	opb, _ := blt.ProposerTransaction().CollectTxFee()
+	opb.Txs = 0
 	opb.Amount = opb.Amount.MustSub(1)
 	ptx := blt.ProposerTransaction()
 	ptx.B.Operations[0].B = opb
@@ -436,7 +420,7 @@ func TestProposedTransactionWithCollectTxFeeWrongAmount(t *testing.T) {
 	conf := common.NewConfig()
 	{
 		err := blt.ProposerTransaction().IsWellFormed(networkID, conf)
-		require.Equal(t, errors.InvalidOperation, err)
+		require.Equal(t, err, errors.OperationAmountOverflow)
 	}
 }
 

--- a/lib/transaction/operation/collect_tx_fee.go
+++ b/lib/transaction/operation/collect_tx_fee.go
@@ -49,11 +49,6 @@ func (o CollectTxFee) IsWellFormed(common.Config) (err error) {
 		return
 	}
 
-	if int64(o.Txs) > 0 && int64(o.Amount) < 1 {
-		err = errors.OperationAmountUnderflow
-		return
-	}
-
 	if int64(o.Txs) == 0 && int64(o.Amount) != 0 {
 		err = errors.OperationAmountOverflow
 		return
@@ -64,9 +59,6 @@ func (o CollectTxFee) IsWellFormed(common.Config) (err error) {
 			err = errors.InvalidOperation
 			return
 		}
-	} else if o.Amount < (common.BaseFee * common.Amount(o.Txs)) {
-		err = errors.InvalidOperation
-		return
 	}
 
 	return

--- a/lib/transaction/operation/collect_tx_fee.go
+++ b/lib/transaction/operation/collect_tx_fee.go
@@ -83,3 +83,7 @@ func (o CollectTxFee) GetAmount() common.Amount {
 func (o CollectTxFee) Serialize() (encoded []byte, err error) {
 	return json.Marshal(o)
 }
+
+func (o CollectTxFee) HasFee() bool {
+	return false
+}

--- a/lib/transaction/operation/congress_voting.go
+++ b/lib/transaction/operation/congress_voting.go
@@ -43,3 +43,7 @@ func (o CongressVoting) IsWellFormed(common.Config) (err error) {
 	}
 	return
 }
+
+func (o CongressVoting) HasFee() bool {
+	return false
+}

--- a/lib/transaction/operation/congress_voting_result.go
+++ b/lib/transaction/operation/congress_voting_result.go
@@ -78,3 +78,7 @@ func (o CongressVotingResult) IsWellFormed(common.Config) (err error) {
 
 	return
 }
+
+func (o CongressVotingResult) HasFee() bool {
+	return false
+}

--- a/lib/transaction/operation/create_account.go
+++ b/lib/transaction/operation/create_account.go
@@ -52,3 +52,7 @@ func (o CreateAccount) TargetAddress() string {
 func (o CreateAccount) GetAmount() common.Amount {
 	return o.Amount
 }
+
+func (o CreateAccount) HasFee() bool {
+	return true
+}

--- a/lib/transaction/operation/operation.go
+++ b/lib/transaction/operation/operation.go
@@ -94,6 +94,7 @@ type Body interface {
 	//
 	IsWellFormed(common.Config) error
 	Serialize() ([]byte, error)
+	HasFee() bool
 }
 
 type Payable interface {
@@ -122,6 +123,10 @@ func (o Operation) String() string {
 	encoded, _ := json.MarshalIndent(o, "", "  ")
 
 	return string(encoded)
+}
+
+func (o Operation) HasFee() bool {
+	return o.B.HasFee()
 }
 
 type envelop struct {

--- a/lib/transaction/operation/operation_inflation.go
+++ b/lib/transaction/operation/operation_inflation.go
@@ -82,3 +82,7 @@ func (o Inflation) GetAmount() common.Amount {
 func (o Inflation) Serialize() (encoded []byte, err error) {
 	return json.Marshal(o)
 }
+
+func (o Inflation) HasFee() bool {
+	return false
+}

--- a/lib/transaction/operation/payment.go
+++ b/lib/transaction/operation/payment.go
@@ -45,3 +45,7 @@ func (o Payment) TargetAddress() string {
 func (o Payment) GetAmount() common.Amount {
 	return o.Amount
 }
+
+func (o Payment) HasFee() bool {
+	return true
+}

--- a/lib/transaction/operation/unfreezing_request.go
+++ b/lib/transaction/operation/unfreezing_request.go
@@ -20,3 +20,7 @@ func (o UnfreezeRequest) Serialize() (encoded []byte, err error) {
 func (o UnfreezeRequest) IsWellFormed(common.Config) (err error) {
 	return
 }
+
+func (o UnfreezeRequest) HasFee() bool {
+	return true
+}

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -163,7 +163,14 @@ func (tx Transaction) TotalAmount(withFee bool) common.Amount {
 
 // TotalBaseFee returns the minimum fee of transaction.
 func (tx Transaction) TotalBaseFee() common.Amount {
-	return common.BaseFee.MustMult(len(tx.B.Operations))
+	var opsHaveFee int
+	for _, op := range tx.B.Operations {
+		if op.HasFee() {
+			opsHaveFee++
+		}
+	}
+
+	return common.BaseFee.MustMult(opsHaveFee)
 }
 
 func (tx Transaction) Serialize() (encoded []byte, err error) {

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -67,9 +67,20 @@ func NewTransaction(source string, sequenceID uint64, ops ...operation.Operation
 		return
 	}
 
+	var opsHaveFee int
+	for _, op := range ops {
+		if op.HasFee() {
+			opsHaveFee++
+		}
+	}
+	fee := common.Amount(0)
+	if opsHaveFee > 0 {
+		fee = common.BaseFee.MustMult(opsHaveFee)
+	}
+
 	txBody := Body{
 		Source:     source,
-		Fee:        common.BaseFee.MustMult(len(ops)),
+		Fee:        fee,
 		SequenceID: sequenceID,
 		Operations: ops,
 	}
@@ -168,6 +179,9 @@ func (tx Transaction) TotalBaseFee() common.Amount {
 		if op.HasFee() {
 			opsHaveFee++
 		}
+	}
+	if opsHaveFee < 1 {
+		return common.Amount(0)
 	}
 
 	return common.BaseFee.MustMult(opsHaveFee)

--- a/lib/transaction/transaction_test.go
+++ b/lib/transaction/transaction_test.go
@@ -78,6 +78,64 @@ func (suite *TestSuite) TestIsWellFormedTransactionWithLowerFeeSuite() {
 		err = tx.IsWellFormed(suite.networkID, suite.conf)
 		require.Equal(suite.T(), errors.InvalidFee, err, "Transaction shouidn't pass Fee checks")
 	}
+
+	{ // with CongressVoting, it has zero fee
+		kp, tx := TestMakeTransaction(networkID, 3)
+
+		opb := operation.NewCongressVoting([]byte("dummy contract"), 1, 100)
+		op := operation.Operation{
+			H: operation.Header{Type: operation.TypeCongressVoting},
+			B: opb,
+		}
+		tx.B.Operations = append(tx.B.Operations, op)
+		tx.Sign(kp, networkID)
+		require.Equal(suite.T(), tx.B.Fee, common.BaseFee*3)
+		require.Equal(suite.T(), len(tx.B.Operations), 4)
+
+		err = tx.IsWellFormed(networkID, suite.conf)
+		require.NoError(suite.T(), err)
+	}
+
+	{ // with CongressVotingResult, it has zero fee
+		kp, tx := TestMakeTransaction(networkID, 3)
+
+		opb := operation.NewCongressVotingResult(
+			string(common.MakeHash([]byte("dummydummy"))),
+			[]string{"http://www.boscoin.io/1", "http://www.boscoin.io/2"},
+			string(common.MakeHash([]byte("dummydummy"))),
+			[]string{"http://www.boscoin.io/3", "http://www.boscoin.io/4"},
+			9, 2, 3, 4,
+		)
+		op := operation.Operation{
+			H: operation.Header{Type: operation.TypeCongressVotingResult},
+			B: opb,
+		}
+		tx.B.Operations = append(tx.B.Operations, op)
+		tx.Sign(kp, networkID)
+		require.Equal(suite.T(), tx.B.Fee, common.BaseFee*3)
+		require.Equal(suite.T(), len(tx.B.Operations), 4)
+
+		err = tx.IsWellFormed(networkID, suite.conf)
+		require.NoError(suite.T(), err)
+	}
+
+	{ // with UnfreezeRequest, it is not zero fee
+		kp, tx := TestMakeTransaction(networkID, 3)
+
+		opb := operation.NewUnfreezeRequest()
+		op := operation.Operation{
+			H: operation.Header{Type: operation.TypeUnfreezingRequest},
+			B: opb,
+		}
+		tx.B.Operations = append(tx.B.Operations, op)
+		tx.B.Fee = common.BaseFee * 4
+		tx.Sign(kp, networkID)
+		require.Equal(suite.T(), tx.B.Fee, common.BaseFee*4)
+		require.Equal(suite.T(), len(tx.B.Operations), 4)
+
+		err = tx.IsWellFormed(networkID, suite.conf)
+		require.NoError(suite.T(), err)
+	}
 }
 
 func (suite *TestSuite) TestIsWellFormedTransactionWithInvalidSourceAddressSuite() {

--- a/lib/transaction/transaction_test.go
+++ b/lib/transaction/transaction_test.go
@@ -47,6 +47,7 @@ func (suite *TestSuite) TestIsWellFormedTransactionSuite() {
 
 func (suite *TestSuite) TestIsWellFormedTransactionWithLowerFeeSuite() {
 	var err error
+	var networkID []byte = []byte("test-sebak")
 
 	{ // valid fee
 		kp, tx := TestMakeTransaction(suite.networkID, 3)


### PR DESCRIPTION
### Github Issue
resolves #381 

### Background

At this time, the zero operation still counted in validation of Transaction fee.

### Solution

* `Operation.HasFee()` added; it returns the operation has fee or not
* `Transaction.TotalBaseFee()` counts only  `Operation.HasFee() == true`
* test cases added in `lib/transaction/transaction_test.go`