### PR TITLE
Expired voting

### DIFF
--- a/lib/consensus/remove_running_round_test.go
+++ b/lib/consensus/remove_running_round_test.go
@@ -1,0 +1,210 @@
+package consensus
+
+import (
+	"testing"
+
+	"boscoin.io/sebak/lib/ballot"
+	"boscoin.io/sebak/lib/voting"
+	"github.com/stretchr/testify/require"
+)
+
+func insertRunningRound(t *testing.T, is *ISAAC, source string, proposer string, height uint64, round uint64, ballotState ballot.State, vote voting.Hole) {
+	basis := voting.Basis{
+		Height: height,
+		Round:  round,
+	}
+
+	b := *ballot.NewBallot(source, proposer, basis, []string{})
+	b.SetVote(ballotState, vote)
+
+	if runningRound, found := is.RunningRounds[basis.Index()]; !found {
+		rr, err := NewRunningRound(proposer, b)
+		require.NoError(t, err)
+		is.RunningRounds[basis.Index()] = rr
+	} else {
+		runningRound.Vote(b)
+	}
+
+}
+
+func TestRunningRoundsLowerOrEqualHeight(t *testing.T) {
+	is := ISAAC{
+		RunningRounds: map[string]*RunningRound{},
+		log:           log.New(),
+	}
+
+	nodes := []string{"node1", "node2", "node3"}
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateACCEPT, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateACCEPT, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+
+	require.Equal(t, 3, len(is.RunningRounds))
+
+	is.RemoveRunningRoundsLowerOrEqualHeight(10)
+	require.Equal(t, 1, len(is.RunningRounds))
+
+	is.RemoveRunningRoundsLowerOrEqualHeight(9)
+	require.Equal(t, 1, len(is.RunningRounds))
+
+	is.RemoveRunningRoundsLowerOrEqualHeight(11)
+	require.Equal(t, 0, len(is.RunningRounds))
+}
+
+func TestRunningRoundsLowerOrEqualBasis(t *testing.T) {
+	is := ISAAC{
+		RunningRounds: map[string]*RunningRound{},
+		log:           log.New(),
+	}
+
+	nodes := []string{"node1", "node2", "node3"}
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateACCEPT, voting.EXP)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateACCEPT, voting.EXP)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateACCEPT, voting.EXP)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+
+	require.Equal(t, 3, len(is.RunningRounds))
+
+	votingBasis := voting.Basis{Height: 10, Round: 0}
+
+	is.RemoveRunningRoundsLowerOrEqualBasis(votingBasis)
+	require.Equal(t, 2, len(is.RunningRounds))
+
+	votingBasis.Height = 11
+
+	is.RemoveRunningRoundsLowerOrEqualBasis(votingBasis)
+	require.Equal(t, 0, len(is.RunningRounds))
+}
+
+func TestRunningRoundsExceptExpired(t *testing.T) {
+	is := ISAAC{
+		RunningRounds: map[string]*RunningRound{},
+		log:           log.New(),
+	}
+
+	nodes := []string{"node1", "node2", "node3"}
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateSIGN, voting.NO)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateSIGN, voting.EXP)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateACCEPT, voting.NO)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateACCEPT, voting.EXP)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+
+	require.Equal(t, 3, len(is.RunningRounds))
+
+	isaacState := ISAACState{Height: 10, Round: 0, BallotState: ballot.StateSIGN}
+	votingBasis := voting.Basis{Height: 10, Round: 0}
+	require.Equal(t, 3, len(is.RunningRounds))
+
+	runningRound, ok := is.RunningRounds[votingBasis.Index()]
+	require.True(t, ok)
+
+	roundVote, ok := runningRound.Voted[nodes[0]]
+	require.True(t, ok)
+
+	require.Equal(t, 3, len(roundVote.SIGN))
+	require.Equal(t, 3, len(roundVote.ACCEPT))
+
+	is.RemoveRunningRoundsExceptExpired(isaacState)
+
+	require.Equal(t, 0, len(roundVote.SIGN))
+	require.Equal(t, 3, len(roundVote.ACCEPT))
+
+	isaacState.BallotState = ballot.StateACCEPT
+	is.RemoveRunningRoundsExceptExpired(isaacState)
+
+	require.Equal(t, 0, len(roundVote.SIGN))
+	require.Equal(t, 0, len(roundVote.ACCEPT))
+
+	isaacState = ISAACState{Height: 10, Round: 1, BallotState: ballot.StateSIGN}
+	votingBasis = voting.Basis{Height: 10, Round: 1}
+
+	runningRound, ok = is.RunningRounds[votingBasis.Index()]
+	require.True(t, ok)
+
+	roundVote, ok = runningRound.Voted[nodes[1]]
+	require.True(t, ok)
+
+	require.Equal(t, 3, len(roundVote.SIGN))
+	require.Equal(t, 3, len(roundVote.ACCEPT))
+
+	is.RemoveRunningRoundsExceptExpired(isaacState)
+
+	require.Equal(t, 1, len(roundVote.SIGN))
+	require.Equal(t, 3, len(roundVote.ACCEPT))
+
+	isaacState.BallotState = ballot.StateACCEPT
+	is.RemoveRunningRoundsExceptExpired(isaacState)
+
+	require.Equal(t, 1, len(roundVote.SIGN))
+	require.Equal(t, 1, len(roundVote.ACCEPT))
+
+	votingBasis = voting.Basis{Height: 11, Round: 0}
+
+	runningRound, ok = is.RunningRounds[votingBasis.Index()]
+	require.True(t, ok)
+
+	roundVote, ok = runningRound.Voted[nodes[1]]
+	require.True(t, ok)
+
+	require.Equal(t, 3, len(roundVote.SIGN))
+	require.Equal(t, 3, len(roundVote.ACCEPT))
+}

