### PR TITLE
Improve and simplify SaveBlockOperations

### DIFF
--- a/lib/block/genesis.go
+++ b/lib/block/genesis.go
@@ -124,7 +124,7 @@ func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, c
 	if _, err = SaveTransactionPool(st, tx); err != nil {
 		return
 	}
-	if err = bt.SaveBlockOperations(st, *blk); err != nil {
+	if err = bt.SaveBlockOperations(st); err != nil {
 		return
 	}
 

--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -175,17 +175,14 @@ func (bt BlockTransaction) Transaction() transaction.Transaction {
 	return bt.transaction
 }
 
-func (bt BlockTransaction) SaveBlockOperations(st *storage.LevelDBBackend, blk Block) (err error) {
+func (bt *BlockTransaction) SaveBlockOperations(st *storage.LevelDBBackend) (err error) {
 	if bt.Transaction().IsEmpty() {
-		err = errors.FailedToSaveBlockOperaton
-		return
+		return errors.FailedToSaveBlockOperaton
 	}
-
-	bt.blockHeight = blk.Height
 
 	for _, op := range bt.Transaction().B.Operations {
 		var bo BlockOperation
-		bo, err = NewBlockOperationFromOperation(op, bt.Transaction(), blk.Height)
+		bo, err = NewBlockOperationFromOperation(op, bt.Transaction(), bt.blockHeight)
 		if err != nil {
 			return
 		}
@@ -200,7 +197,7 @@ func (bt BlockTransaction) SaveBlockOperations(st *storage.LevelDBBackend, blk B
 		}
 	}
 
-	return
+	return nil
 }
 
 func GetBlockTransactionKeyPrefixSource(source string) string {

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -254,7 +254,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 		for _, tx := range txs {
 			bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx)
 			bt.MustSave(st)
-			err := bt.SaveBlockOperations(st, blk)
+			err := bt.SaveBlockOperations(st)
 			require.NoError(t, err)
 		}
 	}
@@ -274,7 +274,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 		for _, tx := range txs {
 			bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx)
 			bt.MustSave(st)
-			err := bt.SaveBlockOperations(st, blk)
+			err := bt.SaveBlockOperations(st)
 			require.NoError(t, err)
 		}
 	}
@@ -293,7 +293,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 		for _, tx := range txs {
 			bt := NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx)
 			bt.MustSave(st)
-			err := bt.SaveBlockOperations(st, blk)
+			err := bt.SaveBlockOperations(st)
 			require.NoError(t, err)
 		}
 	}

--- a/lib/node/runner/api/resource/resource_test.go
+++ b/lib/node/runner/api/resource/resource_test.go
@@ -98,7 +98,7 @@ func TestResourceAccount(t *testing.T) {
 		_, tx := transaction.TestMakeTransaction([]byte{0x00}, 3)
 		bt := block.NewBlockTransactionFromTransaction(common.GetUniqueIDFromUUID(), 0, common.NowISO8601(), tx)
 		bt.MustSave(storage)
-		err = bt.SaveBlockOperations(storage, blk)
+		err = bt.SaveBlockOperations(storage)
 		require.NoError(t, err)
 
 		var rol []Resource

--- a/lib/node/runner/api/test.go
+++ b/lib/node/runner/api/test.go
@@ -91,7 +91,7 @@ func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, []bl
 	for _, tx := range txs {
 		bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.Confirmed, tx)
 		bt.MustSave(storage)
-		if err := bt.SaveBlockOperations(storage, theBlock); err != nil {
+		if err := bt.SaveBlockOperations(storage); err != nil {
 			return nil, nil
 		}
 		btList = append(btList, bt)

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -59,7 +59,7 @@ func (p *HelperTestGetBlocksHandler) createBlock() block.Block {
 	for _, tx := range txs {
 		btx := block.NewBlockTransactionFromTransaction(bk.Hash, bk.Height, bk.Confirmed, tx)
 		btx.MustSave(p.st)
-		btx.SaveBlockOperations(p.st, bk)
+		btx.SaveBlockOperations(p.st)
 		block.SaveTransactionPool(p.st, tx)
 	}
 

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -693,10 +693,8 @@ func TestProposedTransactionStoreWithZeroAmount(t *testing.T) {
 
 	previousCommonAccount, _ := block.GetBlockAccount(p.nr.Storage(), p.commonAccount.Address)
 
-	var blk *block.Block
 	{
-		var err error
-		blk, err = finishBallot(
+		_, err := finishBallot(
 			p.nr.Storage(),
 			*blt,
 			p.nr.TransactionPool,
@@ -718,7 +716,7 @@ func TestProposedTransactionStoreWithZeroAmount(t *testing.T) {
 	tp, err := block.GetTransactionPool(p.nr.Storage(), blt.ProposerTransaction().GetHash())
 	require.NoError(t, err)
 	bt.Message = tp.Message
-	err = bt.SaveBlockOperations(p.nr.Storage(), *blk)
+	err = bt.SaveBlockOperations(p.nr.Storage())
 	require.NoError(t, err)
 
 	require.Equal(t, blt.ProposerTransaction().GetHash(), bt.Hash)

--- a/lib/node/runner/block_operations.go
+++ b/lib/node/runner/block_operations.go
@@ -195,7 +195,7 @@ func (sb *SavingBlockOperations) CheckTransactionByBlock(st *storage.LevelDBBack
 		}
 
 		if !exists {
-			bt.SaveBlockOperations(st, blk)
+			bt.SaveBlockOperations(st)
 			sb.log.Debug("saved missing BlockOperation", "block", blk, "transaction", hash, "operation", op)
 		}
 	}


### PR DESCRIPTION
We don't need to pass a block as an argument, since we only use the height.
We don't need to set the height as it's already done in BlockTransaction constructor.
Last but not least, pass the BlockTransaction by pointer to avoid pointless copying.