### PR TITLE
sync-node expired and trivial refactoring

### DIFF
--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -18,6 +18,9 @@ const (
 	// GenesisBlockHeight set the block height of genesis block
 	GenesisBlockHeight uint64 = 1
 
+	// FirstConsensusBlockHeight is used for calculating block time
+	FirstConsensusBlockHeight uint64 = 2
+
 	// GenesisBlockConfirmedTime is the time for the confirmed time of genesis
 	// block. This time is of the first commit of SEBAK.
 	GenesisBlockConfirmedTime string = "2018-04-17T5:07:31.000000000Z"

--- a/lib/node/runner/broadcaster_test.go
+++ b/lib/node/runner/broadcaster_test.go
@@ -13,7 +13,7 @@ func TestConnectionManagerBroadcaster(t *testing.T) {
 	recv := make(chan struct{})
 	nr, _, cm := createNodeRunnerForTesting(3, conf, recv)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 
 	<-recv

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -244,9 +244,8 @@ func hasBallotValidProposer(is *consensus.ISAAC, b ballot.Ballot) bool {
 // valid round.
 func BallotAlreadyFinished(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
-	ballotRound := checker.Ballot.VotingBasis()
 	if !checker.NodeRunner.Consensus().IsAvailableRound(
-		ballotRound,
+		checker.Ballot.VotingBasis(),
 		block.GetLatestBlock(checker.NodeRunner.Storage()),
 	) {
 		err = errors.BallotAlreadyFinished
@@ -574,7 +573,7 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 		if err = saveBlock(checker); err != nil {
 			return err
 		}
-		checker.NodeRunner.TransitISAACState(checker.Ballot.VotingBasis(), ballot.StateALLCONFIRM)
+		checker.NodeRunner.TransitISAACState(basis, ballot.StateALLCONFIRM)
 		checker.NodeRunner.Consensus().SetLatestVotingBasis(basis)
 
 		reorganizeTransactionPool(checker)

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -160,9 +160,9 @@ func (sm *ISAACStateManager) IncreaseRound() {
 }
 
 func (sm *ISAACStateManager) NextHeight() {
-	state := sm.State()
-	sm.nr.Log().Debug("begin ISAACStateManager.NextHeight()", "height", state.Height, "round", state.Round, "state", state.BallotState)
-	sm.TransitISAACState(state.Height+1, 0, ballot.StateINIT)
+	h := sm.nr.consensus.LatestBlock().Height
+	sm.nr.Log().Debug("begin ISAACStateManager.NextHeight()", "height", h)
+	sm.TransitISAACState(h, 0, ballot.StateINIT)
 }
 
 // In `Start()` method a node proposes ballot.
@@ -265,7 +265,7 @@ func (sm *ISAACStateManager) proposeOrWait(timer *time.Timer, state consensus.IS
 		if _, err := sm.nr.proposeNewBallot(state.Round); err == nil {
 			log.Debug("propose new ballot", "proposer", proposer, "round", state.Round, "ballotState", ballot.StateSIGN)
 		} else {
-			log.Error("failed to proposeNewBallot", "height", sm.nr.consensus.LatestBlock().Height, "error", err)
+			log.Error("failed to proposeNewBallot", "height", sm.state.Height, "error", err)
 		}
 		timer.Reset(sm.Conf.TimeoutINIT)
 	} else {

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -16,13 +16,13 @@ import (
 type ISAACStateManager struct {
 	sync.RWMutex
 
-	nr              *NodeRunner
-	state           consensus.ISAACState
-	stateTransit    chan consensus.ISAACState
-	stop            chan struct{}
-	blockTimeBuffer time.Duration              // the time to wait to adjust the block creation time.
-	transitSignal   func(consensus.ISAACState) // the function is called when the ISAACState is changed.
-	genesis         time.Time                  // the time at which the GenesisBlock was saved. It is used for calculating `blockTimeBuffer`.
+	nr                      *NodeRunner
+	state                   consensus.ISAACState
+	stateTransit            chan consensus.ISAACState
+	stop                    chan struct{}
+	blockTimeBuffer         time.Duration              // the time to wait to adjust the block creation time.
+	transitSignal           func(consensus.ISAACState) // the function is called when the ISAACState is changed.
+	firstConsensusBlockTime time.Time                  // the time at which the first consensus block was saved(height 2). It is used for calculating `blockTimeBuffer`.
 
 	Conf common.Config
 }
@@ -42,19 +42,38 @@ func NewISAACStateManager(nr *NodeRunner, conf common.Config) *ISAACStateManager
 		Conf:            conf,
 	}
 
-	genesisBlock := block.GetGenesis(nr.storage)
-	p.genesis = genesisBlock.Header.Timestamp
+	p.firstConsensusBlockTime = time.Time{}
 
 	return p
 }
 
+func (sm *ISAACStateManager) setTheFirstConsensusBlockTime() {
+	if !sm.firstConsensusBlockTime.IsZero() {
+		return
+	}
+
+	b := sm.nr.Consensus().LatestBlock()
+	if b.Height == common.GenesisBlockHeight {
+		return
+	}
+
+	blk, err := block.GetBlockByHeight(sm.nr.Storage(), common.FirstConsensusBlockHeight)
+	if err != nil {
+		return
+	}
+	sm.firstConsensusBlockTime = blk.Header.Timestamp
+	sm.nr.Log().Debug("set first consnsus block time", "time", sm.firstConsensusBlockTime)
+}
+
 func (sm *ISAACStateManager) SetBlockTimeBuffer() {
 	sm.nr.Log().Debug("begin ISAACStateManager.SetBlockTimeBuffer()", "ISAACState", sm.State())
+	sm.setTheFirstConsensusBlockTime()
 	b := sm.nr.Consensus().LatestBlock()
+
 	ballotProposedTime := getBallotProposedTime(b.Confirmed)
 	sm.blockTimeBuffer = calculateBlockTimeBuffer(
 		sm.Conf.BlockTime,
-		calculateAverageBlockTime(sm.genesis, b.Height),
+		calculateAverageBlockTime(sm.firstConsensusBlockTime, b.Height),
 		time.Now().Sub(ballotProposedTime),
 		1*time.Second,
 	)
@@ -62,7 +81,7 @@ func (sm *ISAACStateManager) SetBlockTimeBuffer() {
 		"calculated blockTimeBuffer",
 		"blockTimeBuffer", sm.blockTimeBuffer,
 		"blockTime", sm.Conf.BlockTime,
-		"genesis", sm.genesis,
+		"firstConsensusBlockTime", sm.firstConsensusBlockTime,
 		"height", b.Height,
 		"confirmed", b.Confirmed,
 		"now", time.Now(),
@@ -76,10 +95,9 @@ func getBallotProposedTime(timeStr string) time.Time {
 	return ballotProposedTime
 }
 
-func calculateAverageBlockTime(genesis time.Time, blockHeight uint64) time.Duration {
-	genesisBlockHeight := uint64(1)
-	height := blockHeight - genesisBlockHeight
-	sinceGenesis := time.Now().Sub(genesis)
+func calculateAverageBlockTime(firstConsensusBlockTime time.Time, blockHeight uint64) time.Duration {
+	height := blockHeight - (common.GenesisBlockHeight + 1)
+	sinceGenesis := time.Now().Sub(firstConsensusBlockTime)
 
 	if height == 0 {
 		return sinceGenesis

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -12,7 +12,7 @@ import (
 )
 
 // ISAACStateManager manages the ISAACState.
-// The most important function `Start()` is called in StartStateManager() function in node_runner.go by goroutine.
+// The most important function `Start()` is called in startStateManager() function in node_runner.go by goroutine.
 type ISAACStateManager struct {
 	sync.RWMutex
 

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -25,7 +25,7 @@ func TestStateINITProposer(t *testing.T) {
 	recv := make(chan struct{})
 	nr, _, cm := createNodeRunnerForTesting(3, conf, recv)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 
 	<-recv
@@ -55,7 +55,7 @@ func TestStateINITNotProposer(t *testing.T) {
 	cm, ok := nr.Consensus().ConnectionManager().(*TestConnectionManager)
 	require.True(t, ok)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 	time.Sleep(1 * time.Second)
 
@@ -84,7 +84,7 @@ func TestStateINITTimeoutNotProposer(t *testing.T) {
 
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 	require.Equal(t, ballot.StateINIT, nr.isaacStateManager.State().BallotState)
 
@@ -131,7 +131,7 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 
 	require.Equal(t, nr.localNode.Address(), proposer)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 
 	require.Equal(t, ballot.StateINIT, nr.isaacStateManager.State().BallotState)
@@ -193,7 +193,7 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 
 	<-recv
@@ -249,7 +249,7 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 	proposer = nr.Consensus().SelectProposer(0, 1)
 	require.NotEqual(t, nr.localNode.Address(), proposer)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 
 	<-recv
@@ -307,7 +307,7 @@ func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 	cm, ok := nr.Consensus().ConnectionManager().(*TestConnectionManager)
 	require.True(t, ok)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 	<-recvTransit
 	state := nr.isaacStateManager.State()
@@ -351,7 +351,7 @@ func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
 	recv := make(chan struct{})
 	nr, _, cm := createNodeRunnerForTesting(3, conf, recv)
 
-	nr.StartStateManager()
+	nr.startStateManager()
 	defer nr.StopStateManager()
 	<-recv
 

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -526,8 +526,8 @@ func (nr *NodeRunner) StopStateManager() {
 	return
 }
 
-func (nr *NodeRunner) TransitISAACState(round voting.Basis, ballotState ballot.State) {
-	nr.isaacStateManager.TransitISAACState(round.Height, round.Round, ballotState)
+func (nr *NodeRunner) TransitISAACState(basis voting.Basis, ballotState ballot.State) {
+	nr.isaacStateManager.TransitISAACState(basis.Height, basis.Round, ballotState)
 }
 
 var NewBallotTransactionCheckerFuncs = []common.CheckerFunc{

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -488,7 +488,7 @@ func (nr *NodeRunner) InitRound() {
 	nr.consensus.SetLatestVotingBasis(voting.Basis{})
 
 	nr.waitForConnectingEnoughNodes()
-	nr.StartStateManager()
+	nr.startStateManager()
 }
 
 func (nr *NodeRunner) waitForConnectingEnoughNodes() {
@@ -509,7 +509,7 @@ func (nr *NodeRunner) waitForConnectingEnoughNodes() {
 	return
 }
 
-func (nr *NodeRunner) StartStateManager() {
+func (nr *NodeRunner) startStateManager() {
 	// check whether current running rounds exist
 	if len(nr.consensus.RunningRounds) > 0 {
 		return


### PR DESCRIPTION
### Background
In master,
There are 4 nodes in this result below.
Three nodes started at the same time, and fourth node 4 `GCDC.WBKY` started after height 6.
The node is the proposer in height 2, 6, 10, ...
The node is synced in height 8. But at height 10, expired again as below(round==1).

node 1 `GDIR.M6CC`
```
INFO[11-07|12:02:27] genesis block created                    module=main height=1 round=0 timestamp=2018-11-07T12:02:27+0900 total-txs=1 total-ops=2 proposer=
INFO[11-07|12:02:27] Starting Sebak                           module=main caller=run.go:406
INFO[11-07|12:02:27] syncer config                            module=sync node=GDIR.M6CC poolSize=300 fetchTimeout=1m0s retryInterval=10s checkInterval=30s caller=config.go:72
INFO[11-07|12:02:27] starting syncer                          module=sync node=GDIR.M6CC caller=syncer.go:116
INFO[11-07|12:02:35] NewBlock created                         module=noderunner node=GDIR.M6CC height=2 round=1 timestamp=2018-11-07T12:02:35+0900 total-txs=2 total-ops=4 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
INFO[11-07|12:02:39] NewBlock created                         module=noderunner node=GDIR.M6CC height=3 round=0 timestamp=2018-11-07T12:02:39+0900 total-txs=3 total-ops=6 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
INFO[11-07|12:02:43] NewBlock created                         module=noderunner node=GDIR.M6CC height=4 round=0 timestamp=2018-11-07T12:02:43+0900 total-txs=4 total-ops=8 proposer=GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4 caller=finish_ballot.go:72
INFO[11-07|12:02:47] NewBlock created                         module=noderunner node=GDIR.M6CC height=5 round=0 timestamp=2018-11-07T12:02:47+0900 total-txs=5 total-ops=10 proposer=GAYGELM74WJMKSLDN5YP2VAMP64WC4IXIGICUNK2SCVIT7KPTLY7M3MW caller=finish_ballot.go:72
INFO[11-07|12:03:00] NewBlock created                         module=noderunner node=GDIR.M6CC height=6 round=1 timestamp=2018-11-07T12:03:00+0900 total-txs=6 total-ops=12 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
INFO[11-07|12:03:04] NewBlock created                         module=noderunner node=GDIR.M6CC height=7 round=0 timestamp=2018-11-07T12:03:04+0900 total-txs=7 total-ops=14 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
INFO[11-07|12:03:08] NewBlock created                         module=noderunner node=GDIR.M6CC height=8 round=0 timestamp=2018-11-07T12:03:08+0900 total-txs=8 total-ops=16 proposer=GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4 caller=finish_ballot.go:72
INFO[11-07|12:03:12] NewBlock created                         module=noderunner node=GDIR.M6CC height=9 round=0 timestamp=2018-11-07T12:03:12+0900 total-txs=9 total-ops=18 proposer=GAYGELM74WJMKSLDN5YP2VAMP64WC4IXIGICUNK2SCVIT7KPTLY7M3MW caller=finish_ballot.go:72
INFO[11-07|12:03:22] NewBlock created                         module=noderunner node=GDIR.M6CC height=10 round=1 timestamp=2018-11-07T12:03:22+0900 total-txs=10 total-ops=20 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
```

node 4 `GCDC.WBKY`
```
INFO[11-07|12:03:00] genesis block created                    module=main height=1 round=0 timestamp=2018-11-07T12:03:00+0900 total-txs=1 total-ops=2 proposer=
INFO[11-07|12:03:00] Starting Sebak                           module=main caller=run.go:406
INFO[11-07|12:03:00] syncer config                            module=sync node=GCDC.WBKY poolSize=300 fetchTimeout=1m0s retryInterval=10s checkInterval=30s caller=config.go:72
INFO[11-07|12:03:00] starting syncer                          module=sync node=GCDC.WBKY caller=syncer.go:116
INFO[11-07|12:03:04] node state transits to sync              module=consensus node=GCDC.WBKY height=6 caller=isaac.go:161
INFO[11-07|12:03:04] sync start                               module=sync node=GCDC.WBKY caller=syncer.go:123
INFO[11-07|12:03:04] updated highest height                   module=sync node=GCDC.WBKY height=6 nodes=3 caller=syncer.go:183
INFO[11-07|12:03:04] sync progress                            module=sync node=GCDC.WBKY start=2 cur=6 high=6 caller=syncer.go:241
INFO[11-07|12:03:04] done sync work                           module=sync node=GCDC.WBKY height=2 hash=jwnDP92oB2F9XdYUNMHFKMeLtwWVCidLKKdrJMRSv3s caller=syncer.go:291
INFO[11-07|12:03:04] done sync work                           module=sync node=GCDC.WBKY height=3 hash=7he1BeTHoigCKHaYYKtLoCQgBTDoLX6k8T27eSdfDMVC caller=syncer.go:291
INFO[11-07|12:03:04] done sync work                           module=sync node=GCDC.WBKY height=4 hash=78dvrjmL9MUQhNDpu8j6th1foDScAdSRBqinu3HMys1A caller=syncer.go:291
INFO[11-07|12:03:04] done sync work                           module=sync node=GCDC.WBKY height=5 hash=294h8h8CfXv3hrFDYcbqVqNMfEyK86EceJLkCXW7Zxhi caller=syncer.go:291
INFO[11-07|12:03:04] done sync work                           module=sync node=GCDC.WBKY height=6 hash=BW3qiCd8xGXtUedpr5GeoinktFSoHvPCWX2zEPFEKFMn caller=syncer.go:291
EROR[11-07|12:03:08] ballot height is not equal to latestBlock module=noderunner node=GCDC.WBKY in ballot=7 latest height=6 caller=checker.go:678
EROR[11-07|12:03:08] ballot height is not equal to latestBlock module=noderunner node=GCDC.WBKY in ballot=7 latest height=6 caller=checker.go:678
INFO[11-07|12:03:08] NewBlock created                         module=noderunner node=GCDC.WBKY height=7 round=0 timestamp=2018-11-07T12:03:08+0900 total-txs=7 total-ops=14 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
INFO[11-07|12:03:08] NewBlock created                         module=noderunner node=GCDC.WBKY height=8 round=0 timestamp=2018-11-07T12:03:08+0900 total-txs=8 total-ops=16 proposer=GDTEPFWEITKFHSUO44NQABY2XHRBBH2UBVGJ2ZJPDREIOL2F6RAEBJE4 caller=finish_ballot.go:72
INFO[11-07|12:03:12] NewBlock created                         module=noderunner node=GCDC.WBKY height=9 round=0 timestamp=2018-11-07T12:03:12+0900 total-txs=9 total-ops=18 proposer=GAYGELM74WJMKSLDN5YP2VAMP64WC4IXIGICUNK2SCVIT7KPTLY7M3MW caller=finish_ballot.go:72
INFO[11-07|12:03:22] NewBlock created                         module=noderunner node=GCDC.WBKY height=10 round=1 timestamp=2018-11-07T12:03:22+0900 total-txs=10 total-ops=20 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
INFO[11-07|12:03:26] NewBlock created                         module=noderunner node=GCDC.WBKY height=11 round=0 timestamp=2018-11-07T12:03:26+0900 total-txs=11 total-ops=22 proposer=GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ caller=finish_ballot.go:72
```

### Solution
It's because of difference genesis confirmed time between started node and sync node.
BlockTimeBuffer for setting block time 5 sec uses `genesis block confirm time` as argument.
The node 1 is `2018-11-07T12:02:27` but the node 4 is `2018-11-07T12:03:00` because it starts after 6 height.
I've modified it to use consensus block height(2) instead of genesis(1) for synced node.

Please check commit messages.