### PR TITLE
The item of `/api/v1/transactions/<hash>/operations` will have `Confirmed` time.

### DIFF
--- a/lib/errors/base.go
+++ b/lib/errors/base.go
@@ -30,6 +30,15 @@ func (o *Error) SetData(k string, v interface{}) *Error {
 	return o
 }
 
+func (o *Error) GetData(k string) interface{} {
+	v, found := o.Data[k]
+	if !found {
+		return nil
+	}
+
+	return v
+}
+
 func (o *Error) Clone() *Error {
 	var new Error
 	new = *o

--- a/lib/network/httputils/json.go
+++ b/lib/network/httputils/json.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 
 	"github.com/nvellon/hal"
+
+	"boscoin.io/sebak/lib/errors"
 )
 
 type HALResource interface {
@@ -21,6 +23,12 @@ func MustWriteJSON(w http.ResponseWriter, code int, v interface{}) {
 // WriteJSONError writes the error to the http response as json encoding
 func WriteJSONError(w http.ResponseWriter, err error) {
 	code := StatusCode(err) //TODO(anarcher): ErrorStateCode is more suitable?
+	if sebakError, ok := err.(*errors.Error); ok {
+		if status := sebakError.GetData("status"); status != nil {
+			code = status.(int)
+		}
+
+	}
 
 	if err := WriteJSON(w, code, err); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/lib/node/runner/api/base_test.go
+++ b/lib/node/runner/api/base_test.go
@@ -52,7 +52,7 @@ func prepareOps(storage *storage.LevelDBBackend, count int) (*keypair.Full, []bl
 
 	return kp, boList
 }
-func prepareOpsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full, []block.BlockOperation) {
+func prepareOpsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full, block.Block, []block.BlockOperation) {
 	kp := keypair.Random()
 	var txs []transaction.Transaction
 	var txHashes []string
@@ -74,7 +74,7 @@ func prepareOpsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full
 		}
 	}
 
-	return kp, boList
+	return kp, theBlock, boList
 }
 
 func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, []block.BlockTransaction) {

--- a/lib/node/runner/api/resource/operation.go
+++ b/lib/node/runner/api/resource/operation.go
@@ -5,12 +5,14 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 
-	"boscoin.io/sebak/lib/transaction/operation"
 	"github.com/nvellon/hal"
+
+	"boscoin.io/sebak/lib/transaction/operation"
 )
 
 type Operation struct {
-	bo *block.BlockOperation
+	Block *block.Block
+	bo    *block.BlockOperation
 }
 
 func NewOperation(bo *block.BlockOperation) *Operation {
@@ -23,13 +25,20 @@ func NewOperation(bo *block.BlockOperation) *Operation {
 func (o Operation) GetMap() hal.Entry {
 	body, _ := operation.UnmarshalBodyJSON(o.bo.Type, o.bo.Body)
 
-	return hal.Entry{
-		"hash":    o.bo.Hash,
-		"source":  o.bo.Source,
-		"type":    o.bo.Type,
-		"tx_hash": o.bo.TxHash,
-		"body":    body,
+	entry := hal.Entry{
+		"hash":         o.bo.Hash,
+		"source":       o.bo.Source,
+		"type":         o.bo.Type,
+		"tx_hash":      o.bo.TxHash,
+		"body":         body,
+		"block_height": o.bo.Height,
 	}
+
+	if o.Block != nil {
+		entry["confirmed"] = o.Block.Confirmed
+	}
+
+	return entry
 }
 
 func (o Operation) Resource() *hal.Resource {

--- a/lib/node/runner/api/resource/operation.go
+++ b/lib/node/runner/api/resource/operation.go
@@ -22,6 +22,10 @@ func NewOperation(bo *block.BlockOperation) *Operation {
 	return o
 }
 
+func (o Operation) BlockOperation() *block.BlockOperation {
+	return o.bo
+}
+
 func (o Operation) GetMap() hal.Entry {
 	body, _ := operation.UnmarshalBodyJSON(o.bo.Type, o.bo.Body)
 
@@ -36,6 +40,7 @@ func (o Operation) GetMap() hal.Entry {
 
 	if o.Block != nil {
 		entry["confirmed"] = o.Block.Confirmed
+		entry["proposed_time"] = o.Block.ProposedTime
 	}
 
 	return entry

--- a/lib/node/runner/api/stream.go
+++ b/lib/node/runner/api/stream.go
@@ -6,9 +6,10 @@ import (
 	"net/http"
 	"strings"
 
+	observable "github.com/GianlucaGuarini/go-observable"
+
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network/httputils"
-	observable "github.com/GianlucaGuarini/go-observable"
 )
 
 // DefaultContentType is "application/json"

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -61,8 +61,9 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 		bo, err := block.GetBlockOperation(storage, hash)
 		require.NoError(t, err)
 		require.NotNil(t, bo)
-		require.NotNil(t, item["confirmed"]) // `block.Block.Confirmed`
-		require.Equal(t, blk.Confirmed, item["confirmed"])
+		require.NotNil(t, item["proposed_time"]) // `block.Block.ProposedTime`
+		require.Equal(t, blk.ProposedTime, item["proposed_time"].(string))
+		require.Equal(t, blk.Confirmed, item["confirmed"].(string))
 		require.Equal(t, blk.Height, uint64(item["block_height"].(float64)))
 	}
 }
@@ -72,14 +73,13 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	wg.Add(1)
 
 	ts, storage := prepareAPIServer()
-	defer storage.Close()
 	defer ts.Close()
 
 	kp := keypair.Random()
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 10, kp)
 
 	blk := block.TestMakeNewBlockWithPrevBlock(block.GetLatestBlock(storage), []string{tx.GetHash()})
-	bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx)
+	bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.ProposedTime, tx)
 
 	boMap := make(map[string]block.BlockOperation)
 	for _, op := range tx.B.Operations {
@@ -132,11 +132,13 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 			txS, err := json.Marshal(r.Resource())
 			require.NoError(t, err)
 			require.Equal(t, txS, line)
-			require.NotNil(t, recv["confirmed"]) // `block.Block.Confirmed`
-			require.Equal(t, blk.Confirmed, recv["confirmed"])
+			require.NotNil(t, recv["confirmed"]) // `block.Block.ProposedTime`
+			require.Equal(t, blk.ProposedTime, recv["proposed_time"].(string))
+			require.Equal(t, blk.Confirmed, recv["confirmed"].(string))
 			require.Equal(t, blk.Height, uint64(recv["block_height"].(float64)))
 		}
 	}
 
 	wg.Wait()
