### PR TITLE
Add node flag for SEBAK_SYNC_CHECK_PREVBLOCK and refactoring

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -52,7 +52,7 @@ var (
 	flagSyncFetchTimeout           string = common.GetENVValue("SEBAK_SYNC_FETCH_TIMEOUT", "1m")
 	flagSyncPoolSize               string = common.GetENVValue("SEBAK_SYNC_POOL_SIZE", "300")
 	flagSyncRetryInterval          string = common.GetENVValue("SEBAK_SYNC_RETRY_INTERVAL", "10s")
-	flagSyncCheckPrevBlockInterval string = common.GetENVValue("SEBAK_SYNC_CHECK_PREVBLOCK", "10m")
+	flagSyncCheckPrevBlockInterval string = common.GetENVValue("SEBAK_SYNC_CHECK_PREVBLOCK", "30s")
 
 	flagThreshold         string = common.GetENVValue("SEBAK_THRESHOLD", "67")
 	flagTimeoutACCEPT     string = common.GetENVValue("SEBAK_TIMEOUT_ACCEPT", "2")

--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -15,7 +15,7 @@ const (
 	FetchTimeout                    = 1 * time.Minute
 	RetryInterval                   = 10 * time.Second
 	CheckBlockHeightInterval        = 30 * time.Second
-	CheckPrevBlockInterval          = 10 * time.Minute
+	CheckPrevBlockInterval          = 30 * time.Second
 )
 
 type Config struct {

--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -60,7 +60,7 @@ func (c *Config) NewSyncer() *Syncer {
 	s := NewSyncer(f, v, c.storage, func(s *Syncer) {
 		s.poolSize = c.SyncPoolSize
 		s.checkInterval = c.CheckBlockHeightInterval
-		s.logger = c.logger.New("module", "sync/syncer")
+		s.logger = c.logger.New("submodule", "syncer")
 	})
 
 	c.LoggingConfig()
@@ -75,7 +75,7 @@ func (c *Config) NewFetcher() Fetcher {
 		c.localNode,
 		func(f *BlockFetcher) {
 			f.fetchTimeout = c.FetchTimeout
-			f.logger = c.logger.New("module", "sync/fetcher")
+			f.logger = c.logger.New("submodule", "fetcher")
 		},
 	)
 	return f
@@ -88,7 +88,7 @@ func (c *Config) NewValidator() Validator {
 		c.commonCfg,
 		func(v *BlockValidator) {
 			v.prevBlockWaitTimeout = c.CheckPrevBlockInterval
-			v.logger = c.logger.New("module", "sync/validator")
+			v.logger = c.logger.New("submodule", "validator")
 		})
 	return v
 }

--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -95,7 +95,6 @@ func (c *Config) NewValidator() Validator {
 
 func (c *Config) LoggingConfig() {
 	c.logger.Info("syncer config",
-		"module", "sync/config",
 		"poolSize", c.SyncPoolSize,
 		"fetchTimeout", c.FetchTimeout,
 		"retryInterval", c.RetryInterval,

--- a/lib/sync/fetcher.go
+++ b/lib/sync/fetcher.go
@@ -108,7 +108,7 @@ func (f *BlockFetcher) fetch(ctx context.Context, si *SyncInfo) error {
 		height    = si.Height
 		nodeAddrs = si.NodeAddrs
 	)
-	f.logger.Debug("fetch start", "height", height)
+	f.logger.Debug("start fetch", "height", height)
 
 	n := f.pickRandomNode(nodeAddrs)
 	if n == nil {
@@ -202,6 +202,8 @@ func (f *BlockFetcher) fetch(ctx context.Context, si *SyncInfo) error {
 			return errors.Wrapf(errors.TransactionNotFound, "proposer transaction block hash: %v", blk.ProposerTransaction)
 		}
 	}
+
+	f.logger.Debug("end fetch", "height", height)
 
 	return nil
 }

--- a/lib/sync/init.go
+++ b/lib/sync/init.go
@@ -6,7 +6,7 @@ import (
 	"boscoin.io/sebak/lib/common"
 )
 
-var log logging.Logger = logging.New()
+var log logging.Logger = logging.New("module", "sync")
 
 func init() {
 	SetLogging(common.DefaultLogLevel, common.DefaultLogHandler)

--- a/lib/sync/init.go
+++ b/lib/sync/init.go
@@ -6,7 +6,7 @@ import (
 	"boscoin.io/sebak/lib/common"
 )
 
-var log logging.Logger = logging.New("module", "sync")
+var log logging.Logger = logging.New()
 
 func init() {
 	SetLogging(common.DefaultLogLevel, common.DefaultLogHandler)


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Related #777

### Background

- For `long-term` testing,  to control  syncer waiting prevblock via node flag.
- Refactoring  `syncer.Config` and `syncer.NewXXX`
- Add more debugging logs. (`start ...` and `end ...` pattern)

### Solution

```
      --sync-check-prevblock string     sync check interval for previous block (default "10m")
```

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

