### PR TITLE
Remove start isaacStateManager fitering

### DIFF
--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -580,21 +580,12 @@ func (nr *NodeRunner) waitForConnectingEnoughNodes() {
 }
 
 func (nr *NodeRunner) startStateManager() {
-	nr.RLock()
-	defer nr.RUnlock()
-
-	// check whether current running rounds exist
-	if len(nr.consensus.RunningRounds) > 0 {
-		return
-	}
-
 	nr.isaacStateManager.Start()
 	nr.isaacStateManager.NextHeight()
 	return
 }
 
 func (nr *NodeRunner) StopStateManager() {
-	// check whether current running rounds exist
 	nr.isaacStateManager.Stop()
 	return
 }


### PR DESCRIPTION
fixes #779

Is there any reason for filtering?
In all `sebak` source, the `startStateManager()` called only once.