### PR TITLE
Fix wrong state transit order

### DIFF
--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -313,7 +313,7 @@ func (sm *ISAACStateManager) setState(state consensus.ISAACState) {
 func (sm *ISAACStateManager) setBallotState(ballotState ballot.State) {
 	sm.Lock()
 	defer sm.Unlock()
-	sm.nr.Log().Debug("begin ISAACStateManager.setBallotState()", "ballotState", ballotState)
+	sm.nr.Log().Debug("begin ISAACStateManager.setBallotState()", "state", sm.state)
 	sm.state.BallotState = ballotState
 
 	return

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -163,9 +163,9 @@ func (sm *ISAACStateManager) TransitISAACState(height uint64, round uint64, ball
 			"current", current,
 			"target", target,
 		)
-		go func() {
-			sm.stateTransit <- target
-		}()
+		go func(t consensus.ISAACState) {
+			sm.stateTransit <- t
+		}(target)
 	}
 }
 
@@ -211,6 +211,11 @@ func (sm *ISAACStateManager) Start() {
 				}
 
 			case state := <-sm.stateTransit:
+				current := sm.State()
+				if !current.IsLater(state) {
+					sm.nr.Log().Debug("break; target is before than or equal to current", "current", current, "target", state)
+					break
+				}
 				if state.BallotState == ballot.StateINIT {
 					sm.proposeOrWait(timer, state)
 				} else {


### PR DESCRIPTION
### Background
Sometimes state transit order is wrong because caller is goroutine closer.
```
msg="target is later than current" current="{Height:12 Round:0 BallotState:ACCEPT}" target="{Height:12 Round:0 BallotState:ALLCONFIRM}"
msg="target is later than current" current="{Height:12 Round:0 BallotState:ACCEPT}" target="{Height:13 Round:0 BallotState:INIT}"
msg="begin ISAACStateManager.setState()" state="{Height:13 Round:0 BallotState:INIT}"
msg="begin ISAACStateManager.setState()" state="{Height:12 Round:0 BallotState:ALLCONFIRM}"
```

### Solution
1. We should double check transit order
1. Modified "closer" to explicitly handle the "target" variable as an argument