### PR TITLE
Follow design when timeout in IsaacStateManager

### DIFF
--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -191,6 +191,8 @@ func BallotCheckSYNC(c common.Checker, args ...interface{}) error {
 		return err
 	}
 
+	checker.NodeRunner.PauseIsaacStateManager()
+
 	defer func() {
 		if b.VotingBasis().Height == syncHeight {
 			is.LatestBallot = b

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -20,6 +20,7 @@ type ISAACStateManager struct {
 	state                   consensus.ISAACState
 	stateTransit            chan consensus.ISAACState
 	stop                    chan struct{}
+	pause                   chan struct{}
 	blockTimeBuffer         time.Duration              // the time to wait to adjust the block creation time.
 	transitSignal           func(consensus.ISAACState) // the function is called when the ISAACState is changed.
 	firstConsensusBlockTime time.Time                  // the time at which the first consensus block was saved(height 2). It is used for calculating `blockTimeBuffer`.
@@ -37,6 +38,7 @@ func NewISAACStateManager(nr *NodeRunner, conf common.Config) *ISAACStateManager
 		},
 		stateTransit:    make(chan consensus.ISAACState),
 		stop:            make(chan struct{}),
+		pause:           make(chan struct{}),
 		blockTimeBuffer: 2 * time.Second,
 		transitSignal:   func(consensus.ISAACState) {},
 		Conf:            conf,
@@ -214,6 +216,10 @@ func (sm *ISAACStateManager) Start() {
 					timer.Reset(sm.Conf.TimeoutALLCONFIRM)
 				}
 
+			case <-sm.pause:
+				sm.nr.Log().Debug("pause ISAACStateManager")
+				timer.Reset(time.Duration(1 * time.Hour))
+
 			case <-sm.stop:
 				return
 			}
@@ -307,6 +313,12 @@ func (sm *ISAACStateManager) setBallotState(ballotState ballot.State) {
 	sm.state.BallotState = ballotState
 
 	return
+}
+
+func (sm *ISAACStateManager) Pause() {
+	go func() {
+		sm.pause <- struct{}{}
+	}()
 }
 
 func (sm *ISAACStateManager) Stop() {

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -537,6 +537,10 @@ func (nr *NodeRunner) NextHeight() {
 	nr.isaacStateManager.NextHeight()
 }
 
+func (nr *NodeRunner) PauseIsaacStateManager() {
+	nr.isaacStateManager.Pause()
+}
+
 var NewBallotTransactionCheckerFuncs = []common.CheckerFunc{
 	IsNew,
 	BallotTransactionsSameSource,

--- a/tests/long-term/run.sh
+++ b/tests/long-term/run.sh
@@ -39,13 +39,13 @@ fi
 # because the reports are written on program's exit, which also means container's shutdown
 # Also SUPER IMPORTANT: the `-test` args need to be before any other args, or they are simply ignored...
 export NODE1=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node1.env \
-                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON})
+                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON} --log-level=debug)
 export NODE2=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node2.env \
-                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON})
+                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON} --log-level=debug)
 export NODE3=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node3.env \
-                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON})
+                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON} --log-level=debug)
 export NODE4=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node4.env \
-                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON})
+                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON} --log-level=debug)
 
 CONTAINERS="${CONTAINERS} ${NODE1} ${NODE2} ${NODE3} ${NODE4}"
 
@@ -59,7 +59,7 @@ docker stop ${NODE4}
 docker rm -f ${NODE4}
 
 export NODE4_2=$(docker run -d --network host --env-file=${ROOT_DIR}/docker/node4.env \
-                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON})
+                        ${NODE_IMAGE} node --genesis=${SEBAK_GENESIS},${SEBAK_COMMON} --log-level=debug)
 
 CONTAINERS="${CONTAINERS} ${NODE4_2}"
 


### PR DESCRIPTION
This is pre commits for #711 

Follow recent design document
1. Timeout in INIT
   * Old: broadcast B(INIT, EXP) -> transit to SIGN
   * New: transit to SIGN
1. Timeout in SIGN
   * Old: broadcast B(ACCEPT, EXP) -> transit to SIGN
   * New: broadcast B(ACCEPT, EXP) -> transit to ACCEPT

Add pausing when expired twice consecutively because it's sync situation.