### PR TITLE
Move setting sync to consensus to saveBlock method

### DIFF
--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -245,8 +245,6 @@ func BallotCheckSYNC(c common.Checker, args ...interface{}) error {
 		}
 		checker.NodeRunner.SavingBlockOperations().Save(*blk)
 
-		checker.NodeRunner.Log().Debug("node state transits to consensus", "height", checker.Ballot.VotingBasis().Height)
-		checker.LocalNode.SetConsensus()
 		checker.NodeRunner.NextHeight()
 		return nil
 	} else {
@@ -635,6 +633,10 @@ func saveBlock(checker *BallotChecker) error {
 	}
 
 	checker.Log.Debug("ballot was stored", "block", *theBlock)
+	if checker.LocalNode.State() != node.StateCONSENSUS {
+		checker.NodeRunner.Log().Debug("node state transits sync to consensus", "height", checker.Ballot.VotingBasis().Height)
+		checker.LocalNode.SetConsensus()
+	}
 
 	for _, tx := range proposedTransactions {
 		checker.LatestBlockSources = append(checker.LatestBlockSources, tx.B.Source)


### PR DESCRIPTION
If a nodes stores two blocks in sync, the state is switched to consensus,
but sometimes this logic isn't performed because it could follow the height directly in StartSync.