+	storage.Close()
 }

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"boscoin.io/sebak/lib/block"
-	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
@@ -53,6 +52,8 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 
 	records := recv["_embedded"].(map[string]interface{})["records"].([]interface{})
 
+	blk, _ := block.GetBlock(storage, bt.Block)
+
 	for _, r := range records {
 		item := r.(map[string]interface{})
 		hash := item["hash"].(string)
@@ -60,6 +61,8 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 		bo, err := block.GetBlockOperation(storage, hash)
 		require.NoError(t, err)
 		require.NotNil(t, bo)
+		require.NotNil(t, item["confirmed"]) // `block.Block.Confirmed`
+		require.Equal(t, blk.Confirmed, item["confirmed"])
 	}
 }
 
@@ -73,7 +76,10 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 
 	kp := keypair.Random()
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 10, kp)
-	bt := block.NewBlockTransactionFromTransaction("block-hash", 1, common.NowISO8601(), tx)
+
+	blk := block.TestMakeNewBlockWithPrevBlock(block.GetLatestBlock(storage), []string{tx.GetHash()})
+
+	bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx)
 
 	boMap := make(map[string]block.BlockOperation)
 	for _, op := range tx.B.Operations {
@@ -83,22 +89,24 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	}
 
 	// Wait until request registered to observer
-	{
-		go func() {
-			for {
-				observer.BlockOperationObserver.RLock()
-				if len(observer.BlockOperationObserver.Callbacks) > 0 {
-					observer.BlockOperationObserver.RUnlock()
-					break
-				}
+	go func() {
+		for {
+			observer.BlockOperationObserver.RLock()
+			if len(observer.BlockOperationObserver.Callbacks) > 0 {
 				observer.BlockOperationObserver.RUnlock()
+				break
 			}
-			for _, bo := range boMap {
-				bo.MustSave(storage)
-			}
-			wg.Done()
-		}()
-	}
+			observer.BlockOperationObserver.RUnlock()
+		}
+
+		blk.MustSave(storage)
+		bt.MustSave(storage)
+
+		for _, bo := range boMap {
+			bo.MustSave(storage)
+		}
+		wg.Done()
+	}()
 
 	// Do a Request
 	var reader *bufio.Reader
@@ -120,9 +128,12 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 			json.Unmarshal(line, &recv)
 			bo := boMap[recv["hash"].(string)]
 			r := resource.NewOperation(&bo)
+			r.Block = &blk
 			txS, err := json.Marshal(r.Resource())
 			require.NoError(t, err)
 			require.Equal(t, txS, line)
+			require.NotNil(t, recv["confirmed"]) // `block.Block.Confirmed`
+			require.Equal(t, blk.Confirmed, recv["confirmed"])
 		}
 	}
 

