### PR TITLE
Sending `Transaction` must use `/api/v1/transactions`

### DIFF
--- a/cmd/sebak/cmd/wallet/payment.go
+++ b/cmd/sebak/cmd/wallet/payment.go
@@ -131,7 +131,7 @@ func init() {
 				fmt.Println(tx)
 			}
 			if flagDry == false {
-				if retbody, err = client.SendMessage(tx); err != nil {
+				if retbody, err = client.SendTransaction(tx); err != nil {
 					log.Fatal("Network error: ", err, " body: ", string(retbody))
 					os.Exit(1)
 				}

--- a/cmd/sebak/cmd/wallet/unfreezeRequest.go
+++ b/cmd/sebak/cmd/wallet/unfreezeRequest.go
@@ -93,7 +93,7 @@ func init() {
 				fmt.Println(tx)
 			}
 			if flagDry == false {
-				if retbody, err = client.SendMessage(tx); err != nil {
+				if retbody, err = client.SendTransaction(tx); err != nil {
 					log.Fatal("Network error: ", err, " body: ", string(retbody))
 					os.Exit(1)
 				}

--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -38,6 +38,7 @@ type NetworkClient interface {
 	Connect(node node.Node) ([]byte, error)
 	GetNodeInfo() ([]byte, error)
 	SendMessage(common.Serializable) ([]byte, error)
+	SendTransaction(common.Serializable) ([]byte, error)
 	SendBallot(common.Serializable) ([]byte, error)
 	GetTransactions([]string) ([]byte, error)
 }

--- a/lib/network/http2_client.go
+++ b/lib/network/http2_client.go
@@ -77,102 +77,46 @@ func (c *HTTP2NetworkClient) GetNodeInfo() (body []byte, err error) {
 	return
 }
 
-func (c *HTTP2NetworkClient) Connect(n node.Node) (body []byte, err error) {
+func (c *HTTP2NetworkClient) Send(path string, message common.Serializable) (retBody []byte, err error) {
 	headers := c.DefaultHeaders()
 	headers.Set("Content-Type", "application/json")
 
-	serialized, _ := n.Serialize()
+	var body []byte
+	if body, err = message.Serialize(); err != nil {
+		return
+	}
+
+	u := c.resolvePath(path)
+
 	var response *http.Response
-	response, err = c.client.Post(c.resolvePath(UrlPathPrefixNode+"/connect").String(), serialized, headers)
+	response, err = c.client.Post(u.String(), body, headers)
 	if err != nil {
 		return
 	}
 	defer response.Body.Close()
-	body, err = ioutil.ReadAll(response.Body)
+	retBody, err = ioutil.ReadAll(response.Body)
 
 	if response.StatusCode != http.StatusOK {
 		err = errors.HTTPProblem.Clone().SetData("status", response.StatusCode)
 	}
 
 	return
+}
+
+func (c *HTTP2NetworkClient) Connect(n node.Node) (body []byte, err error) {
+	return c.Send(UrlPathPrefixNode+"/connect", n)
 }
 
 func (c *HTTP2NetworkClient) SendMessage(message common.Serializable) (retBody []byte, err error) {
-	headers := c.DefaultHeaders()
-	headers.Set("Content-Type", "application/json")
-
-	var body []byte
-	if body, err = message.Serialize(); err != nil {
-		return
-	}
-
-	u := c.resolvePath(UrlPathPrefixNode + "/message")
-
-	var response *http.Response
-	response, err = c.client.Post(u.String(), body, headers)
-	if err != nil {
-		return
-	}
-	defer response.Body.Close()
-	retBody, err = ioutil.ReadAll(response.Body)
-
-	if response.StatusCode != http.StatusOK {
-		err = errors.HTTPProblem.Clone().SetData("status", response.StatusCode)
-	}
-
-	return
+	return c.Send(UrlPathPrefixNode+"/message", message)
 }
 
 func (c *HTTP2NetworkClient) SendTransaction(message common.Serializable) (retBody []byte, err error) {
-	headers := c.DefaultHeaders()
-	headers.Set("Content-Type", "application/json")
-
-	var body []byte
-	if body, err = message.Serialize(); err != nil {
-		return
-	}
-
-	u := c.resolvePath(resource.URLTransactions)
-
-	var response *http.Response
-	response, err = c.client.Post(u.String(), body, headers)
-	if err != nil {
-		return
-	}
-	defer response.Body.Close()
-	retBody, err = ioutil.ReadAll(response.Body)
-
-	if response.StatusCode != http.StatusOK {
-		err = errors.HTTPProblem.Clone().SetData("status", response.StatusCode)
-	}
-
-	return
+	return c.Send(resource.URLTransactions, message)
 }
 
 func (c *HTTP2NetworkClient) SendBallot(message common.Serializable) (retBody []byte, err error) {
-	headers := c.DefaultHeaders()
-	headers.Set("Content-Type", "application/json")
-
-	var body []byte
-	if body, err = message.Serialize(); err != nil {
-		return
-	}
-
-	u := c.resolvePath(UrlPathPrefixNode + "/ballot")
-
-	var response *http.Response
-	response, err = c.client.Post(u.String(), body, headers)
-	if err != nil {
-		return
-	}
-	defer response.Body.Close()
-	retBody, err = ioutil.ReadAll(response.Body)
-
-	if response.StatusCode != http.StatusOK {
-		err = errors.HTTPProblem.Clone().SetData("status", response.StatusCode)
-	}
-
-	return
+	return c.Send(UrlPathPrefixNode+"/ballot", message)
 }
 
 func (c *HTTP2NetworkClient) GetTransactions(txs []string) (retBody []byte, err error) {

--- a/lib/network/memory_client.go
+++ b/lib/network/memory_client.go
@@ -43,6 +43,10 @@ func (m *MemoryTransportClient) SendMessage(message common.Serializable) (body [
 	return
 }
 
+func (m *MemoryTransportClient) SendTransaction(message common.Serializable) (body []byte, err error) {
+	return m.SendMessage(message)
+}
+
 func (m *MemoryTransportClient) SendBallot(message common.Serializable) (body []byte, err error) {
 	var s []byte
 	if s, err = message.Serialize(); err != nil {


### PR DESCRIPTION
### Github Issue

Resolves #656 

### Background

See #656 and the command `unfreezeRequest` will also be applied.

### Solution

Just create new method, `NetworkClient.SendTransaction()`.