### PR TITLE
Change metric_path to /metrics

### DIFF
--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -22,7 +22,7 @@ type Handlers map[string]func(http.ResponseWriter, *http.Request)
 const (
 	RouterNameNode   = "node"
 	RouterNameAPI    = "api"
-	RouterNameMetric = "metric"
+	RouterNameMetric = "metrics"
 	RouterNameDebug  = "debug"
 )
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background
- https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
```
# The HTTP resource path on which to fetch metrics from targets.
[ metrics_path: <path> | default = /metrics ]
```

### Solution

Change to `/metric` to `/metrics`


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