--- a/lib/consensus/round_vote.go
+++ b/lib/consensus/round_vote.go
@@ -25,10 +25,15 @@ func NewRoundVote(ballot ballot.Ballot) (rv *RoundVote) {
 	return rv
 }
 
-func (rv *RoundVote) IsVoted(ballot ballot.Ballot) bool {
-	result := rv.GetResult(ballot.State())
+func (rv *RoundVote) IsVoted(b ballot.Ballot) bool {
+	result := rv.GetResult(b.State())
 
-	_, found := result[ballot.Source()]
+	old, found := result[b.Source()]
+	if (old != voting.EXP) && (b.Vote() == voting.EXP) {
+		// receiving B(SIGN or ACCEPT, YES or NO) -> B(SIGN or ACCEPT, EXP) allows,
+		// since SIGN or ACCEPT_TIMEOUT can occur after sending a B(ACCEPT),
+		return false
+	}
 	return found
 }
 

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -645,14 +645,14 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 		checker.NodeRunner.Consensus().SetLatestVotingBasis(basis)
 
 		checker.NodeRunner.TransactionPool.RemoveFromSources(checker.LatestBlockSources...)
-		checker.NodeRunner.Consensus().RemoveRunningRoundsWithSameHeight(basis.Height)
+		checker.NodeRunner.Consensus().RemoveRunningRoundsLowerOrEqualHeight(basis.Height)
 
 		err = NewCheckerStopCloseConsensus(checker, "ballot got consensus and will be stored")
 	case voting.NO, voting.EXP:
 		checker.NodeRunner.isaacStateManager.NextRound()
 		checker.NodeRunner.Consensus().SetLatestVotingBasis(basis)
 
-		checker.NodeRunner.Consensus().RemoveRunningRoundsWithSameHeight(basis.Height)
+		checker.NodeRunner.Consensus().RemoveRunningRoundsLowerOrEqualBasis(basis)
 
 		err = NewCheckerStopCloseConsensus(checker, "ballot got consensus")
 	case voting.NOTYET:

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -267,7 +267,7 @@ func (sm *ISAACStateManager) broadcastExpiredBallot(round uint64, state ballot.S
 	newExpiredBallot.Sign(sm.nr.localNode.Keypair(), sm.nr.Conf.NetworkID)
 
 	sm.nr.Log().Debug("broadcast", "ballot", *newExpiredBallot)
-	sm.nr.ConnectionManager().Broadcast(*newExpiredBallot)
+	sm.nr.broadcastBallot(*newExpiredBallot)
 }
 
 func (sm *ISAACStateManager) resetTimer(timer *time.Timer, state ballot.State) {

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -101,7 +101,7 @@ func TestStateINITTimeoutNotProposer(t *testing.T) {
 // 3. When `ISAACStateManager` starts, the node proposes B(`INIT`, `YES`) to validators.
 // 4. Then ISAACState will be changed to `SIGN`.
 // 5. But TimeoutSIGN is a millisecond.
-// 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`)
+// 6. After timeout, the node broadcasts B(`SIGN`, `EXP`)
 func TestStateSIGNTimeoutProposer(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
@@ -127,7 +127,7 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 	nr.isaacStateManager.TransitISAACState(state.Height, state.Round, ballot.StateSIGN)
 
 	<-recv
-	require.Equal(t, ballot.StateACCEPT, nr.isaacStateManager.State().BallotState)
+	require.Equal(t, ballot.StateSIGN, nr.isaacStateManager.State().BallotState)
 	require.Equal(t, 2, len(cm.Messages()))
 
 	init, sign, accept := 0, 0, 0
@@ -148,8 +148,8 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, init)
-	require.Equal(t, 0, sign)
-	require.Equal(t, 1, accept)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 0, accept)
 }
 
 // 1. All 3 Nodes.
@@ -158,7 +158,7 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 // 4. TimeoutINIT is a millisecond.
 // 5. ISAACState is changed to `SIGN`.
 // 6. TimeoutSIGN is a millisecond.
-// 7. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+// 7. After timeout, the node broadcasts B(`SIGN`, `EXP`).
 func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = 200 * time.Millisecond
@@ -211,8 +211,8 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 		}
 	}
 	require.Equal(t, 0, init)