--- a/lib/node/runner/api/tx_operations_test.go
+++ b/lib/node/runner/api/tx_operations_test.go
@@ -63,6 +63,7 @@ func TestGetOperationsByTxHashHandler(t *testing.T) {
 		require.NotNil(t, bo)
 		require.NotNil(t, item["confirmed"]) // `block.Block.Confirmed`
 		require.Equal(t, blk.Confirmed, item["confirmed"])
+		require.Equal(t, blk.Height, uint64(item["block_height"].(float64)))
 	}
 }
 
@@ -78,12 +79,11 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 	tx := transaction.TestMakeTransactionWithKeypair(networkID, 10, kp)
 
 	blk := block.TestMakeNewBlockWithPrevBlock(block.GetLatestBlock(storage), []string{tx.GetHash()})
-
 	bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.Confirmed, tx)
 
 	boMap := make(map[string]block.BlockOperation)
 	for _, op := range tx.B.Operations {
-		bo, err := block.NewBlockOperationFromOperation(op, tx, 0)
+		bo, err := block.NewBlockOperationFromOperation(op, tx, blk.Height)
 		require.NoError(t, err)
 		boMap[bo.Hash] = bo
 	}
@@ -134,6 +134,7 @@ func TestGetOperationsByTxHashHandlerStream(t *testing.T) {
 			require.Equal(t, txS, line)
 			require.NotNil(t, recv["confirmed"]) // `block.Block.Confirmed`
 			require.Equal(t, blk.Confirmed, recv["confirmed"])
+			require.Equal(t, blk.Height, uint64(recv["block_height"].(float64)))
 		}
 	}
 


### PR DESCRIPTION
### Github Issue

Resolves #751 

### Background

See #751 , toperation api will

### Solution

Simply `Block.Confirmed` time and `BlockOperation.block_height` in `resource.Operation`.

* `confirmed` time can be considered the creation or stored time of the block, transactions and operations, this value can be different by nodes.
* `proposed_time` is the proposed time by proposer, this must be same between nodes.
* `block_height` is the height of block.

The output will be,
```json
{
  "_embedded": {
    "records": [
      {
        "_links": {
          "self": {
            "href": "/api/v1/operations/HiM4q3P82HuByuqvjGuyj8CxUdK5jk52EZ4YgATafSLr-8N43ibLQLABnYc2PpqbDzBWUBfF69Z5WTFSkf7eChqqw"
          },
          "transaction": {
            "href": "/api/v1/transactions/8N43ibLQLABnYc2PpqbDzBWUBfF69Z5WTFSkf7eChqqw"
          }
        },
        "block_height": 2,
        "body": {
          "target": "GCDPYNLZRGRZEJNDHJMKP45QKT4ZNZWP4ZAWFNNGDT4TG7TJQ73DZINW",
          "amount": "3081"
        },
        "confirmed": "2018-11-20T14:47:42.552511000+09:00",
        "proposed_time": "2018-11-20T14:47:40.152513000+09:00",
        "hash": "HiM4q3P82HuByuqvjGuyj8CxUdK5jk52EZ4YgATafSLr-8N43ibLQLABnYc2PpqbDzBWUBfF69Z5WTFSkf7eChqqw",
        "source": "GCHKDI3GZBSME6SFHNBGI2RS3NM6AD5I5VM522CXKE6YBBDDZB6UPZ2D",
        "tx_hash": "8N43ibLQLABnYc2PpqbDzBWUBfF69Z5WTFSkf7eChqqw",
        "type": "payment"
      }
    ]
  },
  "_links": {
    "next": {
      "href": "/transactions/8N43ibLQLABnYc2PpqbDzBWUBfF69Z5WTFSkf7eChqqw/operations?limit=20&reverse=false"
    },
    "prev": {
      "href": "/transactions/8N43ibLQLABnYc2PpqbDzBWUBfF69Z5WTFSkf7eChqqw/operations?limit=20&reverse=true"
    },
    "self": {
      "href": "/transactions/8N43ibLQLABnYc2PpqbDzBWUBfF69Z5WTFSkf7eChqqw/operations"
    }
  }
}
```