### PR TITLE
Fix 650: Change IsWellFormed to accept only a common.Config

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -505,6 +505,7 @@ func runNode() error {
 		TimeoutINIT:       timeoutINIT,
 		TimeoutSIGN:       timeoutSIGN,
 		TimeoutACCEPT:     timeoutACCEPT,
+		NetworkID:         []byte(flagNetworkID),
 		BlockTime:         blockTime,
 		TxsLimit:          int(transactionsLimit),
 		OpsLimit:          int(operationsLimit),

--- a/lib/ballot/ballot.go
+++ b/lib/ballot/ballot.go
@@ -67,13 +67,13 @@ func (b Ballot) String() string {
 	return string(encoded)
 }
 
-func (b Ballot) IsWellFormed(networkID []byte, conf common.Config) (err error) {
-	if err = b.isBallotWellFormed(networkID, conf); err != nil {
+func (b Ballot) IsWellFormed(conf common.Config) (err error) {
+	if err = b.isBallotWellFormed(conf); err != nil {
 		return
 	}
 
 	if b.Vote() != voting.EXP {
-		if err = b.isProposerInfoWellFormed(networkID, conf); err != nil {
+		if err = b.isProposerInfoWellFormed(conf); err != nil {
 			return
 		}
 	}
@@ -81,7 +81,7 @@ func (b Ballot) IsWellFormed(networkID []byte, conf common.Config) (err error) {
 	return
 }
 
-func (b Ballot) isBallotWellFormed(networkID []byte, conf common.Config) (err error) {
+func (b Ballot) isBallotWellFormed(conf common.Config) (err error) {
 	if b.TransactionsLength() > conf.TxsLimit {
 		err = errors.BallotHasOverMaxTransactionsInBallot
 		return
@@ -104,14 +104,14 @@ func (b Ballot) isBallotWellFormed(networkID []byte, conf common.Config) (err er
 		return
 	}
 
-	if err = b.VerifySource(networkID); err != nil {
+	if err = b.VerifySource(conf.NetworkID); err != nil {
 		return
 	}
 
 	return
 }
 
-func (b Ballot) isProposerInfoWellFormed(networkID []byte, conf common.Config) (err error) {
+func (b Ballot) isProposerInfoWellFormed(conf common.Config) (err error) {
 	var proposerConfirmed time.Time
 	if proposerConfirmed, err = common.ParseISO8601(b.ProposerConfirmed()); err != nil {
 		return
@@ -126,11 +126,11 @@ func (b Ballot) isProposerInfoWellFormed(networkID []byte, conf common.Config) (
 		return
 	}
 
-	if err = b.ProposerTransaction().IsWellFormedWithBallot(networkID, b, conf); err != nil {
+	if err = b.ProposerTransaction().IsWellFormedWithBallot(b, conf); err != nil {
 		return
 	}
 
-	if err = b.VerifyProposer(networkID); err != nil {
+	if err = b.VerifyProposer(conf.NetworkID); err != nil {
 		return
 	}
 

--- a/lib/ballot/proposer_transaction.go
+++ b/lib/ballot/proposer_transaction.go
@@ -103,14 +103,14 @@ var ProposerTransactionWellFormedCheckerFuncs = []common.CheckerFunc{
 	transaction.CheckVerifySignature,
 }
 
-func (p ProposerTransaction) IsWellFormed(networkID []byte, conf common.Config) (err error) {
+func (p ProposerTransaction) IsWellFormed(conf common.Config) (err error) {
 	if _, err = p.CollectTxFee(); err != nil {
 		return
 	}
 
 	checker := &transaction.Checker{
 		DefaultChecker: common.DefaultChecker{Funcs: ProposerTransactionWellFormedCheckerFuncs},
-		NetworkID:      networkID,
+		NetworkID:      conf.NetworkID,
 		Transaction:    p.Transaction,
 		Conf:           conf,
 	}
@@ -121,13 +121,13 @@ func (p ProposerTransaction) IsWellFormed(networkID []byte, conf common.Config) 
 	return
 }
 
-func (p ProposerTransaction) IsWellFormedWithBallot(networkID []byte, blt Ballot, conf common.Config) (err error) {
+func (p ProposerTransaction) IsWellFormedWithBallot(blt Ballot, conf common.Config) (err error) {
 	if p.Source() != blt.Proposer() {
 		err = errors.InvalidProposerTransaction
 		return
 	}
 
-	if err = p.IsWellFormed(networkID, conf); err != nil {
+	if err = p.IsWellFormed(conf); err != nil {
 		return
 	}
 

--- a/lib/block/block_test.go
+++ b/lib/block/block_test.go
@@ -103,6 +103,7 @@ func TestBlockHeightOrdering(t *testing.T) {
 // TestMakeGenesisBlock basically tests MakeGenesisBlock can make genesis block,
 // and further with genesis block, genesis account can be found.
 func TestMakeGenesisBlock(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 	defer st.Close()
 
@@ -117,7 +118,7 @@ func TestMakeGenesisBlock(t *testing.T) {
 	err = commonAccount.Save(st)
 	require.NoError(t, err)
 
-	bk, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
+	bk, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, conf.NetworkID)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), bk.Height)
 	require.Equal(t, 1, len(bk.Transactions))
@@ -136,7 +137,7 @@ func TestMakeGenesisBlock(t *testing.T) {
 	bt, err := GetBlockTransaction(st, bk.Transactions[0])
 	require.NoError(t, err)
 
-	genesisBlockKP := keypair.Master(string(networkID))
+	genesisBlockKP := keypair.Master(string(conf.NetworkID))
 	require.Equal(t, genesisAccount.SequenceID, bt.SequenceID)
 	require.Equal(t, common.Amount(0), bt.Fee)
 	require.Equal(t, 2, len(bt.Operations))
@@ -167,6 +168,7 @@ func TestMakeGenesisBlock(t *testing.T) {
 }
 
 func TestMakeGenesisBlockOverride(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 	defer st.Close()
 
@@ -182,7 +184,7 @@ func TestMakeGenesisBlockOverride(t *testing.T) {
 		err = commonAccount.Save(st)
 		require.NoError(t, err)
 
-		bk, err := MakeGenesisBlock(st, *account, *commonAccount, networkID)
+		bk, err := MakeGenesisBlock(st, *account, *commonAccount, conf.NetworkID)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), bk.Height)
 	}
@@ -199,12 +201,13 @@ func TestMakeGenesisBlockOverride(t *testing.T) {
 		err = commonAccount.Save(st)
 		require.NoError(t, err)
 
-		_, err = MakeGenesisBlock(st, *account, *commonAccount, networkID)
+		_, err = MakeGenesisBlock(st, *account, *commonAccount, conf.NetworkID)
 		require.Equal(t, errors.BlockAlreadyExists, err)
 	}
 }
 
 func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 	defer st.Close()
 
@@ -219,7 +222,7 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 	commonAccount.MustSave(st)
 
 	{
-		bk, err := MakeGenesisBlock(st, *account, *commonAccount, networkID)
+		bk, err := MakeGenesisBlock(st, *account, *commonAccount, conf.NetworkID)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), bk.Height)
 	}
@@ -245,6 +248,7 @@ func TestMakeGenesisBlockFindGenesisAccount(t *testing.T) {
 }
 
 func TestMakeGenesisBlockFindCommonAccount(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 	defer st.Close()
 
@@ -259,7 +263,7 @@ func TestMakeGenesisBlockFindCommonAccount(t *testing.T) {
 	commonAccount.MustSave(st)
 
 	{
-		bk, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID)
+		bk, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, conf.NetworkID)
 		require.NoError(t, err)
 		require.Equal(t, uint64(1), bk.Height)
 	}

--- a/lib/block/genesis.go
+++ b/lib/block/genesis.go
@@ -44,7 +44,7 @@ func GetGenesis(st *storage.LevelDBBackend) Block {
 //   * `CreateAccount.Amount` is 0
 //   * `CreateAccount.Target` is common account
 // * `Transaction.B.Fee` is 0
-func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, commonAccount BlockAccount, networdID []byte) (blk *Block, err error) {
+func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, commonAccount BlockAccount, networkID []byte) (blk *Block, err error) {
 	if genesisAccount.Address == commonAccount.Address {
 		err = fmt.Errorf("genesis account and common account are same.")
 		return
@@ -99,7 +99,7 @@ func MakeGenesisBlock(st *storage.LevelDBBackend, genesisAccount BlockAccount, c
 	}
 
 	kp := keypair.Master(string(networkID))
-	tx.Sign(kp, []byte(networdID))
+	tx.Sign(kp, []byte(networkID))
 
 	blk = NewBlock(
 		"",

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -3,16 +3,17 @@ package block
 import (
 	"testing"
 
+	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
 
 	"github.com/stretchr/testify/require"
-
-	"boscoin.io/sebak/lib/transaction"
 )
 
 func TestNewBlockOperationFromOperation(t *testing.T) {
-	_, tx := transaction.TestMakeTransaction(networkID, 1)
+	conf := common.NewTestConfig()
+	_, tx := transaction.TestMakeTransaction(conf.NetworkID, 1)
 
 	op := tx.B.Operations[0]
 	bo, err := NewBlockOperationFromOperation(op, tx, 0)
@@ -27,9 +28,10 @@ func TestNewBlockOperationFromOperation(t *testing.T) {
 }
 
 func TestBlockOperationSaveAndGet(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 
-	bos := TestMakeNewBlockOperation(networkID, 1)
+	bos := TestMakeNewBlockOperation(conf.NetworkID, 1)
 	bo := bos[0]
 	bos[0].MustSave(st)
 
@@ -43,9 +45,10 @@ func TestBlockOperationSaveAndGet(t *testing.T) {
 }
 
 func TestBlockOperationSaveExisting(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 
-	bos := TestMakeNewBlockOperation(networkID, 1)
+	bos := TestMakeNewBlockOperation(conf.NetworkID, 1)
 	bo := bos[0]
 	bo.MustSave(st)
 
@@ -59,13 +62,14 @@ func TestBlockOperationSaveExisting(t *testing.T) {
 }
 
 func TestGetSortedBlockOperationsByTxHash(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 
 	// create 30 `BlockOperation`
 	var txHashes []string
 	createdOrder := map[string][]string{}
 	for _ = range [3]int{0, 0, 0} {
-		bos := TestMakeNewBlockOperation(networkID, 10)
+		bos := TestMakeNewBlockOperation(conf.NetworkID, 10)
 		txHashes = append(txHashes, bos[0].TxHash)
 
 		for _, bo := range bos {
@@ -95,9 +99,10 @@ func TestGetSortedBlockOperationsByTxHash(t *testing.T) {
 }
 
 func TestBlockOperationSaveByTransaction(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := InitTestBlockchain()
 
-	_, tx := transaction.TestMakeTransaction(networkID, 10)
+	_, tx := transaction.TestMakeTransaction(conf.NetworkID, 10)
 	block := TestMakeNewBlockWithPrevBlock(GetLatestBlock(st), []string{tx.GetHash()})
 	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 	err := bt.Save(st)

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -8,8 +8,6 @@ import (
 	"boscoin.io/sebak/lib/voting"
 )
 
-var networkID []byte = []byte("sebak-test-network")
-
 func TestMakeBlockAccount() *BlockAccount {
 	address := keypair.Random().Address()
 	balance := common.Amount(common.BaseReserve)
@@ -40,6 +38,7 @@ func init() {
 //   st = Storage to write the blockchain to
 //
 func MakeTestBlockchain(st *storage.LevelDBBackend) {
+	conf := common.NewTestConfig()
 	balance := common.MaximumBalance
 	genesisAccount := NewBlockAccount(GenesisKP.Address(), balance)
 	if err := genesisAccount.Save(st); err != nil {
@@ -51,7 +50,7 @@ func MakeTestBlockchain(st *storage.LevelDBBackend) {
 		panic(err)
 	}
 
-	if _, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, networkID); err != nil {
+	if _, err := MakeGenesisBlock(st, *genesisAccount, *commonAccount, conf.NetworkID); err != nil {
 		panic(err)
 	}
 }

--- a/lib/block/transaction_pool_test.go
+++ b/lib/block/transaction_pool_test.go
@@ -12,9 +12,10 @@ import (
 )
 
 func TestTransactionPool(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 
-	_, tx := transaction.TestMakeTransaction(networkID, 1)
+	_, tx := transaction.TestMakeTransaction(conf.NetworkID, 1)
 
 	var tp TransactionPool
 	var err error

--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -13,7 +13,8 @@ import (
 )
 
 func TestNewBlockTransaction(t *testing.T) {
-	_, tx := transaction.TestMakeTransaction(networkID, 1)
+	conf := common.NewTestConfig()
+	_, tx := transaction.TestMakeTransaction(conf.NetworkID, 1)
 	block := TestMakeNewBlock([]string{tx.GetHash()})
 	bt := NewBlockTransactionFromTransaction(block.Hash, block.Height, block.Confirmed, tx)
 
@@ -35,9 +36,10 @@ func TestNewBlockTransaction(t *testing.T) {
 }
 
 func TestBlockTransactionSaveAndGet(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 
-	bt := makeNewBlockTransaction(networkID, 1)
+	bt := makeNewBlockTransaction(conf.NetworkID, 1)
 	err := bt.Save(st)
 	require.NoError(t, err)
 
@@ -55,9 +57,10 @@ func TestBlockTransactionSaveAndGet(t *testing.T) {
 }
 
 func TestBlockTransactionSaveExisting(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 
-	bt := makeNewBlockTransaction(networkID, 1)
+	bt := makeNewBlockTransaction(conf.NetworkID, 1)
 	err := bt.Save(st)
 	require.NoError(t, err)
 
@@ -71,6 +74,7 @@ func TestBlockTransactionSaveExisting(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionSource(t *testing.T) {
+	conf := common.NewTestConfig()
 	kp := keypair.Random()
 	kpAnother := keypair.Random()
 	st := storage.NewTestStorage()
@@ -81,7 +85,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 	var txHashes []string
 	var createdOrder []string
 	for i := 0; i < numTxs; i++ {
-		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+		tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kp)
 		txs = append(txs, tx)
 		createdOrder = append(createdOrder, tx.GetHash())
 		txHashes = append(txHashes, tx.GetHash())
@@ -99,7 +103,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 	txs = []transaction.Transaction{}
 	txHashes = []string{}
 	for i := 0; i < numTxs; i++ {
-		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kpAnother)
+		tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kpAnother)
 		txs = append(txs, tx)
 		txHashes = append(txHashes, tx.GetHash())
 	}
@@ -154,6 +158,7 @@ func TestMultipleBlockTransactionSource(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionConfirmed(t *testing.T) {
+	conf := common.NewTestConfig()
 	kp := keypair.Random()
 	st := storage.NewTestStorage()
 
@@ -163,7 +168,7 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 	var txHashes []string
 	var createdOrder []string
 	for i := 0; i < numTxs; i++ {
-		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+		tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kp)
 		createdOrder = append(createdOrder, tx.GetHash())
 		txs = append(txs, tx)
 		txHashes = append(txHashes, tx.GetHash())
@@ -217,9 +222,10 @@ func TestMultipleBlockTransactionConfirmed(t *testing.T) {
 }
 
 func TestBlockTransactionMultipleSave(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 
-	bt := makeNewBlockTransaction(networkID, 1)
+	bt := makeNewBlockTransaction(conf.NetworkID, 1)
 	err := bt.Save(st)
 	require.NoError(t, err)
 
@@ -232,6 +238,7 @@ func TestBlockTransactionMultipleSave(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
+	conf := common.NewTestConfig()
 	kp := keypair.Random()
 	kpAnother := keypair.Random()
 	st := storage.NewTestStorage()
@@ -244,7 +251,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 	var blk Block
 	{
 		for i := 0; i < numTxs; i++ {
-			tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+			tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kp)
 			txs = append(txs, tx)
 			createdOrder = append(createdOrder, tx.GetHash())
 			txHashes = append(txHashes, tx.GetHash())
@@ -264,7 +271,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 		txs = []transaction.Transaction{}
 		txHashes = []string{}
 		for i := 0; i < numTxs; i++ {
-			tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kpAnother, kp)
+			tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kpAnother, kp)
 			txs = append(txs, tx)
 			createdOrder = append(createdOrder, tx.GetHash())
 			txHashes = append(txHashes, tx.GetHash())
@@ -284,7 +291,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 		txs = []transaction.Transaction{}
 		txHashes = []string{}
 		for i := 0; i < numTxs; i++ {
-			tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kpAnother)
+			tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kpAnother)
 			txs = append(txs, tx)
 			txHashes = append(txHashes, tx.GetHash())
 		}
@@ -319,6 +326,7 @@ func TestMultipleBlockTransactionGetByAccount(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
+	conf := common.NewTestConfig()
 	kp := keypair.Random()
 	st := storage.NewTestStorage()
 
@@ -328,7 +336,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	var txHashes0 []string
 	var createdOrder0 []string
 	for i := 0; i < numTxs; i++ {
-		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+		tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kp)
 		txs0 = append(txs0, tx)
 		createdOrder0 = append(createdOrder0, tx.GetHash())
 		txHashes0 = append(txHashes0, tx.GetHash())
@@ -344,7 +352,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 	var txHashes1 []string
 	var createdOrder1 []string
 	for i := 0; i < numTxs; i++ {
-		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+		tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kp)
 		txs1 = append(txs1, tx)
 		createdOrder1 = append(createdOrder1, tx.GetHash())
 		txHashes1 = append(txHashes1, tx.GetHash())
@@ -396,6 +404,7 @@ func TestMultipleBlockTransactionGetByBlock(t *testing.T) {
 }
 
 func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
+	conf := common.NewTestConfig()
 	kp := keypair.Random()
 	st := storage.NewTestStorage()
 
@@ -410,7 +419,7 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		txs := []transaction.Transaction{}
 		txHashes := []string{}
 		for i := 0; i < numTxs; i++ {
-			tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+			tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kp)
 			txs = append(txs, tx)
 			createdOrder = append(createdOrder, tx.GetHash())
 			txHashes = append(txHashes, tx.GetHash())
@@ -432,7 +441,7 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		txs := []transaction.Transaction{}
 		txHashes := []string{}
 		for i := 0; i < numTxs; i++ {
-			tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+			tx := transaction.TestMakeTransactionWithKeypair(conf.NetworkID, 1, kp)
 			txs = append(txs, tx)
 			createdOrder = append(createdOrder, tx.GetHash())
 			txHashes = append(txHashes, tx.GetHash())

--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -18,11 +18,14 @@ type Config struct {
 	TxsLimit int
 	OpsLimit int
 
+	NetworkID []byte
+
+	// Those fields are not consensus-related
 	RateLimitRuleAPI  RateLimitRule
 	RateLimitRuleNode RateLimitRule
 }
 
-func NewConfig() Config {
+func NewConfig(networkID []byte) Config {
 	p := Config{}
 
 	p.TimeoutINIT = 2 * time.Second
@@ -32,6 +35,8 @@ func NewConfig() Config {
 
 	p.TxsLimit = 1000
 	p.OpsLimit = 1000
+	p.NetworkID = networkID
+
 	p.RateLimitRuleAPI = NewRateLimitRule(RateLimitAPI)
 	p.RateLimitRuleNode = NewRateLimitRule(RateLimitNode)
 

--- a/lib/common/config_test.go
+++ b/lib/common/config_test.go
@@ -12,7 +12,7 @@ import (
 
 //	TestConfigDefault tests the default timeout values.
 func TestConfigDefault(t *testing.T) {
-	n := NewConfig()
+	n := NewTestConfig()
 	require.Equal(t, 2*time.Second, n.TimeoutINIT)
 	require.Equal(t, 2*time.Second, n.TimeoutSIGN)
 	require.Equal(t, 2*time.Second, n.TimeoutACCEPT)
@@ -24,7 +24,7 @@ func TestConfigDefault(t *testing.T) {
 
 //	TestConfigSetAndGet tests setting timeout fields and checking.
 func TestConfigSetAndGet(t *testing.T) {
-	n := NewConfig()
+	n := NewTestConfig()
 	n.TimeoutINIT = 3 * time.Second
 	n.TimeoutSIGN = 1 * time.Second
 	n.TimeoutACCEPT = 1 * time.Second

--- a/lib/common/message.go
+++ b/lib/common/message.go
@@ -21,7 +21,7 @@ type Message interface {
 	GetType() MessageType
 	GetHash() string
 	Serialize() ([]byte, error)
-	IsWellFormed([]byte, Config) error
+	IsWellFormed(Config) error
 	Equal(Message) bool
 	Source() string
 	// Validate(storage.LevelDBBackend) error

--- a/lib/common/test.go
+++ b/lib/common/test.go
@@ -1,0 +1,7 @@
+// Provide test utilities for the common package
+package common
+
+// Initialize a new config object for unittests
+func NewTestConfig() Config {
+	return NewConfig([]byte("sebak-unittest"))
+}

--- a/lib/network/memory_test.go
+++ b/lib/network/memory_test.go
@@ -23,7 +23,7 @@ func NewDummyMessage(data string) DummyMessage {
 	return d
 }
 
-func (m DummyMessage) IsWellFormed([]byte, common.Config) error {
+func (m DummyMessage) IsWellFormed(common.Config) error {
 	return nil
 }
 

--- a/lib/node/runner/api/test.go
+++ b/lib/node/runner/api/test.go
@@ -13,7 +13,7 @@ import (
 	"boscoin.io/sebak/lib/transaction"
 )
 
-var networkID []byte = []byte("sebak-test-network")
+var networkID []byte = []byte("sebak-unittest")
 
 const (
 	QueryPattern = "cursor={cursor}&limit={limit}&reverse={reverse}&type={type}"

--- a/lib/node/runner/api_message_handler_test.go
+++ b/lib/node/runner/api_message_handler_test.go
@@ -31,7 +31,7 @@ type HelperTestNodeMessageHandler struct {
 func (p *HelperTestNodeMessageHandler) Prepare() {
 	p.HelperTestGetNodeTransactionsHandler.Prepare()
 
-	p.conf = common.NewConfig()
+	p.conf = common.NewTestConfig()
 	p.nodeHandler = NewNetworkHandlerNode(
 		p.localNode,
 		p.network,
@@ -78,7 +78,7 @@ func TestNodeMessageHandler(t *testing.T) {
 	u := p.URL(nil)
 
 	tx := p.makeTransaction()
-	require.Nil(t, tx.IsWellFormed(networkID, p.conf))
+	require.Nil(t, tx.IsWellFormed(p.conf))
 
 	postData, _ := tx.Serialize()
 	req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(postData))
@@ -100,7 +100,7 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 	{ // invalid signature
 		tx := p.makeTransaction()
 		tx.H.Signature = "findme"
-		errIsWellformed := tx.IsWellFormed(networkID, p.conf)
+		errIsWellformed := tx.IsWellFormed(p.conf)
 		require.Equal(t, errors.InvalidTransaction.Code, errIsWellformed.(*errors.Error).Code)
 
 		postData, _ := tx.Serialize()
@@ -135,7 +135,7 @@ func TestNodeMessageHandlerNotWellformedTransaction(t *testing.T) {
 		tx.B.Operations[0].B = opb
 		tx.Sign(p.genesisKeypair, networkID)
 
-		errIsWellformed := tx.IsWellFormed(networkID, p.conf)
+		errIsWellformed := tx.IsWellFormed(p.conf)
 		require.Equal(t, errors.OperationAmountUnderflow.Code, errIsWellformed.(*errors.Error).Code)
 
 		postData, _ := tx.Serialize()

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -70,6 +70,7 @@ func pingAndWait(t *testing.T, c0 network.NetworkClient) {
 }
 
 func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Network, nodeRunner *NodeRunner) {
+	conf := common.NewTestConfig()
 	g := network.NewKeyGenerator(dirPath, certPath, keyPath)
 
 	var config *network.HTTP2NetworkConfig
@@ -104,8 +105,8 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Netw
 	)
 
 	st := block.InitTestBlockchain()
-	is, _ := consensus.NewISAAC(networkID, localNode, p, connectionManager, st, common.NewConfig(), nil)
-	if nodeRunner, err = NewNodeRunner(string(networkID), localNode, p, n, is, st, common.NewConfig()); err != nil {
+	is, _ := consensus.NewISAAC(networkID, localNode, p, connectionManager, st, conf, nil)
+	if nodeRunner, err = NewNodeRunner(string(networkID), localNode, p, n, is, st, conf); err != nil {
 		panic(err)
 	}
 
@@ -226,7 +227,7 @@ func TestGetNodeInfoHandler(t *testing.T) {
 		nil,
 		network.NewValidatorConnectionManager(localNode, nil, nil),
 		st,
-		common.NewConfig(),
+		common.NewTestConfig(),
 		nil,
 	)
 

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -58,7 +58,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 		nil,
 		NewTestConnectionManager(p.localNode, nil, nil, make(chan struct{}, 100)),
 		p.st,
-		common.NewConfig(),
+		common.NewTestConfig(),
 		nil,
 	)
 	p.consensus = isaac

--- a/lib/node/runner/broadcaster_test.go
+++ b/lib/node/runner/broadcaster_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestConnectionManagerBroadcaster(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 
 	recv := make(chan struct{})
 	nr, _, cm := createNodeRunnerForTesting(3, conf, recv)

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -66,7 +66,7 @@ func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	if err = b.IsWellFormed(checker.NetworkID, checker.NodeRunner.Conf); err != nil {
+	if err = b.IsWellFormed(checker.NodeRunner.Conf); err != nil {
 		return
 	}
 
@@ -391,7 +391,7 @@ func insertMissingTransaction(checker *BallotChecker) (err error) {
 			err = errors.TransactionNotFound
 			return
 		}
-		if err = tx.IsWellFormed(checker.NetworkID, checker.NodeRunner.Conf); err != nil {
+		if err = tx.IsWellFormed(checker.NodeRunner.Conf); err != nil {
 			return
 		}
 

--- a/lib/node/runner/checker_message.go
+++ b/lib/node/runner/checker_message.go
@@ -50,7 +50,7 @@ func TransactionUnmarshal(c common.Checker, args ...interface{}) (err error) {
 		return
 	}
 
-	if err = tx.IsWellFormed(checker.NetworkID, checker.Conf); err != nil {
+	if err = tx.IsWellFormed(checker.Conf); err != nil {
 		return
 	}
 

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -380,7 +380,7 @@ type irregularIncomingBallot struct {
 }
 
 func (p *irregularIncomingBallot) prepare() {
-	p.nr, p.nodes, _ = createNodeRunnerForTesting(2, common.NewConfig(), nil)
+	p.nr, p.nodes, _ = createNodeRunnerForTesting(2, common.NewTestConfig(), nil)
 
 	p.genesisBlock = block.GetGenesis(p.nr.Storage())
 	p.commonAccount, _ = GetCommonAccount(p.nr.Storage())

--- a/lib/node/runner/finish_ballot_test.go
+++ b/lib/node/runner/finish_ballot_test.go
@@ -64,7 +64,7 @@ func createNodeRunnerForTestingWithFileStorage(n int, conf common.Config, recv c
 		block.MakeTestBlockchain(st)
 	}
 
-	is, _ := consensus.NewISAAC(networkID, localNode, policy, connectionManager, st, common.NewConfig(), nil)
+	is, _ := consensus.NewISAAC(conf.NetworkID, localNode, policy, connectionManager, st, conf, nil)
 	is.SetProposerSelector(FixedSelector{localNode.Address()})
 
 	nr, err := NewNodeRunner(string(networkID), localNode, policy, ns[0], is, st, conf)
@@ -77,7 +77,8 @@ func createNodeRunnerForTestingWithFileStorage(n int, conf common.Config, recv c
 }
 
 func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOperations int) error {
-	nr, localNodes, dir := createNodeRunnerForTestingWithFileStorage(1, common.NewConfig(), nil)
+	conf := common.NewTestConfig()
+	nr, localNodes, dir := createNodeRunnerForTestingWithFileStorage(1, conf, nil)
 	defer func() {
 		nr.Storage().Close()
 		os.RemoveAll(dir)
@@ -108,7 +109,7 @@ func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOpe
 			accountA.MustSave(nr.Storage())
 
 			kpB := keypair.Random()
-			tx := transaction.MakeTransactionCreateAccount(networkID, kpA, kpB.Address(), common.Amount(1))
+			tx := transaction.MakeTransactionCreateAccount(conf.NetworkID, kpA, kpB.Address(), common.Amount(1))
 
 			var ops []operation.Operation
 			for j := 0; j < numberOfOperations-1; j++ {
@@ -125,7 +126,7 @@ func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOpe
 			}
 			tx.B.Operations = append(tx.B.Operations, ops...)
 			tx.B.SequenceID = accountA.SequenceID
-			tx.Sign(kpA, networkID)
+			tx.Sign(kpA, conf.NetworkID)
 
 			txHashes = append(txHashes, tx.GetHash())
 			txs = append(txs, tx)
@@ -140,7 +141,7 @@ func testFinishBallotWithBatch(withBatch bool, numberOfTransactions, numberOfOpe
 
 		blt.SetProposerTransaction(ptx)
 		blt.SetVote(ballot.StateINIT, voting.YES)
-		blt.Sign(proposerNode.Keypair(), networkID)
+		blt.Sign(proposerNode.Keypair(), conf.NetworkID)
 	}
 
 	st := nr.Storage()

--- a/lib/node/runner/isaac_simulation_test.go
+++ b/lib/node/runner/isaac_simulation_test.go
@@ -24,7 +24,8 @@ TestISAACSimulationProposer indicates the following:
 	4. The node receives a ballot that exceeds the threshold, and the block is confirmed.
 */
 func TestISAACSimulationProposer(t *testing.T) {
-	nr, nodes, _ := createNodeRunnerForTesting(5, common.NewConfig(), nil)
+	conf := common.NewTestConfig()
+	nr, nodes, _ := createNodeRunnerForTesting(5, conf, nil)
 	tx, _ := GetTransaction()
 
 	// `nr` is proposer's runner
@@ -46,8 +47,6 @@ func TestISAACSimulationProposer(t *testing.T) {
 		TotalTxs:  b.TotalTxs,
 	}
 	require.True(t, nr.TransactionPool.Has(tx.GetHash()))
-
-	conf := common.NewConfig()
 
 	ballotSIGN1 := GenerateBallot(proposer, votingBasis, tx, ballot.StateSIGN, nodes[1], conf)
 	err = ReceiveBallot(nr, ballotSIGN1)

--- a/lib/node/runner/isaac_simulation_unfreezing_test.go
+++ b/lib/node/runner/isaac_simulation_unfreezing_test.go
@@ -22,7 +22,7 @@ TestUnfreezingSimulation indicates the following:
 	5. Unfreezing tx will not be processed untill X period pass.
 */
 func TestUnfreezingSimulation(t *testing.T) {
-	nr, nodes, _ := createNodeRunnerForTesting(3, common.NewConfig(), nil)
+	nr, nodes, _ := createNodeRunnerForTesting(3, common.NewTestConfig(), nil)
 
 	st := nr.storage
 

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -17,7 +17,7 @@ import (
 // 2. Proposer itself.
 // 3. When `ISAACStateManager` starts, the node proposes ballot to validators.
 func TestStateINITProposer(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
 	conf.TimeoutSIGN = time.Hour
 	conf.TimeoutACCEPT = time.Hour
@@ -43,7 +43,7 @@ func TestStateINITProposer(t *testing.T) {
 // 3. When `ISAACStateManager` starts, the node waits a ballot by proposer.
 // 4. But TimeoutINIT is an hour, so it doesn't broadcast anything.
 func TestStateINITNotProposer(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
 	conf.TimeoutSIGN = time.Hour
 	conf.TimeoutACCEPT = time.Hour
@@ -68,7 +68,7 @@ func TestStateINITNotProposer(t *testing.T) {
 // 4. But TimeoutINIT is a millisecond.
 // 5. After timeout, the node broadcasts B(`SIGN`, `EXP`)
 func TestStateINITTimeoutNotProposer(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = 200 * time.Millisecond
 	conf.TimeoutSIGN = time.Hour
 	conf.TimeoutACCEPT = time.Hour
@@ -119,7 +119,7 @@ func TestStateINITTimeoutNotProposer(t *testing.T) {
 // 5. But TimeoutSIGN is a millisecond.
 // 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`)
 func TestStateSIGNTimeoutProposer(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
 	conf.TimeoutSIGN = 200 * time.Millisecond
 	conf.TimeoutACCEPT = time.Hour
@@ -177,7 +177,7 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 // 7. TimeoutSIGN is a millisecond.
 // 8. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
 func TestStateSIGNTimeoutNotProposer(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = 200 * time.Millisecond
 	conf.TimeoutSIGN = 200 * time.Millisecond
 	conf.TimeoutACCEPT = time.Hour
@@ -231,7 +231,7 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 // 5. TimeoutSIGN is a millisecond.
 // 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
 func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
 	conf.TimeoutSIGN = 200 * time.Millisecond
 	conf.TimeoutACCEPT = 200 * time.Millisecond
@@ -290,7 +290,7 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 // 6. TimeoutSIGN is a millisecond.
 // 7. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
 func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
 	conf.TimeoutSIGN = 200 * time.Millisecond
 	conf.TimeoutACCEPT = 200 * time.Millisecond
@@ -343,7 +343,7 @@ func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 // 1. TimeoutACCEPT is a millisecond.
 // 1. After timeout, ISAACState is back to `INIT`
 func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
 	conf.TimeoutSIGN = time.Hour
 	conf.TimeoutACCEPT = 200 * time.Millisecond

--- a/lib/node/runner/isaac_voting_empty_transaction_test.go
+++ b/lib/node/runner/isaac_voting_empty_transaction_test.go
@@ -12,7 +12,7 @@ import (
 
 // Test that ballot with empty transactions have voting.YES
 func TestISAACBallotWithEmptyTransaction(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	nr, _, _ := createNodeRunnerForTesting(1, conf, nil)
 
 	latestBlock := nr.Consensus().LatestBlock()
@@ -29,7 +29,7 @@ func TestISAACBallotWithEmptyTransaction(t *testing.T) {
 
 // Test that the voting process ends normally with a ballot with an empty transaction.
 func TestISAACBallotWithEmptyTransactionVoting(t *testing.T) {
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	nr, nodes, _ := createNodeRunnerForTesting(5, conf, nil)
 
 	// `nodeRunner` is proposer's runner

--- a/lib/node/runner/modified_source_validate_test.go
+++ b/lib/node/runner/modified_source_validate_test.go
@@ -26,7 +26,7 @@ TestUnfreezingSimulation indicates the following:
 	7. The transaction `tx1` is removed because it is not valid anymore.
 */
 func TestModifiedSourceValidate(t *testing.T) {
-	nr, nodes, _ := createNodeRunnerForTesting(3, common.NewConfig(), nil)
+	nr, nodes, _ := createNodeRunnerForTesting(3, common.NewTestConfig(), nil)
 
 	st := nr.storage
 

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -73,7 +73,7 @@ func createTestNodeRunner(n int, conf common.Config) []*NodeRunner {
 }
 
 func createTestNodeRunnerWithReady(n int) []*NodeRunner {
-	nodeRunners := createTestNodeRunner(n, common.NewConfig())
+	nodeRunners := createTestNodeRunner(n, common.NewTestConfig())
 
 	for _, nr := range nodeRunners {
 		go nr.Start()
@@ -149,10 +149,10 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 			policy,
 		)
 
-		conf := common.NewConfig()
+		conf := common.NewTestConfig()
 		st := block.InitTestBlockchain()
-		is, _ := consensus.NewISAAC(networkID, node, policy, connectionManager, st, conf, nil)
-		nodeRunner, _ := NewNodeRunner(string(networkID), node, policy, n, is, st, conf)
+		is, _ := consensus.NewISAAC(conf.NetworkID, node, policy, connectionManager, st, conf, nil)
+		nodeRunner, _ := NewNodeRunner(string(conf.NetworkID), node, policy, n, is, st, conf)
 		nodeRunners = append(nodeRunners, nodeRunner)
 	}
 
@@ -206,7 +206,7 @@ func createTestNodeRunnersHTTP2NetworkWithReady(n int) (nodeRunners []*NodeRunne
 
 // Check that createTestNodeRunner creates the appropriate number of node runners.
 func TestCreateNodeRunner(t *testing.T) {
-	nodeRunners := createTestNodeRunner(3, common.NewConfig())
+	nodeRunners := createTestNodeRunner(3, common.NewTestConfig())
 
 	require.Equal(t, 3, len(nodeRunners))
 }
@@ -257,7 +257,8 @@ func TestNodeRunnerSaveBlock(t *testing.T) {
 // We can make sure to check the proposer of the expired ballot.
 // If the proposer of a ballot is different from the node, the node votes with VotingNo
 func TestExpiredBallotCheckProposer(t *testing.T) {
-	nr, nodes, _ := createNodeRunnerForTesting(2, common.NewConfig(), nil)
+	conf := common.NewTestConfig()
+	nr, nodes, _ := createNodeRunnerForTesting(2, conf, nil)
 
 	_, ok := nr.Consensus().ConnectionManager().(*TestConnectionManager)
 	require.True(t, ok)
@@ -272,7 +273,7 @@ func TestExpiredBallotCheckProposer(t *testing.T) {
 	}
 
 	// The createNodeRunnerForTesting has FixedSelector{localNode.Address()} so the proposer is always nr(nodes[0]).
-	validBallot := GenerateEmptyTxBallot(nr.localNode, basis, ballot.StateSIGN, nodes[1], common.NewConfig())
+	validBallot := GenerateEmptyTxBallot(nr.localNode, basis, ballot.StateSIGN, nodes[1], conf)
 	validBallot.SetVote(ballot.StateSIGN, voting.EXP)
 
 	checker := &BallotChecker{
@@ -293,7 +294,7 @@ func TestExpiredBallotCheckProposer(t *testing.T) {
 
 	// The createNodeRunnerForTesting has FixedSelector{localNode.Address()} so the proposer is always nr(nodes[0]).
 	// The invalidBallot has nodes[1] as a proposer so it is invalid.
-	invalidBallot := GenerateEmptyTxBallot(nodes[1], basis, ballot.StateSIGN, nodes[1], common.NewConfig())
+	invalidBallot := GenerateEmptyTxBallot(nodes[1], basis, ballot.StateSIGN, nodes[1], common.NewTestConfig())
 	invalidBallot.SetVote(ballot.StateSIGN, voting.EXP)
 
 	checker = &BallotChecker{

--- a/lib/node/runner/proposer_selector_test.go
+++ b/lib/node/runner/proposer_selector_test.go
@@ -9,7 +9,7 @@ import (
 
 // In TestProposerSelector test, the proposer is always the node itself because of SelfProposerCalculator.
 func TestProposerSelector(t *testing.T) {
-	nodeRunners := createTestNodeRunner(1, common.NewConfig())
+	nodeRunners := createTestNodeRunner(1, common.NewTestConfig())
 
 	nodeRunner := nodeRunners[0]
 
@@ -22,7 +22,7 @@ func TestProposerSelector(t *testing.T) {
 func TestNodesHaveSameProposers(t *testing.T) {
 	numberOfNodes := 3
 
-	nodeRunners := createTestNodeRunner(numberOfNodes, common.NewConfig())
+	nodeRunners := createTestNodeRunner(numberOfNodes, common.NewTestConfig())
 
 	nr0 := nodeRunners[0]
 	nr1 := nodeRunners[1]

--- a/lib/node/runner/test.go
+++ b/lib/node/runner/test.go
@@ -15,9 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var networkID []byte = []byte("sebak-test-network")
+var networkID []byte = []byte("sebak-unittest")
 
 func MakeNodeRunner() (*NodeRunner, *node.LocalNode) {
+	conf := common.NewTestConfig()
 	_, n, localNode := network.CreateMemoryNetwork(nil)
 
 	policy, _ := consensus.NewDefaultVotingThresholdPolicy(66)
@@ -29,10 +30,9 @@ func MakeNodeRunner() (*NodeRunner, *node.LocalNode) {
 		policy,
 	)
 
-	conf := common.NewConfig()
 	st := block.InitTestBlockchain()
-	is, _ := consensus.NewISAAC(networkID, localNode, policy, connectionManager, st, conf, nil)
-	nodeRunner, _ := NewNodeRunner(string(networkID), localNode, policy, n, is, st, conf)
+	is, _ := consensus.NewISAAC(conf.NetworkID, localNode, policy, connectionManager, st, conf, nil)
+	nodeRunner, _ := NewNodeRunner(string(conf.NetworkID), localNode, policy, n, is, st, conf)
 	return nodeRunner, localNode
 }
 
@@ -132,7 +132,7 @@ func GenerateBallot(proposer *node.LocalNode, basis voting.Basis, tx transaction
 	b.SetVote(ballotState, voting.YES)
 	b.Sign(sender.Keypair(), networkID)
 
-	if err := b.IsWellFormed(networkID, conf); err != nil {
+	if err := b.IsWellFormed(conf); err != nil {
 		panic(err)
 	}
 
@@ -152,7 +152,7 @@ func GenerateEmptyTxBallot(proposer *node.LocalNode, basis voting.Basis, ballotS
 	b.SetVote(ballotState, voting.YES)
 	b.Sign(sender.Keypair(), networkID)
 
-	if err := b.IsWellFormed(networkID, conf); err != nil {
+	if err := b.IsWellFormed(conf); err != nil {
 		panic(err)
 	}
 
@@ -195,7 +195,7 @@ func createNodeRunnerForTesting(n int, conf common.Config, recv chan struct{}) (
 	)
 
 	st := block.InitTestBlockchain()
-	is, _ := consensus.NewISAAC(networkID, localNode, policy, connectionManager, st, common.NewConfig(), nil)
+	is, _ := consensus.NewISAAC(networkID, localNode, policy, connectionManager, st, common.NewTestConfig(), nil)
 	is.SetProposerSelector(FixedSelector{localNode.Address()})
 
 	nr, err := NewNodeRunner(string(networkID), localNode, policy, ns[0], is, st, conf)
@@ -223,7 +223,7 @@ func MakeConsensusAndBlock(t *testing.T, tx transaction.Transaction, nr *NodeRun
 		TotalTxs:  b.TotalTxs,
 	}
 
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 
 	// Check that the transaction is in RunningRounds
 

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestNewConfig(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := storage.NewTestStorage()
 	_, nt, _ := network.CreateMemoryNetwork(nil)
 	cm := &mockConnectionManager{}
@@ -22,9 +23,8 @@ func TestNewConfig(t *testing.T) {
 	require.Equal(t, nil, err)
 
 	node, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
-	networkID := []byte("test-network")
 
-	cfg := NewConfig(networkID, node, st, nt, cm, common.NewConfig())
+	cfg := NewConfig(conf.NetworkID, node, st, nt, cm, conf)
 	cfg.SyncPoolSize = 100
 	cfg.logger = common.NopLogger()
 

--- a/lib/sync/syncer_test.go
+++ b/lib/sync/syncer_test.go
@@ -68,16 +68,16 @@ func TestSyncerSetSyncTarget(t *testing.T) {
 }
 
 func SyncerTest(t *testing.T, fn func(*SyncerTestContext)) {
+	conf := common.NewTestConfig()
 	st := block.InitTestBlockchain()
 	defer st.Close()
 	_, nw, localNode := network.CreateMemoryNetwork(nil)
 	cm := &mockConnectionManager{}
-	networkID := []byte("test-network")
 
 	tickc := make(chan time.Time)
 	infoc := make(chan *SyncInfo)
 
-	syncer := NewSyncer(st, nw, cm, networkID, localNode, common.NewConfig())
+	syncer := NewSyncer(st, nw, cm, conf.NetworkID, localNode, conf)
 	defer syncer.Stop()
 
 	syncer.fetcher = &mockFetcher{

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -179,7 +179,7 @@ func (v *BlockValidator) validateBlock(ctx context.Context, si *SyncInfo, prevBl
 func (v *BlockValidator) validateTxs(ctx context.Context, si *SyncInfo) error {
 	// proposer transaction
 	if si.Ptx != nil {
-		if err := si.Ptx.IsWellFormed(v.networkID, v.commonCfg); err != nil {
+		if err := si.Ptx.IsWellFormed(v.commonCfg); err != nil {
 			return err
 		}
 	}
@@ -191,7 +191,7 @@ func (v *BlockValidator) validateTxs(ctx context.Context, si *SyncInfo) error {
 			return err
 		}
 
-		if err := tx.IsWellFormed(v.networkID, v.commonCfg); err != nil {
+		if err := tx.IsWellFormed(v.commonCfg); err != nil {
 			return err
 		}
 

--- a/lib/sync/validator_test.go
+++ b/lib/sync/validator_test.go
@@ -11,13 +11,12 @@ import (
 )
 
 func TestValidator(t *testing.T) {
+	conf := common.NewTestConfig()
 	st := block.InitTestBlockchain()
 	defer st.Close()
-
-	networkID := []byte("test-network")
 	_, nw, _ := network.CreateMemoryNetwork(nil)
 
-	v := NewBlockValidator(nw, st, networkID, common.NewConfig())
+	v := NewBlockValidator(nw, st, conf.NetworkID, conf)
 
 	ctx := context.Background()
 

--- a/lib/transaction/operation/create_account_test.go
+++ b/lib/transaction/operation/create_account_test.go
@@ -13,7 +13,7 @@ import (
 func TestCreateAccountOperation(t *testing.T) {
 	kp := keypair.Random()
 
-	conf := common.NewConfig()
+	conf := common.NewTestConfig()
 	{ // minimum Amount
 		o := CreateAccount{
 			Target: kp.Address(),

--- a/lib/transaction/operation/operation_test.go
+++ b/lib/transaction/operation/operation_test.go
@@ -29,7 +29,7 @@ func TestMakeHashOfOperationBodyPayment(t *testing.T) {
 
 func TestIsWellFormedOperation(t *testing.T) {
 	op := MakeTestPayment(-1)
-	err := op.IsWellFormed(common.NewConfig())
+	err := op.IsWellFormed(common.NewTestConfig())
 	require.NoError(t, err)
 }
 
@@ -39,7 +39,7 @@ func TestIsWellFormedOperationLowerAmount(t *testing.T) {
 		Target: kp.Address(),
 		Amount: common.Amount(0),
 	}
-	err := obp.IsWellFormed(common.NewConfig())
+	err := obp.IsWellFormed(common.NewTestConfig())
 	require.Error(t, err)
 }
 
@@ -65,7 +65,7 @@ func TestOperationBodyCongressVoting(t *testing.T) {
 	expected := "4CcZvkNYQUgvdmjGDuMx7tesCdRp3HU4CW3pbRxeqtEZ"
 	require.Equal(t, hashed, expected)
 
-	err := op.IsWellFormed(common.NewConfig())
+	err := op.IsWellFormed(common.NewTestConfig())
 	require.NoError(t, err)
 
 }
@@ -87,7 +87,7 @@ func TestOperationBodyCongressVotingResult(t *testing.T) {
 	expected := "8DgD3heMuNLYhnNBgPSBEquAdKXuogrSybdqt7WD87CV"
 	require.Equal(t, hashed, expected)
 
-	err := op.IsWellFormed(common.NewConfig())
+	err := op.IsWellFormed(common.NewTestConfig())
 	require.NoError(t, err)
 
 }

--- a/lib/transaction/transaction.go
+++ b/lib/transaction/transaction.go
@@ -105,12 +105,12 @@ var TransactionWellFormedCheckerFuncs = []common.CheckerFunc{
 	CheckVerifySignature,
 }
 
-func (tx Transaction) IsWellFormed(networkID []byte, conf common.Config) (err error) {
+func (tx Transaction) IsWellFormed(conf common.Config) (err error) {
 	// TODO check `Version` format with SemVer
 
 	checker := &Checker{
 		DefaultChecker: common.DefaultChecker{Funcs: TransactionWellFormedCheckerFuncs},
-		NetworkID:      networkID,
+		NetworkID:      conf.NetworkID,
 		Transaction:    tx,
 		Conf:           conf,
 	}


### PR DESCRIPTION
There are still many `NetworkID` stored around the place which we could remove,
but I figured the diff was already big enough, so I'll make a follow-up PR.