-	require.Equal(t, 0, sign)
-	require.Equal(t, 1, accept)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 0, accept)
 }
 
 // 1. All 3 Nodes.
@@ -220,7 +220,7 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 // 3. When `ISAACStateManager` starts, the node proposes a ballot.
 // 4. ISAACState is changed to `SIGN`.
 // 5. TimeoutSIGN is a millisecond.
-// 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+// 6. After timeout, the node broadcasts B(`SIGN`, `EXP`).
 func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
@@ -269,8 +269,8 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 	}
 
 	require.Equal(t, 1, init)
-	require.Equal(t, 0, sign)
-	require.Equal(t, 1, accept)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 0, accept)
 }
 
 // 1. All 3 Nodes.
@@ -279,7 +279,7 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 // 4. TransitISAACState(SIGN) method is called.
 // 5. ISAACState is changed to `SIGN`.
 // 6. TimeoutSIGN is a millisecond.
-// 7. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+// 7. After timeout, the node broadcasts B(`SIGN`, `EXP`).
 func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
@@ -320,7 +320,7 @@ func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 		b, ok := message.(ballot.Ballot)
 		require.True(t, ok)
 		require.NotEqual(t, nr.localNode.Address(), b.Proposer())
-		require.Equal(t, ballot.StateACCEPT, b.State())
+		require.Equal(t, ballot.StateSIGN, b.State())
 		require.Equal(t, voting.EXP, b.Vote())
 	}
 }
@@ -332,7 +332,7 @@ func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 // 1. TransitISAACState(ACCEPT) method is called.
 // 1. ISAACState is changed to `ACCEPT`.
 // 1. TimeoutACCEPT is a millisecond.
-// 1. After timeout, ISAACState is back to `INIT`
+// 1. After timeout, the node sends B(`ACCEPT`, `EXP`)
 func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
@@ -366,11 +366,24 @@ func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
 	<-recv
 
 	require.Equal(t, 2, len(cm.Messages()))
+	init, sign, accept := 0, 0, 0
 	for _, message := range cm.Messages() {
 		b, ok := message.(ballot.Ballot)
 		require.True(t, ok)
-		require.Equal(t, nr.localNode.Address(), b.Proposer())
-		require.Equal(t, ballot.StateINIT, b.State())
-		require.Equal(t, voting.YES, b.Vote())
+		require.Equal(t, 0, len(b.Transactions()))
+		switch b.State() {
+		case ballot.StateINIT:
+			init++
+			require.Equal(t, b.Vote(), voting.YES)
+		case ballot.StateSIGN:
+			sign++
+		case ballot.StateACCEPT:
+			accept++
+			require.Equal(t, b.Vote(), voting.EXP)
+		}
 	}
+
+	require.Equal(t, 1, init)
+	require.Equal(t, 0, sign)
+	require.Equal(t, 1, accept)
 }


### PR DESCRIPTION
### Background
#755 
It's because rounds are different among the nodes.

### Solution
1. When expired, nodes increase round after `consensus`
1. When a node is expired, it removes all voting results in that round except expired.
1. When expired voting is passed, the node increases round and remove lower round voting results.

ps. test code -> 220 line.