### PR TITLE
Do not run integration test alongside unittests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - <<: *workspace
       - run:
           name: run tests
-          command: SEBAK_LOG_HANDLER=null go test -v -timeout 8m `go list ./... | grep -v tests`
+          command: SEBAK_LOG_HANDLER=null go test -v -timeout 8m ./...
 
   generate_merged_tree:
     <<: *defaults
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: run tests
           command: |
-            for pkg in $(go list ./... | grep -v vendor | grep -v tests); do
+            for pkg in $(go list ./... | grep -v vendor); do
                 SEBAK_LOG_HANDLER=null go test -race -v -timeout 8m -coverprofile=profile.out "$pkg"
                 if [ -f profile.out ]; then
                     cat profile.out >> coverage.txt

--- a/tests/client/account_test.go
+++ b/tests/client/account_test.go
@@ -1,3 +1,5 @@
+// +build client_integration_tests
+
 package client
 
 import (

--- a/tests/client/congressvoting_test.go
+++ b/tests/client/congressvoting_test.go
@@ -1,3 +1,5 @@
+// +build client_integration_tests
+
 package client
 
 import (

--- a/tests/client/const.go
+++ b/tests/client/const.go
@@ -1,3 +1,5 @@
+// +build client_integration_tests
+
 package client
 
 const (

--- a/tests/client/ping_test.go
+++ b/tests/client/ping_test.go
@@ -1,3 +1,5 @@
+// +build client_integration_tests
+
 package client
 
 import (

--- a/tests/client/run.sh
+++ b/tests/client/run.sh
@@ -34,7 +34,7 @@ fi
 IMAGE=$(docker build -q \
     --build-arg BUILD_MODE="test" \
     --build-arg BUILD_PKG="./tests/client" \
-    --build-arg BUILD_ARGS="-c -o /go/bin/client_test"  \
+    --build-arg BUILD_ARGS="-tags client_integration_tests -c -o /go/bin/client_test"  \
     ${ROOT_DIR}/ -f ${ROOT_DIR}/Dockerfile_client.build | cut -d: -f2)
 
 if [ -z ${IMAGE} ]; then


### PR DESCRIPTION
Because go test ./... should just work, this uses build tags
to prevent integration tests from being run when one runs unittests.