### PR TITLE
Skip broadcasting self-signed Ballot

### DIFF
--- a/lib/ballot/ballot.go
+++ b/lib/ballot/ballot.go
@@ -51,6 +51,10 @@ func NewBallotFromJSON(data []byte) (b Ballot, err error) {
 	return
 }
 
+func (b Ballot) IsEmpty() bool {
+	return len(b.H.Hash) < 1
+}
+
 func (b Ballot) GetType() common.MessageType {
 	return common.BallotMessage
 }

--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -66,6 +66,9 @@ func NewISAAC(node *node.LocalNode, p voting.ThresholdPolicy,
 }
 
 func (is *ISAAC) SetLatestVotingBasis(basis voting.Basis) {
+	is.Lock()
+	defer is.Unlock()
+
 	is.LatestVotingBasis = basis
 }
 
@@ -82,10 +85,16 @@ func (is *ISAAC) SelectProposer(blockHeight uint64, round uint64) string {
 }
 
 func (is *ISAAC) SaveNodeHeight(senderAddr string, height uint64) {
+	is.Lock()
+	defer is.Unlock()
+
 	is.nodesHeight[senderAddr] = height
 }
 
 func (is *ISAAC) IsValidVotingBasis(basis voting.Basis, latestBlock block.Block) bool {
+	is.RLock()
+	defer is.RUnlock()
+
 	if basis.Height == latestBlock.Height {
 		if is.isInitRound(basis) {
 			return true
@@ -169,8 +178,8 @@ func (is *ISAAC) IsVoted(b ballot.Ballot) bool {
 }
 
 func (is *ISAAC) Vote(b ballot.Ballot) (isNew bool, err error) {
-	is.RLock()
-	defer is.RUnlock()
+	is.Lock()
+	defer is.Unlock()
 	basisIndex := b.VotingBasis().Index()
 
 	var found bool

--- a/lib/network/validator_connection_manager.go
+++ b/lib/network/validator_connection_manager.go
@@ -196,6 +196,10 @@ func (c *ValidatorConnectionManager) Broadcast(message common.Message) {
 	c.RLock()
 	defer c.RUnlock()
 	for addr, connected := range c.connected {
+		if c.validators[addr].Address() == c.localNode.Address() {
+			continue
+		}
+
 		if connected {
 			go func(v *node.Validator) {
 				client := c.GetConnection(v.Address())

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -42,6 +42,7 @@ func (p *ballotCheckerProposedTransaction) Prepare() {
 
 	p.proposerNode = localNodes[1]
 	nr.Consensus().SetProposerSelector(FixedSelector{p.proposerNode.Address()})
+	go p.nr.startBroadcastBallot()
 
 	p.keys = map[string]*keypair.Full{}
 }

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -46,6 +46,7 @@ type BallotChecker struct {
 	LocalNode          *node.LocalNode
 	Message            common.NetworkMessage
 	IsNew              bool
+	IsMine             bool
 	Ballot             ballot.Ballot
 	VotingHole         voting.Hole
 	Result             consensus.RoundVoteResult
@@ -59,17 +60,22 @@ type BallotChecker struct {
 // BallotUnmarshal makes `Ballot` from common.NetworkMessage.
 func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
+	if checker.Ballot.IsEmpty() {
+		var b ballot.Ballot
+		if b, err = ballot.NewBallotFromJSON(checker.Message.Data); err != nil {
+			return
+		}
 
-	var b ballot.Ballot
-	if b, err = ballot.NewBallotFromJSON(checker.Message.Data); err != nil {
-		return
+		if err = b.IsWellFormed(checker.NodeRunner.Conf); err != nil {
+			return
+		}
+
+		checker.Log.Debug("message is verified")
+		checker.Ballot = b
 	}
 
-	if err = b.IsWellFormed(checker.NodeRunner.Conf); err != nil {
-		return
-	}
+	checker.IsMine = checker.Ballot.Source() == checker.LocalNode.Address()
 
-	checker.Ballot = b
 	checker.Log = checker.Log.New(logging.Ctx{
 		"ballot":      checker.Ballot.GetHash(),
 		"state":       checker.Ballot.State(),
@@ -77,8 +83,8 @@ func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 		"votingBasis": checker.Ballot.VotingBasis(),
 		"from":        checker.Ballot.Source(),
 		"vote":        checker.Ballot.Vote(),
+		"isMine":      checker.IsMine,
 	})
-	checker.Log.Debug("message is verified")
 
 	return
 }
@@ -87,6 +93,10 @@ func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 // `CollectTxFee`.
 func BallotValidateOperationBodyCollectTxFee(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
+
+	if checker.IsMine {
+		return
+	}
 
 	var opb operation.CollectTxFee
 	if opb, err = checker.Ballot.ProposerTransaction().CollectTxFee(); err != nil {
@@ -105,6 +115,10 @@ func BallotValidateOperationBodyCollectTxFee(c common.Checker, args ...interface
 // BallotValidateOperationBodyInflation validates `Inflation`
 func BallotValidateOperationBodyInflation(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
+
+	if checker.IsMine {
+		return
+	}
 
 	var opb operation.Inflation
 	if opb, err = checker.Ballot.ProposerTransaction().Inflation(); err != nil {
@@ -146,6 +160,10 @@ func BallotValidateOperationBodyInflation(c common.Checker, args ...interface{})
 // is from the known validators.
 func BallotNotFromKnownValidators(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
+	if checker.IsMine {
+		return
+	}
+
 	if checker.LocalNode.HasValidators(checker.Ballot.Source()) {
 		return
 	}
@@ -161,6 +179,11 @@ func BallotNotFromKnownValidators(c common.Checker, args ...interface{}) (err er
 // update the latestblock by referring to the database.
 func BallotCheckSYNC(c common.Checker, args ...interface{}) error {
 	checker := c.(*BallotChecker)
+
+	if checker.IsMine {
+		return nil
+	}
+
 	var err error
 
 	is := checker.NodeRunner.Consensus()
@@ -265,6 +288,11 @@ func hasBallotValidProposer(is *consensus.ISAAC, b ballot.Ballot) bool {
 // valid round.
 func BallotCheckBasis(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
+
+	if checker.IsMine {
+		return
+	}
+
 	blk := block.GetLatestBlock(checker.NodeRunner.Storage())
 	if !checker.NodeRunner.Consensus().IsValidVotingBasis(
 		checker.Ballot.VotingBasis(),
@@ -309,6 +337,10 @@ func BallotVote(c common.Checker, args ...interface{}) (err error) {
 // same proposer with the current `RunningRound`.
 func BallotIsSameProposer(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
+
+	if checker.IsMine {
+		return
+	}
 
 	if checker.VotingHole != voting.NOTYET {
 		return
@@ -447,6 +479,10 @@ func insertMissingTransaction(nr *NodeRunner, ballot ballot.Ballot) (err error) 
 func BallotGetMissingTransaction(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
 
+	if checker.IsMine {
+		return
+	}
+
 	if checker.VotingHole != voting.NOTYET {
 		return
 	}
@@ -472,6 +508,11 @@ var INITBallotTransactionCheckerFuncs = []common.CheckerFunc{
 // transactions of newly added ballot.
 func INITBallotValidateTransactions(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
+
+	if checker.IsMine {
+		checker.VotingHole = voting.YES
+		return
+	}
 
 	if checker.VotingFinished {
 		return
@@ -534,7 +575,7 @@ func SIGNBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 		return
 
 	}
-	checker.NodeRunner.ConnectionManager().Broadcast(newBallot)
+	checker.NodeRunner.BroadcastBallot(newBallot)
 	checker.Log.Debug("ballot will be broadcasted", "newBallot", newBallot)
 
 	return
@@ -566,7 +607,7 @@ func ACCEPTBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 		return
 
 	}
-	checker.NodeRunner.ConnectionManager().Broadcast(newBallot)
+	checker.NodeRunner.BroadcastBallot(newBallot)
 	checker.Log.Debug("ballot will be broadcasted", "newBallot", newBallot)
 
 	return

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -382,7 +382,11 @@ func (p *irregularIncomingBallot) prepare() {
 	p.initialBalance, _ = GetGenesisBalance(p.nr.Storage())
 
 	p.nr.Consensus().SetProposerSelector(FixedSelector{p.nr.Node().Address()})
-	go p.nr.startBroadcastBallot()
+	go p.nr.Start()
+}
+
+func (p *irregularIncomingBallot) done() {
+	p.nr.Stop()
 }
 
 func (p *irregularIncomingBallot) runChecker(blt ballot.Ballot) (checker *BallotChecker, err error) {
@@ -470,6 +474,7 @@ func (p *irregularIncomingBallot) makeBallot(state ballot.State) (blt *ballot.Ba
 func TestRegularIncomingBallots(t *testing.T) {
 	p := &irregularIncomingBallot{}
 	p.prepare()
+	defer p.done()
 
 	cm := p.nr.ConnectionManager().(*TestConnectionManager)
 	require.Equal(t, 0, len(cm.Messages()))
@@ -497,6 +502,7 @@ func TestRegularIncomingBallots(t *testing.T) {
 func TestIrregularIncomingBallots(t *testing.T) {
 	p := &irregularIncomingBallot{}
 	p.prepare()
+	defer p.done()
 
 	cm := p.nr.ConnectionManager().(*TestConnectionManager)
 	require.Equal(t, 0, len(cm.Messages()))

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -382,6 +382,7 @@ func (p *irregularIncomingBallot) prepare() {
 	p.initialBalance, _ = GetGenesisBalance(p.nr.Storage())
 
 	p.nr.Consensus().SetProposerSelector(FixedSelector{p.nr.Node().Address()})
+	go p.nr.startBroadcastBallot()
 }
 
 func (p *irregularIncomingBallot) runChecker(blt ballot.Ballot) (checker *BallotChecker, err error) {
@@ -477,13 +478,16 @@ func TestRegularIncomingBallots(t *testing.T) {
 	blt := p.makeBallot(ballot.StateINIT)
 	_, err := p.runChecker(*blt)
 	require.NoError(t, err)
+
+	<-time.After(time.Millisecond * 100)
+
 	require.Equal(t, 1, len(cm.Messages())) // this check node broadcast the new SIGN ballot
 
 	received := cm.Messages()[0].(ballot.Ballot)
 	require.Equal(t, blt.H.ProposerSignature, received.H.ProposerSignature)
 
 	_, err = p.runChecker(received)
-	require.NoError(t, err)
+	<-time.After(time.Millisecond * 100)
 	require.Equal(t, 1, len(cm.Messages())) // this check node does not broadcast
 }
 
@@ -507,11 +511,13 @@ func TestIrregularIncomingBallots(t *testing.T) {
 
 	_, err := p.runChecker(*signBallot)
 	require.NoError(t, err)
+	<-time.After(time.Millisecond * 100)
 	require.Equal(t, 0, len(cm.Messages()))
 
 	_, err = p.runChecker(*initBallot)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(cm.Messages()))
+	<-time.After(time.Millisecond * 100)
+	require.True(t, len(cm.Messages()) > 0)
 
 	// check the broadcasted ballot is valid `SIGN` ballot
 	received := cm.Messages()[0].(ballot.Ballot)

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -372,7 +372,6 @@ func (nr *NodeRunner) Start() (err error) {
 func (nr *NodeRunner) Stop() {
 	nr.network.Stop()
 	nr.isaacStateManager.Stop()
-	close(nr.ballotBroadcastChannel)
 }
 
 func (nr *NodeRunner) Node() *node.LocalNode {
@@ -671,7 +670,6 @@ func (nr *NodeRunner) proposeNewBallot(round uint64) (ballot.Ballot, error) {
 
 	nr.log.Debug("new ballot created", "ballot", theBallot)
 
-	//nr.ConnectionManager().Broadcast(*theBallot)
 	nr.broadcastBallot(*theBallot)
 
 	return *theBallot, nil

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -10,6 +10,7 @@ package runner
 import (
 	"net/http"
 	"net/http/pprof"
+	"sync"
 	"time"
 
 	ghandlers "github.com/gorilla/handlers"
@@ -67,6 +68,8 @@ var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
 }
 
 type NodeRunner struct {
+	sync.RWMutex
+
 	localNode         *node.LocalNode
 	policy            voting.ThresholdPolicy
 	network           network.Network
@@ -575,6 +578,9 @@ func (nr *NodeRunner) waitForConnectingEnoughNodes() {
 }
 
 func (nr *NodeRunner) startStateManager() {
+	nr.RLock()
+	defer nr.RUnlock()
+
 	// check whether current running rounds exist
 	if len(nr.consensus.RunningRounds) > 0 {
 		return

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -496,9 +496,10 @@ func (nr *NodeRunner) handleBallotMessage(msg interface{}) (err error) {
 	}
 
 	if message, ok := msg.(common.NetworkMessage); ok {
-		nr.log.Debug("got ballot")
+		nr.log.Debug("got ballot(NetworkMessage)")
 		baseChecker.Message = message
 	} else if ball, ok := msg.(ballot.Ballot); ok {
+		nr.log.Debug("got ballot(Ballot)")
 		baseChecker.Ballot = ball
 	} else {
 		nr.log.Debug("weird message found", "message", msg)


### PR DESCRIPTION
### Github Issue

Slightly Related to #595 

### Background
Currently the node will broadcast ballot to the validators, including itself. This patch will skip to broadcast to node itself.

### Solution
This patch will reduce the broadcasting time and consensus time.

Old:
```
Broadcasting Ballot -> HTTP2 `/node/message` -> `NodeRunner.HandleBallot()`
```

New:

```
Broadcasting Ballot -> `NodeRunner.HandleBallot()`
```