### PR TITLE
Support CIDR in rate-limit

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -218,9 +218,11 @@ func parseFlagRateLimit(l cmdcommon.ListFlags, defaultRate limiter.Rate) (rule c
 		}
 
 		if len(ip) > 0 {
-			if net.ParseIP(ip) == nil {
-				err = fmt.Errorf("invalid ip address")
-				return
+			if _, _, err = net.ParseCIDR(ip); err != nil {
+				if net.ParseIP(ip) == nil {
+					err = fmt.Errorf("invalid ip or cirdr address")
+					return
+				}
 			}
 		}
 

--- a/lib/network/http_middlewares.go
+++ b/lib/network/http_middlewares.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"fmt"
+	"net"
 	"net/http"
 	"runtime/debug"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/hashicorp/golang-lru"
 	logging "github.com/inconshreveable/log15"
 	"github.com/ulule/limiter"
 	"github.com/ulule/limiter/drivers/middleware/stdlib"
@@ -75,7 +77,9 @@ func RateLimitMiddleware(logger logging.Logger, rule common.RateLimitRule) mux.M
 		)
 	}
 
-	middlewaresByIP := map[ /* ip address */ string]*stdlib.Middleware{}
+	middlewares := map[string]*stdlib.Middleware{}
+	middlewaresByIP := map[ /* ip address */ string]string{}
+	byCIDRs := map[ /* ip address */ string]*net.IPNet{}
 	for ip, rate := range rule.ByIPAddress {
 		var m *stdlib.Middleware
 		if rate.Limit > 0 {
@@ -86,8 +90,17 @@ func RateLimitMiddleware(logger logging.Logger, rule common.RateLimitRule) mux.M
 				stdlib.WithLimitReachedHandler(rateLimitReachedHandler),
 			)
 		}
-		middlewaresByIP[ip] = m
+
+		key := common.GetUniqueIDFromUUID()
+		middlewares[key] = m
+		middlewaresByIP[ip] = key
+
+		if _, ipnet, err := net.ParseCIDR(ip); err == nil {
+			byCIDRs[ip] = ipnet
+		}
 	}
+
+	middlewareCache, _ := lru.New(40000)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -105,13 +118,27 @@ func RateLimitMiddleware(logger logging.Logger, rule common.RateLimitRule) mux.M
 
 			var middleware *stdlib.Middleware
 
-			if len(middlewaresByIP) < 1 {
-				middleware = defaultMiddleware
-			} else { // find middleware by ip
-				var found bool
-				if middleware, found = middlewaresByIP[ip]; !found {
-					middleware = defaultMiddleware
+			if key, ok := middlewareCache.Get(ip); ok {
+				middleware = middlewares[key.(string)]
+			} else if len(middlewaresByIP) > 0 {
+				if key, found := middlewaresByIP[ip]; found {
+					middleware = middlewares[key]
+					middlewareCache.Add(ip, key)
+				} else if pip := net.ParseIP(ip); pip != nil {
+					for inip, ipnet := range byCIDRs {
+						if !ipnet.Contains(pip) {
+							continue
+						}
+						key := middlewaresByIP[inip]
+						middleware = middlewares[key]
+						middlewareCache.Add(ip, key)
+						break
+					}
 				}
+			}
+
+			if middleware == nil {
+				middleware = defaultMiddleware
 			}
 
 			if middleware == nil {

--- a/lib/network/http_middlewares.go
+++ b/lib/network/http_middlewares.go
@@ -100,7 +100,7 @@ func RateLimitMiddleware(logger logging.Logger, rule common.RateLimitRule) mux.M
 		}
 	}
 
-	middlewareCache, _ := lru.New(40000)
+	middlewareCache, _ := lru.New(10000000)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### Background

Simply to say, currently rate limit supports the rule by ip address. This patch will be able to by cidr, ip address range. The current testnet env does not indicate the exact ip address to angelbot, it can just provide ip range. 