### PR TITLE
Change CongressVoting's Contract field type from []byte to string

### DIFF
--- a/lib/client/response.go
+++ b/lib/client/response.go
@@ -133,7 +133,7 @@ type OperationsPage struct {
 }
 
 type CongressVoting struct {
-	Contract []byte `json:"contract"`
+	Contract string `json:"contract"`
 	Voting   struct {
 		Start uint64 `json:"start"`
 		End   uint64 `json:"end"`

--- a/lib/transaction/operation/congress_voting.go
+++ b/lib/transaction/operation/congress_voting.go
@@ -8,7 +8,7 @@ import (
 )
 
 type CongressVoting struct {
-	Contract []byte `json:"contract"`
+	Contract string `json:"contract"`
 	Voting   struct {
 		Start uint64 `json:"start"`
 		End   uint64 `json:"end"`
@@ -17,7 +17,7 @@ type CongressVoting struct {
 	Amount         common.Amount `json:"amount"`
 }
 
-func NewCongressVoting(contract []byte, start, end uint64, amount common.Amount, fundingAddress string) CongressVoting {
+func NewCongressVoting(contract string, start, end uint64, amount common.Amount, fundingAddress string) CongressVoting {
 
 	return CongressVoting{
 		Contract: contract,

--- a/lib/transaction/operation/operation_test.go
+++ b/lib/transaction/operation/operation_test.go
@@ -55,7 +55,7 @@ func TestSerializeOperation(t *testing.T) {
 }
 
 func TestOperationBodyCongressVoting(t *testing.T) {
-	opb := NewCongressVoting([]byte("dummy contract"), 1, 100, common.Amount(1000000), "dummy account")
+	opb := NewCongressVoting("dummy contract", 1, 100, common.Amount(1000000), "dummy account")
 	op := Operation{
 		H: Header{Type: TypeCongressVoting},
 		B: opb,

--- a/lib/transaction/transaction_test.go
+++ b/lib/transaction/transaction_test.go
@@ -80,7 +80,7 @@ func (suite *TestSuite) TestIsWellFormedTransactionWithLowerFeeSuite() {
 	{ // with CongressVoting, it has zero fee
 		kp, tx := TestMakeTransaction(suite.conf.NetworkID, 3)
 
-		opb := operation.NewCongressVoting([]byte("dummy contract"), 1, 100, common.Amount(1000000), "dummy account")
+		opb := operation.NewCongressVoting("dummy contract", 1, 100, common.Amount(1000000), "dummy account")
 		op := operation.Operation{
 			H: operation.Header{Type: operation.TypeCongressVoting},
 			B: opb,

--- a/tests/client/congressvoting_inflationpf_test.go
+++ b/tests/client/congressvoting_inflationpf_test.go
@@ -118,7 +118,7 @@ func TestInflationPF(t *testing.T) {
 		congressAccount, err := c.LoadAccount(CongressAddr)
 		require.NoError(t, err)
 
-		ob := operation.NewCongressVoting([]byte("dummy"), 10, 20, common.Amount(fundingAmount), account1Addr)
+		ob := operation.NewCongressVoting("dummy", 10, 20, common.Amount(fundingAmount), account1Addr)
 		o, err := operation.NewOperation(ob)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### Github Issue


### Background
To improve the usability of client-side,
[]byte is changed to string 

### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

