### PR TITLE
Add MaxLimitExceed check

### DIFF
--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -102,5 +102,5 @@ var (
 	InflationPFAmountMissMatched              = NewError(184, "inflation pf amount missmatched")
 	InflationPFFundingAddressMissMatched      = NewError(185, "inflation pf funding address missmatched")
 	CongressAddressMisMatched                 = NewError(186, "congress address mismatched")
-	MaxLimitExceed                            = NewError(187, "max limit exceed")
+	PageQueryLimitMaxExceed                   = NewError(187, "maximum value of limit query parameter exceed")
 )

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -102,4 +102,5 @@ var (
 	InflationPFAmountMissMatched              = NewError(184, "inflation pf amount missmatched")
 	InflationPFFundingAddressMissMatched      = NewError(185, "inflation pf funding address missmatched")
 	CongressAddressMisMatched                 = NewError(186, "congress address mismatched")
+	MaxLimitExceed                            = NewError(187, "max limit exceed")
 )

--- a/lib/node/runner/api/pagequery.go
+++ b/lib/node/runner/api/pagequery.go
@@ -7,11 +7,15 @@ import (
 	"strconv"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/storage"
 )
 
-const DefaultMaxLimit uint64 = 100
+const (
+	DefaultLimit    uint64 = 100
+	DefaultMaxLimit uint64 = 1000
+)
 
 type PageQuery struct {
 	request *http.Request
@@ -23,7 +27,7 @@ type PageQuery struct {
 func NewPageQuery(r *http.Request) (*PageQuery, error) {
 	p := &PageQuery{
 		request: r,
-		limit:   DefaultMaxLimit,
+		limit:   DefaultLimit,
 	}
 	err := p.parseRequest()
 	return p, err
@@ -87,6 +91,10 @@ func (p *PageQuery) parseRequest() error {
 		limit, err := strconv.ParseUint(l, 10, 64)
 		if err != nil {
 			return err
+		}
+
+		if limit > DefaultMaxLimit {
+			return errors.MaxLimitExceed
 		}
 		p.limit = limit
 	}

--- a/lib/node/runner/api/pagequery.go
+++ b/lib/node/runner/api/pagequery.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	DefaultLimit    uint64 = 20
-	DefaultMaxLimit uint64 = 100
+	DefaultLimit uint64 = 20
+	MaxLimit     uint64 = 100
 )
 
 type PageQuery struct {
@@ -93,8 +93,8 @@ func (p *PageQuery) parseRequest() error {
 			return err
 		}
 
-		if limit > DefaultMaxLimit {
-			return errors.MaxLimitExceed
+		if limit > MaxLimit {
+			return errors.PageQueryLimitMaxExceed
 		}
 		p.limit = limit
 	}

--- a/lib/node/runner/api/pagequery.go
+++ b/lib/node/runner/api/pagequery.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	DefaultLimit    uint64 = 100
-	DefaultMaxLimit uint64 = 1000
+	DefaultLimit    uint64 = 20
+	DefaultMaxLimit uint64 = 100
 )
 
 type PageQuery struct {


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

To protect resources, Add paging MaxLimitExceed checking.  (DefaultMaxLimit=1000)

### Solution

The `PageQuery` can check this limit parameter, all handlers to use this `PageQuery` do check limit automatically.

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

