### PR TITLE
Failed to save `BlockOperation`

### DIFF
--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -190,19 +190,36 @@ func (bt *BlockTransaction) SaveBlockOperations(st *storage.LevelDBBackend) (err
 	}
 
 	for _, op := range bt.Transaction().B.Operations {
-		var bo BlockOperation
-		bo, err = NewBlockOperationFromOperation(op, bt.Transaction(), bt.blockHeight)
+		if err = bt.SaveBlockOperation(st, op); err != nil {
+			return
+		}
+	}
+
+	return nil
+}
+
+func (bt *BlockTransaction) SaveBlockOperation(st *storage.LevelDBBackend, op operation.Operation) (err error) {
+	if bt.blockHeight < 1 {
+		var blk Block
+		if blk, err = GetBlock(st, bt.Block); err != nil {
+			return
+		} else {
+			bt.blockHeight = blk.Height
+		}
+	}
+
+	var bo BlockOperation
+	bo, err = NewBlockOperationFromOperation(op, bt.Transaction(), bt.blockHeight)
+	if err != nil {
+		return
+	}
+	if err = bo.Save(st); err != nil {
+		return
+	}
+	if pop, ok := op.B.(operation.Payable); ok {
+		err = st.New(bt.NewBlockTransactionKeyByAccount(pop.TargetAddress()), bt.Hash)
 		if err != nil {
 			return
-		}
-		if err = bo.Save(st); err != nil {
-			return
-		}
-		if pop, ok := op.B.(operation.Payable); ok {
-			err = st.New(bt.NewBlockTransactionKeyByAccount(pop.TargetAddress()), bt.Hash)
-			if err != nil {
-				return
-			}
 		}
 	}
 

--- a/lib/node/runner/block_operations.go
+++ b/lib/node/runner/block_operations.go
@@ -119,13 +119,13 @@ func (sb *SavingBlockOperations) CheckByBlock(st *storage.LevelDBBackend, blk bl
 		return
 	}
 
-	txs := make(chan string)
-	errChan := make(chan error)
+	txs := make(chan string, 100)
+	errChan := make(chan error, 100)
 	defer close(errChan)
 
 	numWorker := int(len(blk.Transactions) / 2)
-	if numWorker > 10 {
-		numWorker = 10
+	if numWorker > 100 {
+		numWorker = 100
 	} else if numWorker < 1 {
 		numWorker = 1
 	}

--- a/lib/node/runner/block_operations_test.go
+++ b/lib/node/runner/block_operations_test.go
@@ -32,7 +32,7 @@ func (p *TestSavingBlockOperationHelper) makeBlock(prevBlock block.Block, numTxs
 	var txs []transaction.Transaction
 	var txHashes []string
 	for i := 0; i < numTxs; i++ {
-		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+		tx := transaction.TestMakeTransactionWithKeypair(networkID, 100, kp)
 		block.SaveTransactionPool(p.st, tx)
 		txs = append(txs, tx)
 		txHashes = append(txHashes, tx.GetHash())


### PR DESCRIPTION
### Background
Currently to save operations the several goroutines are used and transactions are injected by channel. The problem is the number of transaction is over channel buffer, the saving process is stuck.

### Solution

The part of inserting transaction set inside goroutine and fixed the other bugs to save `BlockOperation`.