### PR TITLE
BlockOperations save with BlockHeight prefix 

### DIFF
--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -171,7 +171,7 @@ func GetBlockOperationKeyPrefixSourceAndType(source string, ty operation.Operati
 }
 
 func GetBlockOperationKeyPrefixBlockHeight(height uint64) string {
-	return fmt.Sprintf("%s%d-", common.BlockOperationPrefixBlockHeight, height)
+	return fmt.Sprintf("%s%s-", common.BlockOperationPrefixBlockHeight, common.EncodeUint64ToByteSlice(height))
 }
 
 func (bo BlockOperation) NewBlockOperationTxHashKey() string {

--- a/lib/common/prefix.go
+++ b/lib/common/prefix.go
@@ -17,6 +17,7 @@ const (
 	BlockOperationPrefixPeers             = string(0x24)
 	BlockOperationPrefixCreateFrozen      = string(0x25)
 	BlockOperationPrefixFrozenLinked      = string(0x26)
+	BlockOperationPrefixBlockHeight       = string(0x27)
 	BlockAccountPrefixAddress             = string(0x30)
 	BlockAccountPrefixCreated             = string(0x31)
 	BlockAccountSequenceIDPrefix          = string(0x32)


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

For  `/blocks/{hash}/operations` API ,  block operations should save an index with block height prefix. 


### Solution

- Add Index (`BlockOperationPrefixBlockHeight`)
- Add `GetBlockOperationsByBlockHeight`

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

