### PR TITLE
Sending Invalid transaction message should get `BadRequest`(400) error code

### DIFF
--- a/lib/node/runner/api/transaction_post.go
+++ b/lib/node/runner/api/transaction_post.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/transaction"
@@ -43,6 +44,10 @@ func (api NetworkHandlerAPI) PostTransactionsHandler(
 
 	var tx transaction.Transaction
 	if tx, err = handler(body, funcs); err != nil {
+		if _, ok := err.(*errors.Error); !ok {
+			err = errors.HTTPProblem.Clone().SetData("error", err.Error())
+		}
+
 		httputils.WriteJSONError(w, err)
 		return
 	}

--- a/lib/node/runner/post_transaction_test.go
+++ b/lib/node/runner/post_transaction_test.go
@@ -1,0 +1,79 @@
+package runner
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
+	"boscoin.io/sebak/lib/consensus"
+	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/node/runner/api"
+	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
+)
+
+func TestPostTransaction(t *testing.T) {
+	st := storage.NewTestStorage()
+	defer st.Close()
+
+	endpoint, _ := common.NewEndpointFromString("http://localhost:12345")
+	localNode, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
+	localNode.AddValidators(localNode.ConvertToValidator())
+	isaac, _ := consensus.NewISAAC(
+		localNode,
+		nil,
+		network.NewValidatorConnectionManager(localNode, nil, nil),
+		st,
+		common.NewTestConfig(),
+		nil,
+	)
+
+	var config *network.HTTP2NetworkConfig
+
+	config, _ = network.NewHTTP2NetworkConfigFromEndpoint(localNode.Alias(), endpoint)
+	nt := network.NewHTTP2Network(config)
+
+	nodeHandler := NetworkHandlerNode{
+		storage:   st,
+		consensus: isaac,
+		network:   nt,
+		localNode: localNode,
+		conf:      common.Config{OpsLimit: 1},
+	}
+	apiHandler := api.NewNetworkHandlerAPI(localNode, nt, nil, "", node.NodeInfo{})
+
+	router := mux.NewRouter()
+	router.HandleFunc(
+		api.GetTransactionsHandlerPattern,
+		func(w http.ResponseWriter, r *http.Request) {
+			apiHandler.PostTransactionsHandler(
+				w, r,
+				nodeHandler.ReceiveTransaction, HandleTransactionCheckerFuncs,
+			)
+			return
+		},
+	).Methods("POST")
+
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	kp := keypair.Random()
+	tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp)
+	b, _ := tx.Serialize()
+
+	{ // send broken json message
+		req, _ := http.NewRequest("POST", server.URL+api.GetTransactionsHandlerPattern, bytes.NewReader(b[:10]))
+		resp, err := server.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
### Github Issue
Resolves #749

### Background

See #749 . At this time, the invalid or broken transaction message got `500` status code with error message.

### Solution

This patch handles the none-sebak-errors to send `http.StatusBadRequest`(400) status code.