### PR TITLE
fix expiring in saving tx

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -51,6 +51,7 @@ var (
 	flagSyncRetryInterval string = common.GetENVValue("SEBAK_SYNC_RETRY_INTERVAL", "10s")
 	flagThreshold         string = common.GetENVValue("SEBAK_THRESHOLD", "67")
 	flagTimeoutACCEPT     string = common.GetENVValue("SEBAK_TIMEOUT_ACCEPT", "2")
+	flagTimeoutALLCONFIRM string = common.GetENVValue("SEBAK_TIMEOUT_ALLCONFIRM", "30")
 	flagTimeoutINIT       string = common.GetENVValue("SEBAK_TIMEOUT_INIT", "2")
 	flagTimeoutSIGN       string = common.GetENVValue("SEBAK_TIMEOUT_SIGN", "2")
 	flagTLSCertFile       string = common.GetENVValue("SEBAK_TLS_CERT", "sebak.crt")
@@ -83,6 +84,7 @@ var (
 	syncRetryInterval time.Duration
 	threshold         int
 	timeoutACCEPT     time.Duration
+	timeoutALLCONFIRM time.Duration
 	timeoutINIT       time.Duration
 	timeoutSIGN       time.Duration
 	transactionsLimit uint64
@@ -158,6 +160,7 @@ func init() {
 	nodeCmd.Flags().StringVar(&flagTimeoutINIT, "timeout-init", flagTimeoutINIT, "timeout of the init state")
 	nodeCmd.Flags().StringVar(&flagTimeoutSIGN, "timeout-sign", flagTimeoutSIGN, "timeout of the sign state")
 	nodeCmd.Flags().StringVar(&flagTimeoutACCEPT, "timeout-accept", flagTimeoutACCEPT, "timeout of the accept state")
+	nodeCmd.Flags().StringVar(&flagTimeoutALLCONFIRM, "timeout-allconfirm", flagTimeoutALLCONFIRM, "timeout of the allconfirm state")
 	nodeCmd.Flags().StringVar(&flagBlockTime, "block-time", flagBlockTime, "block creation time")
 	nodeCmd.Flags().StringVar(&flagTransactionsLimit, "transactions-limit", flagTransactionsLimit, "transactions limit in a ballot")
 	nodeCmd.Flags().StringVar(&flagUnfreezingPeriod, "unfreezing-period", flagUnfreezingPeriod, "how long freezing must last")
@@ -317,6 +320,7 @@ func parseFlagsNode() {
 	timeoutINIT = getTime(flagTimeoutINIT, 2*time.Second, "--timeout-init")
 	timeoutSIGN = getTime(flagTimeoutSIGN, 2*time.Second, "--timeout-sign")
 	timeoutACCEPT = getTime(flagTimeoutACCEPT, 2*time.Second, "--timeout-accept")
+	timeoutALLCONFIRM = getTime(flagTimeoutALLCONFIRM, 30*time.Second, "--timeout-accept")
 	blockTime = getTime(flagBlockTime, 5*time.Second, "--block-time")
 
 	if transactionsLimit, err = strconv.ParseUint(flagTransactionsLimit, 10, 64); err != nil {
@@ -420,6 +424,7 @@ func parseFlagsNode() {
 	parsedFlags = append(parsedFlags, "\n\ttimeout-init", flagTimeoutINIT)
 	parsedFlags = append(parsedFlags, "\n\ttimeout-sign", flagTimeoutSIGN)
 	parsedFlags = append(parsedFlags, "\n\ttimeout-accept", flagTimeoutACCEPT)
+	parsedFlags = append(parsedFlags, "\n\ttimeout-allconfirm", flagTimeoutALLCONFIRM)
 	parsedFlags = append(parsedFlags, "\n\tblock-time", flagBlockTime)
 	parsedFlags = append(parsedFlags, "\n\ttransactions-limit", flagTransactionsLimit)
 	parsedFlags = append(parsedFlags, "\n\toperations-limit", flagOperationsLimit)
@@ -505,6 +510,7 @@ func runNode() error {
 		TimeoutINIT:       timeoutINIT,
 		TimeoutSIGN:       timeoutSIGN,
 		TimeoutACCEPT:     timeoutACCEPT,
+		TimeoutALLCONFIRM: timeoutALLCONFIRM,
 		NetworkID:         []byte(flagNetworkID),
 		BlockTime:         blockTime,
 		TxsLimit:          int(transactionsLimit),

--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -10,10 +10,11 @@ import (
 // these timeout features are used in ISAAC consensus.
 //
 type Config struct {
-	TimeoutINIT   time.Duration
-	TimeoutSIGN   time.Duration
-	TimeoutACCEPT time.Duration
-	BlockTime     time.Duration
+	TimeoutINIT       time.Duration
+	TimeoutSIGN       time.Duration
+	TimeoutACCEPT     time.Duration
+	TimeoutALLCONFIRM time.Duration
+	BlockTime         time.Duration
 
 	TxsLimit int
 	OpsLimit int
@@ -31,6 +32,7 @@ func NewConfig(networkID []byte) Config {
 	p.TimeoutINIT = 2 * time.Second
 	p.TimeoutSIGN = 2 * time.Second
 	p.TimeoutACCEPT = 2 * time.Second
+	p.TimeoutALLCONFIRM = 30 * time.Second
 	p.BlockTime = 5 * time.Second
 
 	p.TxsLimit = 1000

--- a/lib/common/config_test.go
+++ b/lib/common/config_test.go
@@ -16,6 +16,7 @@ func TestConfigDefault(t *testing.T) {
 	require.Equal(t, 2*time.Second, n.TimeoutINIT)
 	require.Equal(t, 2*time.Second, n.TimeoutSIGN)
 	require.Equal(t, 2*time.Second, n.TimeoutACCEPT)
+	require.Equal(t, 30*time.Second, n.TimeoutALLCONFIRM)
 	require.Equal(t, 5*time.Second, n.BlockTime)
 
 	require.Equal(t, 1000, n.TxsLimit)
@@ -28,6 +29,7 @@ func TestConfigSetAndGet(t *testing.T) {
 	n.TimeoutINIT = 3 * time.Second
 	n.TimeoutSIGN = 1 * time.Second
 	n.TimeoutACCEPT = 1 * time.Second
+	n.TimeoutALLCONFIRM = 10 * time.Second
 	n.BlockTime = 7 * time.Second
 
 	n.TxsLimit = 500
@@ -36,6 +38,7 @@ func TestConfigSetAndGet(t *testing.T) {
 	require.Equal(t, 3*time.Second, n.TimeoutINIT)
 	require.Equal(t, 1*time.Second, n.TimeoutSIGN)
 	require.Equal(t, 1*time.Second, n.TimeoutACCEPT)
+	require.Equal(t, 10*time.Second, n.TimeoutALLCONFIRM)
 	require.Equal(t, 7*time.Second, n.BlockTime)
 
 	require.Equal(t, 500, n.TxsLimit)

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -565,14 +565,14 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 	}
 
 	basis := checker.Ballot.VotingBasis()
-
 	var err error
 	switch checker.FinishedVotingHole {
 	case voting.YES:
+		checker.NodeRunner.TransitISAACState(basis, ballot.StateALLCONFIRM)
+		defer checker.NodeRunner.NextHeight()
 		if err = saveBlock(checker); err != nil {
 			return err
 		}
-		checker.NodeRunner.TransitISAACState(basis, ballot.StateALLCONFIRM)
 		checker.NodeRunner.Consensus().SetLatestVotingBasis(basis)
 
 		reorganizeTransactionPool(checker)

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -580,7 +580,7 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 
 		err = NewCheckerStopCloseConsensus(checker, "ballot got consensus and will be stored")
 	case voting.NO, voting.EXP:
-		checker.NodeRunner.isaacStateManager.IncreaseRound()
+		checker.NodeRunner.isaacStateManager.NextRound()
 		checker.NodeRunner.Consensus().SetLatestVotingBasis(basis)
 
 		checker.NodeRunner.Consensus().RemoveRunningRoundsWithSameHeight(basis.Height)

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -153,9 +153,9 @@ func (sm *ISAACStateManager) TransitISAACState(height uint64, round uint64, ball
 	}
 }
 
-func (sm *ISAACStateManager) IncreaseRound() {
+func (sm *ISAACStateManager) NextRound() {
 	state := sm.State()
-	sm.nr.Log().Debug("begin ISAACStateManager.IncreaseRound()", "height", state.Height, "round", state.Round, "state", state.BallotState)
+	sm.nr.Log().Debug("begin ISAACStateManager.NextRound()", "height", state.Height, "round", state.Round, "state", state.BallotState)
 	sm.TransitISAACState(state.Height, state.Round+1, ballot.StateINIT)
 }
 
@@ -179,7 +179,7 @@ func (sm *ISAACStateManager) Start() {
 				sm.nr.Log().Debug("timeout", "ISAACState", sm.State())
 				if sm.State().BallotState == ballot.StateACCEPT {
 					sm.SetBlockTimeBuffer()
-					sm.IncreaseRound()
+					sm.NextRound()
 					break
 				}
 				go sm.broadcastExpiredBallot(sm.State())

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -209,9 +209,9 @@ func (sm *ISAACStateManager) Start() {
 					sm.transitSignal(state)
 					timer.Reset(sm.Conf.TimeoutACCEPT)
 				case ballot.StateALLCONFIRM:
-					timer.Reset(time.Minute)
 					sm.setState(state)
 					sm.transitSignal(state)
+					timer.Reset(sm.Conf.TimeoutALLCONFIRM)
 				}
 
 			case <-sm.stop:
@@ -257,6 +257,8 @@ func (sm *ISAACStateManager) resetTimer(timer *time.Timer, state ballot.State) {
 		timer.Reset(sm.Conf.TimeoutSIGN)
 	case ballot.StateACCEPT:
 		timer.Reset(sm.Conf.TimeoutACCEPT)
+	case ballot.StateALLCONFIRM:
+		timer.Reset(sm.Conf.TimeoutALLCONFIRM)
 	}
 }
 

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -65,8 +65,8 @@ func (sm *ISAACStateManager) setTheFirstConsensusBlockTime() {
 	sm.nr.Log().Debug("set first consnsus block time", "time", sm.firstConsensusBlockTime)
 }
 
-func (sm *ISAACStateManager) SetBlockTimeBuffer() {
-	sm.nr.Log().Debug("begin ISAACStateManager.SetBlockTimeBuffer()", "ISAACState", sm.State())
+func (sm *ISAACStateManager) setBlockTimeBuffer() {
+	sm.nr.Log().Debug("begin ISAACStateManager.setBlockTimeBuffer()", "ISAACState", sm.State())
 	sm.setTheFirstConsensusBlockTime()
 	b := sm.nr.Consensus().LatestBlock()
 
@@ -178,7 +178,7 @@ func (sm *ISAACStateManager) Start() {
 			case <-timer.C:
 				sm.nr.Log().Debug("timeout", "ISAACState", sm.State())
 				if sm.State().BallotState == ballot.StateACCEPT {
-					sm.SetBlockTimeBuffer()
+					sm.setBlockTimeBuffer()
 					sm.NextRound()
 					break
 				}
@@ -202,7 +202,7 @@ func (sm *ISAACStateManager) Start() {
 				case ballot.StateALLCONFIRM:
 					sm.setState(state)
 					sm.transitSignal(state)
-					sm.SetBlockTimeBuffer()
+					sm.setBlockTimeBuffer()
 					sm.NextHeight()
 				}
 

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -143,7 +143,7 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 	nr.isaacStateManager.TransitISAACState(state.Height, state.Round, ballot.StateSIGN)
 
 	<-recv
-	require.Equal(t, ballot.StateACCEPT, nr.isaacStateManager.State().BallotState)
+	require.Equal(t, ballot.StateSIGN, nr.isaacStateManager.State().BallotState)
 	require.Equal(t, 2, len(cm.Messages()))
 
 	init, sign, accept := 0, 0, 0

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -525,6 +525,10 @@ func (nr *NodeRunner) TransitISAACState(basis voting.Basis, ballotState ballot.S
 	nr.isaacStateManager.TransitISAACState(basis.Height, basis.Round, ballotState)
 }
 
+func (nr *NodeRunner) NextHeight() {
+	nr.isaacStateManager.NextHeight()
+}
+
 var NewBallotTransactionCheckerFuncs = []common.CheckerFunc{
 	IsNew,
 	BallotTransactionsSameSource,


### PR DESCRIPTION
Fixes #637

Make the node save block in ALLCONFIRM

If there are too many transactions in a ballot,
ballot is expired after saving block.
Because state transition is called after saving transactions.
Confirming process is,
1. ACCEPT ballot exceeded
1. save block
1. save transaction
1. state transit to ALLCONFIRM
1. state transit to INIT

If there are many transactions, a timeout might occur while
saving them.

Therefore, I've modified it to this process
1. ACCEPT ballot exceeded
1. state transit to ALLCONFIRM
1. save block
1. save transaction
1. state transit to INIT

And there is 1 minute timeout in ALLCONFIRM. It's because of exceptional
case.

Please review each commit sequentially :)