### PR TITLE
Make validation simple after block confirm and apply review 632

### DIFF
--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -14,7 +14,6 @@ import (
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
-	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/voting"
 )
 
@@ -61,47 +60,6 @@ func NewISAAC(node *node.LocalNode, p voting.ThresholdPolicy,
 		nodesHeight:       make(map[string]uint64),
 		syncer:            syncer,
 		LatestBallot:      ballot.Ballot{},
-	}
-
-	return
-}
-
-func (is *ISAAC) CloseConsensus(proposer string, basis voting.Basis, vh voting.Hole, transactionPool *transaction.Pool) (err error) {
-	is.Lock()
-	defer is.Unlock()
-
-	is.SetLatestVotingBasis(basis)
-
-	if vh == voting.NOTYET {
-		err = errors.New("invalid voting.Hole, `voting.NOTYET`")
-		return
-	}
-
-	basisIndex := basis.Index()
-	rr, found := is.RunningRounds[basisIndex]
-	if !found {
-		return
-	}
-
-	if vh == voting.NO {
-		delete(rr.Transactions, proposer)
-		delete(rr.Voted, proposer)
-
-		return
-	}
-
-	if vh == voting.YES {
-		transactionPool.Remove(rr.Transactions[proposer]...)
-	}
-
-	delete(is.RunningRounds, basisIndex)
-
-	// remove all the same rounds
-	for hash, runningRound := range is.RunningRounds {
-		if runningRound.VotingBasis.Height > basis.Height {
-			continue
-		}
-		delete(is.RunningRounds, hash)
 	}
 
 	return

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -672,7 +672,7 @@ func TestProposedTransactionStoreWithZeroAmount(t *testing.T) {
 	previousCommonAccount, _ := block.GetBlockAccount(p.nr.Storage(), p.commonAccount.Address)
 
 	{
-		_, err := finishBallot(
+		_, _, err := finishBallot(
 			p.nr.Storage(),
 			*blt,
 			p.nr.TransactionPool,
@@ -759,7 +759,7 @@ func TestProposedTransactionStoreWithAmount(t *testing.T) {
 	previousCommonAccount, _ := block.GetBlockAccount(p.nr.Storage(), p.commonAccount.Address)
 
 	{
-		_, err := finishBallot(
+		_, _, err := finishBallot(
 			p.nr.Storage(),
 			*blt,
 			p.nr.TransactionPool,

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -614,10 +614,6 @@ func saveBlock(checker *BallotChecker) error {
 		return err
 	}
 
-	for _, tx := range proposedTransactions {
-		checker.LatestUpdatedSources[tx.B.Source] = struct{}{}
-	}
-
 	var theBlock *block.Block
 	theBlock, err = finishBallotWithProposedTxs(
 		bs,
@@ -641,6 +637,9 @@ func saveBlock(checker *BallotChecker) error {
 
 	checker.Log.Debug("ballot was stored", "block", *theBlock)
 
+	for _, tx := range proposedTransactions {
+		checker.LatestUpdatedSources[tx.B.Source] = struct{}{}
+	}
 	checker.NodeRunner.SavingBlockOperations().Save(*theBlock)
 
 	return nil

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -640,12 +640,13 @@ func saveBlock(checker *BallotChecker) error {
 	}
 
 	checker.Log.Debug("ballot was stored", "block", *theBlock)
+
 	checker.NodeRunner.SavingBlockOperations().Save(*theBlock)
 
 	return nil
 }
 
-func reorganizeTransactionPool(checker *BallotChecker) error {
+func reorganizeTransactionPool(checker *BallotChecker) {
 	basisIndex := checker.Ballot.VotingBasis().Index()
 	proposer := checker.Ballot.Proposer()
 	transactionPool := checker.NodeRunner.TransactionPool
@@ -666,7 +667,7 @@ func reorganizeTransactionPool(checker *BallotChecker) error {
 	}
 	transactionPool.Remove(invalids...)
 
-	return nil
+	return
 }
 
 func isValidRound(st *storage.LevelDBBackend, r voting.Basis, log logging.Logger) (bool, error) {

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -589,6 +589,7 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 	case voting.NOTYET:
 		return errors.New("invalid voting.Hole, `NOTYET`")
 	}
+	delete(checker.NodeRunner.Consensus().RunningRounds, basis.Index())
 
 	return err
 }

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -263,13 +263,13 @@ func TestGetMissingTransactionAllMissing(t *testing.T) {
 	}
 
 	baseChecker := &BallotChecker{
-		DefaultChecker:       common.DefaultChecker{Funcs: DefaultHandleBaseBallotCheckerFuncs},
-		NodeRunner:           g.consensusNR,
-		LocalNode:            g.consensusNR.Node(),
-		Message:              ballotMessage,
-		Log:                  g.consensusNR.Log(),
-		VotingHole:           voting.NOTYET,
-		LatestUpdatedSources: make(map[string]struct{}),
+		DefaultChecker:     common.DefaultChecker{Funcs: DefaultHandleBaseBallotCheckerFuncs},
+		NodeRunner:         g.consensusNR,
+		LocalNode:          g.consensusNR.Node(),
+		Message:            ballotMessage,
+		Log:                g.consensusNR.Log(),
+		VotingHole:         voting.NOTYET,
+		LatestBlockSources: []string{},
 	}
 	err := common.RunChecker(baseChecker, common.DefaultDeferFunc)
 	require.NoError(t, err)
@@ -282,14 +282,14 @@ func TestGetMissingTransactionAllMissing(t *testing.T) {
 	}
 
 	checker := &BallotChecker{
-		DefaultChecker:       common.DefaultChecker{Funcs: checkerFuncs},
-		NodeRunner:           baseChecker.NodeRunner,
-		LocalNode:            baseChecker.LocalNode,
-		Message:              ballotMessage,
-		Ballot:               baseChecker.Ballot,
-		VotingHole:           voting.NOTYET,
-		Log:                  baseChecker.Log,
-		LatestUpdatedSources: baseChecker.LatestUpdatedSources,
+		DefaultChecker:     common.DefaultChecker{Funcs: checkerFuncs},
+		NodeRunner:         baseChecker.NodeRunner,
+		LocalNode:          baseChecker.LocalNode,
+		Message:            ballotMessage,
+		Ballot:             baseChecker.Ballot,
+		VotingHole:         voting.NOTYET,
+		Log:                baseChecker.Log,
+		LatestBlockSources: baseChecker.LatestBlockSources,
 	}
 
 	err = common.RunChecker(checker, common.DefaultDeferFunc)

--- a/lib/node/runner/finish_ballot.go
+++ b/lib/node/runner/finish_ballot.go
@@ -11,31 +11,26 @@ import (
 	"boscoin.io/sebak/lib/transaction/operation"
 )
 
-func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *transaction.Pool, log, infoLog logging.Logger) (*block.Block, error) {
-	var proposedTransactions []*transaction.Transaction
-	var err error
-	proposedTransactions, err = getProposedTransactions(
+func finishBallot(st *storage.LevelDBBackend, b ballot.Ballot, transactionPool *transaction.Pool, log, infoLog logging.Logger) (*block.Block, []*transaction.Transaction, error) {
+	proposedTxs, err := getProposedTransactions(
 		st,
 		b.B.Proposed.Transactions,
 		transactionPool,
 	)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var blk *block.Block
 	blk, err = finishBallotWithProposedTxs(
 		st,
 		b,
-		proposedTransactions,
+		proposedTxs,
 		log,
 		infoLog,
 	)
-	if err != nil {
-		return nil, err
-	}
 
-	return blk, nil
+	return blk, proposedTxs, nil
 }
 
 func finishBallotWithProposedTxs(st *storage.LevelDBBackend, b ballot.Ballot, proposedTransactions []*transaction.Transaction, log, infoLog logging.Logger) (*block.Block, error) {

--- a/lib/node/runner/finish_ballot_test.go
+++ b/lib/node/runner/finish_ballot_test.go
@@ -149,7 +149,7 @@ func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOpe
 		st, _ = st.OpenBatch()
 	}
 
-	_, err := finishBallot(
+	_, _, err := finishBallot(
 		st,
 		*blt,
 		nr.TransactionPool,

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -424,13 +424,13 @@ func (nr *NodeRunner) handleBallotMessage(message common.NetworkMessage) (err er
 	nr.log.Debug("got ballot", "message", message.Head(50))
 
 	baseChecker := &BallotChecker{
-		DefaultChecker:       common.DefaultChecker{Funcs: nr.handleBaseBallotCheckerFuncs},
-		NodeRunner:           nr,
-		LocalNode:            nr.localNode,
-		Message:              message,
-		Log:                  nr.Log(),
-		VotingHole:           voting.NOTYET,
-		LatestUpdatedSources: make(map[string]struct{}),
+		DefaultChecker:     common.DefaultChecker{Funcs: nr.handleBaseBallotCheckerFuncs},
+		NodeRunner:         nr,
+		LocalNode:          nr.localNode,
+		Message:            message,
+		Log:                nr.Log(),
+		VotingHole:         voting.NOTYET,
+		LatestBlockSources: []string{},
 	}
 	err = common.RunChecker(baseChecker, nr.handleBallotCheckerDeferFunc)
 	if err != nil {
@@ -451,15 +451,15 @@ func (nr *NodeRunner) handleBallotMessage(message common.NetworkMessage) (err er
 	}
 
 	checker := &BallotChecker{
-		DefaultChecker:       common.DefaultChecker{Funcs: checkerFuncs},
-		NodeRunner:           nr,
-		LocalNode:            nr.localNode,
-		Message:              message,
-		Ballot:               baseChecker.Ballot,
-		VotingHole:           baseChecker.VotingHole,
-		IsNew:                baseChecker.IsNew,
-		Log:                  baseChecker.Log,
-		LatestUpdatedSources: baseChecker.LatestUpdatedSources,
+		DefaultChecker:     common.DefaultChecker{Funcs: checkerFuncs},
+		NodeRunner:         nr,
+		LocalNode:          nr.localNode,
+		Message:            message,
+		Ballot:             baseChecker.Ballot,
+		VotingHole:         baseChecker.VotingHole,
+		IsNew:              baseChecker.IsNew,
+		Log:                baseChecker.Log,
+		LatestBlockSources: baseChecker.LatestBlockSources,
 	}
 	err = common.RunChecker(checker, nr.handleBallotCheckerDeferFunc)
 	if err != nil {

--- a/lib/transaction/pool.go
+++ b/lib/transaction/pool.go
@@ -95,6 +95,28 @@ func (tp *Pool) Remove(hashes ...string) {
 	}
 }
 
+func (tp *Pool) RemoveFromSources(sources ...string) {
+	if len(sources) < 1 {
+		return
+	}
+
+	tp.Lock()
+	defer tp.Unlock()
+
+	for _, source := range sources {
+		if hash, found := tp.sources[source]; found {
+			if _, found := tp.Pool[hash]; found {
+				delete(tp.sources, source)
+				delete(tp.Pool, hash)
+				if e, ok := tp.hashMap[hash]; ok {
+					tp.hashList.Remove(e)
+					delete(tp.hashMap, hash)
+				}
+			}
+		}
+	}
+}
+
 func (tp *Pool) AvailableTransactions(transactionLimit int) []string {
 	if transactionLimit < 1 {
 		return nil


### PR DESCRIPTION
It makes validation simple. Thanks @Geod24 
We don't have to validate transactions which have same source in latestBlock again.
Please check https://github.com/bosnet/sebak/commit/4a404ea0ec5547410037a74436c82092b0a61e8d message


And applying review in https://github.com/bosnet/sebak/pull/632 after merging
