### PR TITLE
Subscribe API

### DIFF
--- a/lib/block/account.go
+++ b/lib/block/account.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/storage"
 )
 
@@ -73,12 +72,6 @@ func (b *BlockAccount) Save(st *storage.LevelDBBackend) (err error) {
 	}
 	if err != nil {
 		return err
-	}
-
-	if err == nil {
-		event := "saved"
-		event += " " + fmt.Sprintf("address-%s", b.Address)
-		observer.BlockAccountObserver.Trigger(event, b)
 	}
 
 	bac := BlockAccountSequenceID{

--- a/lib/block/account_test.go
+++ b/lib/block/account_test.go
@@ -1,13 +1,10 @@
 package block
 
 import (
-	"fmt"
 	"math/rand"
-	"sync"
 	"testing"
 
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/storage"
 
 	"github.com/stretchr/testify/require"
@@ -131,28 +128,4 @@ func TestBlockAccountSaveBlockAccountSequenceIDs(t *testing.T) {
 		require.Equal(t, b.GetBalance(), fetched[i].Balance)
 		require.Equal(t, b.SequenceID, fetched[i].SequenceID)
 	}
-}
-func TestBlockAccountObserver(t *testing.T) {
-	var wg sync.WaitGroup
-	wg.Add(1)
-
-	b := TestMakeBlockAccount()
-
-	var triggered *BlockAccount
-	ObserverFunc := func(args ...interface{}) {
-		triggered = args[0].(*BlockAccount)
-		wg.Done()
-	}
-	observer.BlockAccountObserver.On(fmt.Sprintf("address-%s", b.Address), ObserverFunc)
-	defer observer.BlockAccountObserver.Off(fmt.Sprintf("address-%s", b.Address), ObserverFunc)
-
-	st := storage.NewTestStorage()
-
-	b.MustSave(st)
-
-	wg.Wait()
-
-	require.Equal(t, b.Address, triggered.Address)
-	require.Equal(t, b.GetBalance(), triggered.GetBalance())
-	require.Equal(t, b.SequenceID, triggered.SequenceID)
 }

--- a/lib/block/block.go
+++ b/lib/block/block.go
@@ -7,7 +7,6 @@ import (
 	"github.com/btcsuite/btcutil/base58"
 
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/voting"
@@ -106,8 +105,6 @@ func (b *Block) Save(st *storage.LevelDBBackend) (err error) {
 	if err = st.New(getBlockKeyPrefixHeight(b.Height), b.Hash); err != nil {
 		return
 	}
-
-	observer.BlockObserver.Trigger(EventBlockPrefix, b)
 
 	return
 }

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
@@ -116,18 +115,6 @@ func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 	}
 
 	bo.isSaved = true
-
-	event := "saved"
-	event += " " + fmt.Sprintf("source-%s", bo.Source)
-	event += " " + fmt.Sprintf("hash-%s", bo.Hash)
-	event += " " + fmt.Sprintf("txhash-%s", bo.TxHash)
-	event += " " + fmt.Sprintf("source-type-%s%s", bo.Source, bo.Type)
-	event += " " + fmt.Sprintf("blockheight-%d", bo.Height)
-	if casted.Linked != "" {
-		event += " frozen"
-		event += " " + fmt.Sprintf("linked-%s", casted.Linked)
-	}
-	observer.BlockOperationObserver.Trigger(event, bo)
 
 	return nil
 }

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -8,8 +8,13 @@ import (
 	"boscoin.io/sebak/lib/voting"
 )
 
-func TestMakeBlockAccount() *BlockAccount {
-	address := keypair.Random().Address()
+func TestMakeBlockAccount(kps ...*keypair.Full) *BlockAccount {
+	var address string
+	if len(kps) == 0 {
+		address = keypair.Random().Address()
+	} else {
+		address = kps[0].Address()
+	}
 	balance := common.Amount(common.BaseReserve)
 
 	return NewBlockAccount(address, balance)

--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
@@ -135,10 +134,6 @@ func (bt *BlockTransaction) Save(st *storage.LevelDBBackend) (err error) {
 		return
 	}
 
-	event := "saved"
-	event += " " + fmt.Sprintf("source-%s", bt.Source)
-	event += " " + fmt.Sprintf("hash-%s", bt.Hash)
-	observer.BlockTransactionObserver.Trigger(event, bt)
 	bt.isSaved = true
 
 	return nil

--- a/lib/block/transaction_pool.go
+++ b/lib/block/transaction_pool.go
@@ -53,7 +53,7 @@ func (tp TransactionPool) Save(st *storage.LevelDBBackend) (err error) {
 		return
 	}
 
-	event := observer.NewSubscribe(observer.NewEvent(observer.ResourceTransactionPool, observer.ConditionTxHash, tp.Hash)).String()
+	event := observer.NewCondition(observer.ResourceTransactionPool, observer.KeyTxHash, tp.Hash).Event()
 	go observer.ResourceObserver.Trigger(event, &tp)
 
 	return nil

--- a/lib/block/transaction_pool.go
+++ b/lib/block/transaction_pool.go
@@ -53,8 +53,8 @@ func (tp TransactionPool) Save(st *storage.LevelDBBackend) (err error) {
 		return
 	}
 
-	event := fmt.Sprintf("pushed-%s", tp.Hash)
-	observer.BlockTransactionObserver.Trigger(event, &tp)
+	event := observer.NewSubscribe(observer.NewEvent(observer.ResourceTransactionPool, observer.ConditionTxHash, tp.Hash)).String()
+	go observer.ResourceObserver.Trigger(event, &tp)
 
 	return nil
 }

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -314,7 +314,7 @@ func (c *Client) Stream(ctx context.Context, url string, body []byte, handler fu
 }
 
 func (c *Client) StreamAccount(ctx context.Context, id string, handler func(Account)) (err error) {
-	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceAccount, observer.ConditionAll, ""))}
+	s := []observer.Conditions{{observer.NewCondition(observer.ResourceAccount, observer.KeyAll, "")}}
 	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Account
@@ -329,7 +329,7 @@ func (c *Client) StreamAccount(ctx context.Context, id string, handler func(Acco
 }
 
 func (c *Client) StreamTransactions(ctx context.Context, handler func(Transaction)) (err error) {
-	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionAll, ""))}
+	s := []observer.Conditions{{observer.NewCondition(observer.ResourceTransaction, observer.KeyAll, "")}}
 	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Transaction
@@ -344,7 +344,7 @@ func (c *Client) StreamTransactions(ctx context.Context, handler func(Transactio
 }
 
 func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, handler func(Transaction)) (err error) {
-	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionSource, id)), observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionTarget, id))}
+	s := []observer.Conditions{{observer.NewCondition(observer.ResourceTransaction, observer.KeySource, id), observer.NewCondition(observer.ResourceTransaction, observer.KeyTarget, id)}}
 	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Transaction
@@ -373,7 +373,7 @@ func (c *Client) StreamTransactionStatus(ctx context.Context, id string, body []
 }
 
 func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, handler func(Transaction)) (err error) {
-	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionTxHash, id))}
+	s := []observer.Conditions{{observer.NewCondition(observer.ResourceTransaction, observer.KeyTxHash, id)}}
 	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Transaction
@@ -388,7 +388,7 @@ func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, handle
 }
 
 func (c *Client) StreamOperationsByAccount(ctx context.Context, id string, body []byte, handler func(Operation)) (err error) {
-	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionSource, id)), observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionTarget, id))}
+	s := []observer.Conditions{{observer.NewCondition(observer.ResourceOperation, observer.KeySource, id), observer.NewCondition(observer.ResourceOperation, observer.KeyTarget, id)}}
 	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Operation
@@ -403,7 +403,7 @@ func (c *Client) StreamOperationsByAccount(ctx context.Context, id string, body 
 }
 
 func (c *Client) StreamOperationsByTransaction(ctx context.Context, id string, body []byte, handler func(Operation)) (err error) {
-	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionTxHash, id))}
+	s := []observer.Conditions{{observer.NewCondition(observer.ResourceOperation, observer.KeyTxHash, id)}}
 	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Operation

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"boscoin.io/sebak/lib/common/observer"
 	"bufio"
 	"context"
 	"encoding/json"
@@ -26,6 +27,7 @@ const (
 	UrlTransactionByHash     = "/transactions/{id}"
 	UrlTransactionStatus     = "/transactions/{id}/status"
 	UrlTransactionOperations = "/transactions/{id}/operations"
+	UrlSubscribe             = "/subscribe"
 )
 
 type QueryKey string
@@ -259,15 +261,10 @@ func (c *Client) SubmitTransactionAndWait(hash string, tx []byte) (pTransaction 
 	return
 }
 
-func (c *Client) Stream(ctx context.Context, theUrl string, cursor *string, handler func(data []byte) error) (err error) {
-	query := neturl.Values{}
-	if cursor != nil {
-		query.Set("cursor", string(*cursor))
-	}
-	theUrl += "?" + query.Encode()
+func (c *Client) Stream(ctx context.Context, body []byte, handler func(data []byte) error) (err error) {
 	var headers = http.Header{}
 	headers.Set("Accept", "text/event-stream")
-	resp, err := c.Get(theUrl, headers)
+	resp, err := c.Post(UrlSubscribe, body, headers)
 	if err != nil {
 		return err
 	}
@@ -311,8 +308,9 @@ func (c *Client) Stream(ctx context.Context, theUrl string, cursor *string, hand
 	return
 }
 
-func (c *Client) StreamAccount(ctx context.Context, id string, cursor *string, handler func(Account)) (err error) {
-	url := strings.Replace(UrlAccount, "{id}", id, -1)
+func (c *Client) StreamAccount(ctx context.Context, id string, handler func(Account)) (err error) {
+	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceAccount, observer.ConditionAll, ""))}
+	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Account
 		err = json.Unmarshal(b, &v)
@@ -322,39 +320,12 @@ func (c *Client) StreamAccount(ctx context.Context, id string, cursor *string, h
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
+	return c.Stream(ctx, b, handlerFunc)
 }
 
-func (c *Client) StreamFrozenAccountsByLinked(ctx context.Context, id string, cursor *string, handler func(FrozenAccount)) (err error) {
-	url := strings.Replace(UrlAccountFrozenAccounts, "{id}", id, -1)
-	handlerFunc := func(b []byte) (err error) {
-		var v FrozenAccount
-		err = json.Unmarshal(b, &v)
-		if err != nil {
-			return
-		}
-		handler(v)
-		return nil
-	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
-}
-
-func (c *Client) StreamFrozenAccounts(ctx context.Context, id string, cursor *string, handler func(FrozenAccount)) (err error) {
-	url := strings.Replace(UrlFrozenAccounts, "{id}", id, -1)
-	handlerFunc := func(b []byte) (err error) {
-		var v FrozenAccount
-		err = json.Unmarshal(b, &v)
-		if err != nil {
-			return err
-		}
-		handler(v)
-		return nil
-	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
-}
-
-func (c *Client) StreamTransactions(ctx context.Context, cursor *string, handler func(Transaction)) (err error) {
-	url := UrlTransactions
+func (c *Client) StreamTransactions(ctx context.Context, handler func(Transaction)) (err error) {
+	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionAll, ""))}
+	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Transaction
 		err = json.Unmarshal(b, &v)
@@ -364,11 +335,12 @@ func (c *Client) StreamTransactions(ctx context.Context, cursor *string, handler
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
+	return c.Stream(ctx, b, handlerFunc)
 }
 
-func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, cursor *string, handler func(Transaction)) (err error) {
-	url := strings.Replace(UrlAccountTransactions, "{id}", id, -1)
+func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, handler func(Transaction)) (err error) {
+	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionSource, id)), observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionTarget, id))}
+	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Transaction
 		err = json.Unmarshal(b, &v)
@@ -378,11 +350,10 @@ func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, cur
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
+	return c.Stream(ctx, b, handlerFunc)
 }
 
-func (c *Client) StreamTransactionStatus(ctx context.Context, id string, cursor *string, handler func(TransactionStatus)) (err error) {
-	url := strings.Replace(UrlTransactionStatus, "{id}", id, -1)
+func (c *Client) StreamTransactionStatus(ctx context.Context, id string, body []byte, handler func(TransactionStatus)) (err error) {
 	handlerFunc := func(b []byte) (err error) {
 		var v TransactionStatus
 		err = json.Unmarshal(b, &v)
@@ -392,11 +363,12 @@ func (c *Client) StreamTransactionStatus(ctx context.Context, id string, cursor 
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
+	return c.Stream(ctx, body, handlerFunc)
 }
 
-func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, cursor *string, handler func(Transaction)) (err error) {
-	url := strings.Replace(UrlTransactionByHash, "{id}", id, -1)
+func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, handler func(Transaction)) (err error) {
+	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionTxHash, id))}
+	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Transaction
 		err = json.Unmarshal(b, &v)
@@ -406,11 +378,12 @@ func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, cursor
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
+	return c.Stream(ctx, b, handlerFunc)
 }
 
-func (c *Client) StreamOperationsByAccount(ctx context.Context, id string, cursor *string, handler func(Operation)) (err error) {
-	url := strings.Replace(UrlAccountOperations, "{id}", id, -1)
+func (c *Client) StreamOperationsByAccount(ctx context.Context, id string, body []byte, handler func(Operation)) (err error) {
+	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionSource, id)), observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionTarget, id))}
+	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Operation
 		err = json.Unmarshal(b, &v)
@@ -420,11 +393,12 @@ func (c *Client) StreamOperationsByAccount(ctx context.Context, id string, curso
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
+	return c.Stream(ctx, b, handlerFunc)
 }
 
-func (c *Client) StreamOperationsByTransaction(ctx context.Context, id string, cursor *string, handler func(Operation)) (err error) {
-	url := strings.Replace(UrlTransactionOperations, "{id}", id, -1)
+func (c *Client) StreamOperationsByTransaction(ctx context.Context, id string, body []byte, handler func(Operation)) (err error) {
+	s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionTxHash, id))}
+	b, err := json.Marshal(s)
 	handlerFunc := func(b []byte) (err error) {
 		var v Operation
 		err = json.Unmarshal(b, &v)
@@ -434,5 +408,5 @@ func (c *Client) StreamOperationsByTransaction(ctx context.Context, id string, c
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, cursor, handlerFunc)
+	return c.Stream(ctx, b, handlerFunc)
 }

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -261,10 +261,15 @@ func (c *Client) SubmitTransactionAndWait(hash string, tx []byte) (pTransaction 
 	return
 }
 
-func (c *Client) Stream(ctx context.Context, body []byte, handler func(data []byte) error) (err error) {
+func (c *Client) Stream(ctx context.Context, url string, body []byte, handler func(data []byte) error) (err error) {
 	var headers = http.Header{}
 	headers.Set("Accept", "text/event-stream")
-	resp, err := c.Post(UrlSubscribe, body, headers)
+	var resp *http.Response
+	if body != nil {
+		resp, err = c.Post(url, body, headers)
+	} else {
+		resp, err = c.Get(url, headers)
+	}
 	if err != nil {
 		return err
 	}
@@ -320,7 +325,7 @@ func (c *Client) StreamAccount(ctx context.Context, id string, handler func(Acco
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, b, handlerFunc)
+	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamTransactions(ctx context.Context, handler func(Transaction)) (err error) {
@@ -335,7 +340,7 @@ func (c *Client) StreamTransactions(ctx context.Context, handler func(Transactio
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, b, handlerFunc)
+	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, handler func(Transaction)) (err error) {
@@ -350,10 +355,11 @@ func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, han
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, b, handlerFunc)
+	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamTransactionStatus(ctx context.Context, id string, body []byte, handler func(TransactionStatus)) (err error) {
+	url := strings.Replace(UrlTransactionStatus, "{id}", id, -1)
 	handlerFunc := func(b []byte) (err error) {
 		var v TransactionStatus
 		err = json.Unmarshal(b, &v)
@@ -363,7 +369,7 @@ func (c *Client) StreamTransactionStatus(ctx context.Context, id string, body []
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, body, handlerFunc)
+	return c.Stream(ctx, url, nil, handlerFunc)
 }
 
 func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, handler func(Transaction)) (err error) {
@@ -378,7 +384,7 @@ func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, handle
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, b, handlerFunc)
+	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamOperationsByAccount(ctx context.Context, id string, body []byte, handler func(Operation)) (err error) {
@@ -393,7 +399,7 @@ func (c *Client) StreamOperationsByAccount(ctx context.Context, id string, body 
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, b, handlerFunc)
+	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamOperationsByTransaction(ctx context.Context, id string, body []byte, handler func(Operation)) (err error) {
@@ -408,5 +414,5 @@ func (c *Client) StreamOperationsByTransaction(ctx context.Context, id string, b
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, b, handlerFunc)
+	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
 }

--- a/lib/common/observer/observer.go
+++ b/lib/common/observer/observer.go
@@ -13,16 +13,17 @@ var SyncBlockWaitObserver = observable.New()
 var ResourceObserver = observable.New()
 
 const (
-	ResourceTransaction = "tx"
-	ResourceOperation   = "op"
-	ResourceAccount     = "ac"
-	ConditionAll        = "*"
-	ConditionSource     = "source"
-	ConditionTarget     = "target"
-	ConditionType       = "type"
-	ConditionOpHash     = "ophash"
-	ConditionTxHash     = "txhash"
-	ConditionAddress    = "address"
+	ResourceTransaction     = "tx"
+	ResourceTransactionPool = "txpool"
+	ResourceOperation       = "op"
+	ResourceAccount         = "ac"
+	ConditionAll            = "*"
+	ConditionSource         = "source"
+	ConditionTarget         = "target"
+	ConditionType           = "type"
+	ConditionOpHash         = "ophash"
+	ConditionTxHash         = "txhash"
+	ConditionAddress        = "address"
 )
 
 type Event struct {

--- a/lib/common/observer/observer.go
+++ b/lib/common/observer/observer.go
@@ -7,3 +7,5 @@ var BlockTransactionObserver = observable.New()
 var BlockObserver = observable.New()
 var BlockOperationObserver = observable.New()
 var SyncBlockWaitObserver = observable.New()
+
+var XXXObserver = observable.New()

--- a/lib/common/observer/observer.go
+++ b/lib/common/observer/observer.go
@@ -1,6 +1,8 @@
 package observer
 
-import "github.com/GianlucaGuarini/go-observable"
+import (
+	"github.com/GianlucaGuarini/go-observable"
+)
 
 var BlockAccountObserver = observable.New()
 var BlockTransactionObserver = observable.New()
@@ -8,4 +10,59 @@ var BlockObserver = observable.New()
 var BlockOperationObserver = observable.New()
 var SyncBlockWaitObserver = observable.New()
 
-var XXXObserver = observable.New()
+var ResourceObserver = observable.New()
+
+const (
+	ResourceTransaction = "tx"
+	ResourceOperation   = "op"
+	ResourceAccount     = "ac"
+	ConditionSource     = "source"
+	ConditionTarget     = "target"
+	ConditionType       = "type"
+	ConditionOpHash     = "ophash"
+	ConditionTxHash     = "txhash"
+	ConditionAddress    = "address"
+)
+
+type Event struct {
+	Resource  string `json:"resource"`
+	Condition string `json:"condition"`
+	Id        string `json:"id"`
+}
+
+func NewEvent(resource, condition, id string) Event {
+	return Event{
+		Resource:  resource,
+		Condition: condition,
+		Id:        id,
+	}
+}
+func (e Event) String() string {
+	toStr := e.Resource + "-"
+	toStr += e.Condition + "="
+	toStr += e.Id
+	return toStr
+}
+
+type Subscribe struct {
+	Events []Event `json:"resources"`
+}
+
+func NewSubscribe(events ...Event) Subscribe {
+	s := Subscribe{}
+	for _, e := range events {
+		s.Events = append(s.Events, e)
+	}
+	return s
+}
+
+func (s Subscribe) String() string {
+	toStr := ""
+	for i, e := range s.Events {
+		toStr += e.String()
+		if i == len(s.Events)-1 && len(s.Events) != 1 {
+			toStr += "&"
+		}
+	}
+	return toStr
+}

--- a/lib/common/observer/observer.go
+++ b/lib/common/observer/observer.go
@@ -2,6 +2,7 @@ package observer
 
 import (
 	"github.com/GianlucaGuarini/go-observable"
+	"strings"
 )
 
 var BlockAccountObserver = observable.New()
@@ -17,58 +18,50 @@ const (
 	ResourceTransactionPool = "txpool"
 	ResourceOperation       = "op"
 	ResourceAccount         = "ac"
-	ConditionAll            = "*"
-	ConditionSource         = "source"
-	ConditionTarget         = "target"
-	ConditionType           = "type"
-	ConditionOpHash         = "ophash"
-	ConditionTxHash         = "txhash"
-	ConditionAddress        = "address"
+	KeyAll                  = "*"
+	KeySource               = "source"
+	KeyTarget               = "target"
+	KeyType                 = "type"
+	KeyOpHash               = "ophash"
+	KeyTxHash               = "txhash"
+	KeyAddress              = "address"
 )
 
-type Event struct {
-	Resource  string `json:"resource"`
-	Condition string `json:"condition"`
-	Id        string `json:"id"`
+type Event interface {
+	Event() string
 }
 
-func NewEvent(resource, condition, id string) Event {
-	return Event{
-		Resource:  resource,
-		Condition: condition,
-		Id:        id,
+type Condition struct {
+	Resource string `json:"resource"`
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+}
+
+func NewCondition(resource, key, value string) Condition {
+	return Condition{
+		Resource: resource,
+		Key:      key,
+		Value:    value,
 	}
 }
-func (e Event) String() string {
-	toStr := e.Resource + "-"
-	if e.Condition == ConditionAll {
-		toStr += e.Condition
+
+func (c Condition) Event() string {
+	toStr := c.Resource + "-"
+	if c.Key == KeyAll {
+		toStr += c.Key
 	} else {
-		toStr += e.Condition + "="
-		toStr += e.Id
+		toStr += c.Key + "="
+		toStr += c.Value
 	}
 	return toStr
 }
 
-type Subscribe struct {
-	Events []Event `json:"resources"`
-}
+type Conditions []Condition
 
-func NewSubscribe(events ...Event) Subscribe {
-	s := Subscribe{}
-	for _, e := range events {
-		s.Events = append(s.Events, e)
+func (cs Conditions) Event() string {
+	var ss []string
+	for _, c := range cs {
+		ss = append(ss, c.Event())
 	}
-	return s
-}
-
-func (s Subscribe) String() string {
-	toStr := ""
-	for i, e := range s.Events {
-		toStr += e.String()
-		if i == len(s.Events)-1 && len(s.Events) != 1 {
-			toStr += "&"
-		}
-	}
-	return toStr
+	return strings.Join(ss, "&")
 }

--- a/lib/common/observer/observer.go
+++ b/lib/common/observer/observer.go
@@ -5,10 +5,6 @@ import (
 	"strings"
 )
 
-var BlockAccountObserver = observable.New()
-var BlockTransactionObserver = observable.New()
-var BlockObserver = observable.New()
-var BlockOperationObserver = observable.New()
 var SyncBlockWaitObserver = observable.New()
 
 var ResourceObserver = observable.New()

--- a/lib/common/observer/observer.go
+++ b/lib/common/observer/observer.go
@@ -16,6 +16,7 @@ const (
 	ResourceTransaction = "tx"
 	ResourceOperation   = "op"
 	ResourceAccount     = "ac"
+	ConditionAll        = "*"
 	ConditionSource     = "source"
 	ConditionTarget     = "target"
 	ConditionType       = "type"
@@ -39,8 +40,12 @@ func NewEvent(resource, condition, id string) Event {
 }
 func (e Event) String() string {
 	toStr := e.Resource + "-"
-	toStr += e.Condition + "="
-	toStr += e.Id
+	if e.Condition == ConditionAll {
+		toStr += e.Condition
+	} else {
+		toStr += e.Condition + "="
+		toStr += e.Id
+	}
 	return toStr
 }
 

--- a/lib/node/runner/api/account.go
+++ b/lib/node/runner/api/account.go
@@ -1,14 +1,12 @@
 package api
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
@@ -33,19 +31,6 @@ func (api NetworkHandlerAPI) GetAccountHandler(w http.ResponseWriter, r *http.Re
 		}
 		payload = resource.NewAccount(ba)
 		return payload, nil
-	}
-
-	if httputils.IsEventStream(r) {
-		event := fmt.Sprintf("address-%s", address)
-		es := NewEventStream(w, r, renderEventStream, DefaultContentType)
-		payload, err := readFunc()
-		if err != nil {
-			es.Render(nil)
-		} else {
-			es.Render(payload)
-		}
-		es.Run(observer.BlockAccountObserver, event)
-		return
 	}
 
 	payload, err := readFunc()
@@ -159,21 +144,6 @@ func (api NetworkHandlerAPI) GetFrozenAccountsByAccountHandler(w http.ResponseWr
 		return txs
 	}
 
-	if httputils.IsEventStream(r) {
-		event := fmt.Sprintf("linked-%s", address)
-		es := NewEventStream(w, r, renderEventStream, DefaultContentType)
-		txs := readFunc()
-		if len(txs) > 0 {
-			for _, tx := range txs {
-				es.Render(tx)
-			}
-		} else {
-			es.Render(nil)
-		}
-		es.Run(observer.BlockOperationObserver, event)
-		return
-	}
-
 	txs := readFunc()
 
 	list := p.ResourceList(txs, cursor)
@@ -277,21 +247,6 @@ func (api NetworkHandlerAPI) GetFrozenAccountsHandler(w http.ResponseWriter, r *
 		}
 		closeFunc()
 		return txs
-	}
-
-	if httputils.IsEventStream(r) {
-		event := "frozen"
-		es := NewEventStream(w, r, renderEventStream, DefaultContentType)
-		txs := readFunc()
-		if len(txs) > 0 {
-			for _, tx := range txs {
-				es.Render(tx)
-			}
-		} else {
-			es.Render(nil)
-		}
-		es.Run(observer.BlockOperationObserver, event)
-		return
 	}
 
 	txs := readFunc()

--- a/lib/node/runner/api/account_test.go
+++ b/lib/node/runner/api/account_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -48,45 +47,6 @@ func TestGetAccountHandler(t *testing.T) {
 		defer resp.Body.Close()
 
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
-	}
-}
-
-func TestGetAccountHandlerStream(t *testing.T) {
-
-	ts, storage := prepareAPIServer()
-	defer storage.Close()
-	defer ts.Close()
-	ba := block.TestMakeBlockAccount()
-	ba.MustSave(storage)
-
-	key := ba.Address
-
-	// Do a Request
-	var reader *bufio.Reader
-	{
-		url := strings.Replace(GetAccountHandlerPattern, "{id}", key, -1)
-		respBody := request(ts, url, true)
-		defer respBody.Close()
-		reader = bufio.NewReader(respBody)
-	}
-
-	// Save
-	{
-		ba.MustSave(storage)
-	}
-
-	// Check the output
-	{
-		line, err := reader.ReadBytes('\n')
-		line = bytes.Trim(line, "\n")
-		if len(line) == 0 {
-			line, err = reader.ReadBytes('\n')
-			require.NoError(t, err)
-			line = bytes.Trim(line, "\n")
-		}
-		recv := make(map[string]interface{})
-		json.Unmarshal(line, &recv)
-		require.Equal(t, key, recv["address"], "address is not same")
 	}
 }
 

--- a/lib/node/runner/api/api.go
+++ b/lib/node/runner/api/api.go
@@ -101,6 +101,7 @@ func TriggerEvent(st *storage.LevelDBBackend, transactions []*transaction.Transa
 		accountBlock, _ := block.GetBlockAccount(st, account)
 		go observer.ResourceObserver.Trigger(accEvent, accountBlock)
 	}
+
 }
 
 func renderEventStream(args ...interface{}) ([]byte, error) {

--- a/lib/node/runner/api/api.go
+++ b/lib/node/runner/api/api.go
@@ -67,13 +67,15 @@ func TriggerEvent(st *storage.LevelDBBackend, transactions []*transaction.Transa
 		accountMap[source] = struct{}{}
 		txHash := tx.H.Hash
 
-		txEvent := observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionSource, source)).String()
+		txEvent := observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionAll, "")).String()
+		txEvent += " " + observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionSource, source)).String()
 		txEvent += " " + observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionTxHash, txHash)).String()
 
 		for _, op := range tx.B.Operations {
 			opHash := fmt.Sprintf("%s-%s", op.MakeHashString(), txHash)
 
-			opEvent := observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionTxHash, txHash)).String()
+			opEvent := observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionAll, "")).String()
+			opEvent += " " + observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionTxHash, txHash)).String()
 			opEvent += " " + observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionOpHash, opHash)).String()
 
 			opEvent += " " + observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionSource, source)).String()
@@ -94,7 +96,8 @@ func TriggerEvent(st *storage.LevelDBBackend, transactions []*transaction.Transa
 
 	}
 	for account, _ := range accountMap {
-		accEvent := observer.NewSubscribe(observer.NewEvent(observer.ResourceAccount, observer.ConditionAddress, account)).String()
+		accEvent := observer.NewSubscribe(observer.NewEvent(observer.ResourceAccount, observer.ConditionAll, "")).String()
+		accEvent += " " + observer.NewSubscribe(observer.NewEvent(observer.ResourceAccount, observer.ConditionAddress, account)).String()
 		accountBlock, _ := block.GetBlockAccount(st, account)
 		go observer.ResourceObserver.Trigger(accEvent, accountBlock)
 	}

--- a/lib/node/runner/api/blocks.go
+++ b/lib/node/runner/api/blocks.go
@@ -6,7 +6,6 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/storage"
@@ -31,9 +30,6 @@ func (api NetworkHandlerAPI) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 			height = common.GenesisBlockHeight // default cursor is genesis block height
 		}
 		option = storage.NewWalkOption(block.GetBlockKeyPrefixHeight(height), p.Limit(), p.Reverse(), false)
-		if httputils.IsEventStream(r) {
-			option.Limit = 10
-		}
 	}
 
 	{
@@ -55,19 +51,6 @@ func (api NetworkHandlerAPI) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 			return
 
 		}
-	}
-
-	if httputils.IsEventStream(r) {
-		es := NewEventStream(w, r, renderEventStream, DefaultContentType)
-		if len(blocks) > 0 {
-			for _, b := range blocks {
-				es.Render(b)
-			}
-		} else {
-			es.Render(nil)
-		}
-		es.Run(observer.BlockObserver, block.EventBlockPrefix)
-		return
 	}
 
 	list := p.ResourceList(blocks, cursor)

--- a/lib/node/runner/api/blocks_test.go
+++ b/lib/node/runner/api/blocks_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"testing"
@@ -64,44 +63,5 @@ func TestBlocksHandler(t *testing.T) {
 			b := records[9-i].(map[string]interface{})
 			require.Equal(t, a.Hash, b["hash"])
 		}
-	}
-}
-
-func TestBlocksHandlerStream(t *testing.T) {
-
-	ts, st := prepareAPIServer()
-	defer st.Close()
-	defer ts.Close()
-
-	genesis := block.GetLatestBlock(st)
-	b := block.TestMakeNewBlockWithPrevBlock(genesis, []string{})
-
-	// Do a Request
-	var reader *bufio.Reader
-	{
-		url := GetBlocksHandlerPattern + "?cursor=2"
-		respBody := request(ts, url, true)
-		defer respBody.Close()
-		reader = bufio.NewReader(respBody)
-	}
-
-	// Save
-	{
-		b.MustSave(st)
-	}
-
-	// Check the output
-	{
-		line, err := reader.ReadBytes('\n')
-		line = bytes.Trim(line, "\n")
-		if len(line) == 0 {
-			line, err = reader.ReadBytes('\n')
-			require.NoError(t, err)
-			line = bytes.Trim(line, "\n")
-		}
-		recv := make(map[string]interface{})
-		json.Unmarshal(line, &recv)
-		require.Equal(t, b.Hash, recv["hash"], "hash is not the same")
-		require.Equal(t, b.Height, uint64(recv["height"].(float64)), "height is not the same")
 	}
 }

--- a/lib/node/runner/api/operation_test.go
+++ b/lib/node/runner/api/operation_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bufio"
-	"bytes"
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
@@ -13,7 +12,6 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/transaction/operation"
 )
 
@@ -119,64 +117,4 @@ func TestGetOperationsByAccountHandlerWithType(t *testing.T) {
 		}
 	}
 
-}
-
-func TestGetOperationsByAccountHandlerStream(t *testing.T) {
-
-	ts, storage := prepareAPIServer()
-	defer ts.Close()
-
-	boMap := make(map[string]block.BlockOperation)
-	kp, blk, boList := prepareOpsWithoutSave(10, storage)
-
-	for _, bo := range boList {
-		boMap[bo.Hash] = bo
-	}
-	ba := block.NewBlockAccount(kp.Address(), common.Amount(common.BaseReserve))
-	ba.MustSave(storage)
-
-	// Do a Request
-	var reader *bufio.Reader
-	{
-		url := strings.Replace(GetAccountOperationsHandlerPattern, "{id}", kp.Address(), -1)
-		respBody := request(ts, url, true)
-		defer respBody.Close()
-		reader = bufio.NewReader(respBody)
-	}
-
-	// Save
-	{
-		blk.MustSave(storage)
-		for _, bo := range boMap {
-			bo.MustSave(storage)
-		}
-	}
-
-	// Check the output
-	{
-		// Do stream Request to the Server
-		for n := 0; n < 10; n++ {
-			line, err := reader.ReadBytes('\n')
-			line = bytes.Trim(line, "\n")
-			if len(line) == 0 {
-				line, err = reader.ReadBytes('\n')
-				require.NoError(t, err)
-				line = bytes.Trim(line, "\n")
-			}
-			recv := make(map[string]interface{})
-			json.Unmarshal(line, &recv)
-
-			bo := boMap[recv["hash"].(string)]
-			r := resource.NewOperation(&bo)
-			r.Block = &blk
-			txS, err := json.Marshal(r.Resource())
-			require.NoError(t, err)
-			require.Equal(t, txS, line)
-
-			require.Equal(t, blk.ProposedTime, recv["proposed_time"].(string))
-			require.Equal(t, blk.Confirmed, recv["confirmed"].(string))
-		}
-	}
-
-	storage.Close()
 }

--- a/lib/node/runner/api/stream.go
+++ b/lib/node/runner/api/stream.go
@@ -30,15 +30,15 @@ func (api NetworkHandlerAPI) PostSubscribeHandler(w http.ResponseWriter, r *http
 		httputils.WriteJSONError(w, errors.BadRequestParameter)
 		return
 	}
-	var requestParams []observer.Subscribe
+	var requestParams []observer.Conditions
 	if err := json.Unmarshal(body, &requestParams); err != nil {
 		httputils.WriteJSONError(w, errors.BadRequestParameter)
 		return
 	}
 
 	var events []string
-	for _, subscribe := range requestParams {
-		events = append(events, subscribe.String())
+	for _, conditions := range requestParams {
+		events = append(events, conditions.Event())
 	}
 
 	es := NewEventStream(w, r, renderEventStream, DefaultContentType)

--- a/lib/node/runner/api/stream.go
+++ b/lib/node/runner/api/stream.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"boscoin.io/sebak/lib/common/observer"
+	"boscoin.io/sebak/lib/errors"
 	"encoding/json"
 	"fmt"
+	"github.com/gorilla/mux"
 	"net/http"
 	"strings"
 
-	observable "github.com/GianlucaGuarini/go-observable"
+	"github.com/GianlucaGuarini/go-observable"
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network/httputils"
@@ -14,6 +17,17 @@ import (
 
 // DefaultContentType is "application/json"
 const DefaultContentType = "application/json"
+
+func (api NetworkHandlerAPI) GetSubscribeHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	event := vars["resource"]
+	if !httputils.IsEventStream(r) {
+		httputils.WriteJSONError(w, errors.BadRequestParameter)
+	}
+
+	es := NewEventStream(w, r, renderEventStream, DefaultContentType)
+	es.Run(observer.XXXObserver, event)
+}
 
 // EventStream handles chunked responses of a observable trigger
 //

--- a/lib/node/runner/api/stream_test.go
+++ b/lib/node/runner/api/stream_test.go
@@ -37,7 +37,7 @@ func TestAccountStream(t *testing.T) {
 	var txReader *bufio.Reader
 	var opReader *bufio.Reader
 	{
-		s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceAccount, observer.ConditionAddress, ba.Address))}
+		s := []observer.Conditions{{observer.NewCondition(observer.ResourceAccount, observer.KeyAddress, ba.Address)}}
 		b, err := json.Marshal(s)
 		require.NoError(t, err)
 		respBody := request(ts, PostSubscribePattern, true, b)
@@ -45,7 +45,7 @@ func TestAccountStream(t *testing.T) {
 		acReader = bufio.NewReader(respBody)
 	}
 	{
-		s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionTxHash, bt.Hash))}
+		s := []observer.Conditions{{observer.NewCondition(observer.ResourceTransaction, observer.KeyTxHash, bt.Hash)}}
 		b, err := json.Marshal(s)
 		require.NoError(t, err)
 		respBody := request(ts, PostSubscribePattern, true, b)
@@ -53,7 +53,7 @@ func TestAccountStream(t *testing.T) {
 		txReader = bufio.NewReader(respBody)
 	}
 	{
-		s := []observer.Subscribe{observer.NewSubscribe(observer.NewEvent(observer.ResourceOperation, observer.ConditionOpHash, bo.Hash))}
+		s := []observer.Conditions{{observer.NewCondition(observer.ResourceOperation, observer.KeyOpHash, bo.Hash)}}
 		b, err := json.Marshal(s)
 		require.NoError(t, err)
 		respBody := request(ts, PostSubscribePattern, true, b)

--- a/lib/node/runner/api/stream_test.go
+++ b/lib/node/runner/api/stream_test.go
@@ -10,11 +10,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"boscoin.io/sebak/lib/block"
-	observable "github.com/GianlucaGuarini/go-observable"
+	"github.com/GianlucaGuarini/go-observable"
 
 	"github.com/stretchr/testify/require"
 )
@@ -107,53 +106,6 @@ func TestAccountStream(t *testing.T) {
 		require.Equal(t, bo.Hash, recv["hash"], "hash is not same")
 	}
 
-}
-
-func TestTransactionStream(t *testing.T) {
-
-}
-
-func TestOperationStream(t *testing.T) {
-
-}
-
-func TestGetAccountHandlerStream(t *testing.T) {
-
-	ts, storage := prepareAPIServer()
-	defer storage.Close()
-	defer ts.Close()
-	ba := block.TestMakeBlockAccount()
-	ba.MustSave(storage)
-
-	key := ba.Address
-
-	// Do a Request
-	var reader *bufio.Reader
-	{
-		url := strings.Replace(GetAccountHandlerPattern, "{id}", key, -1)
-		respBody := request(ts, url, true)
-		defer respBody.Close()
-		reader = bufio.NewReader(respBody)
-	}
-
-	// Save
-	{
-		ba.MustSave(storage)
-	}
-
-	// Check the output
-	{
-		line, err := reader.ReadBytes('\n')
-		line = bytes.Trim(line, "\n")
-		if len(line) == 0 {
-			line, err = reader.ReadBytes('\n')
-			require.NoError(t, err)
-			line = bytes.Trim(line, "\n")
-		}
-		recv := make(map[string]interface{})
-		json.Unmarshal(line, &recv)
-		require.Equal(t, key, recv["address"], "address is not same")
-	}
 }
 
 func TestAPIStreamRun(t *testing.T) {

--- a/lib/node/runner/api/transaction.go
+++ b/lib/node/runner/api/transaction.go
@@ -145,8 +145,8 @@ func (api NetworkHandlerAPI) GetTransactionStatusByHashHandler(w http.ResponseWr
 		}
 
 		var events []string
-		events = append(events, observer.NewSubscribe(observer.NewEvent(observer.ResourceTransaction, observer.ConditionTxHash, key)).String())
-		events = append(events, observer.NewSubscribe(observer.NewEvent(observer.ResourceTransactionPool, observer.ConditionTxHash, key)).String())
+		events = append(events, observer.NewCondition(observer.ResourceTransaction, observer.KeyTxHash, key).Event())
+		events = append(events, observer.NewCondition(observer.ResourceTransactionPool, observer.KeyTxHash, key).Event())
 
 		es := NewEventStream(w, r, txStatusRenderFunc, DefaultContentType)
 		es.Render(payload)

--- a/lib/node/runner/api/transaction.go
+++ b/lib/node/runner/api/transaction.go
@@ -38,22 +38,6 @@ func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *ht
 		return txs
 	}
 
-	if httputils.IsEventStream(r) {
-		event := "saved"
-		es := NewEventStream(w, r, renderEventStream, DefaultContentType)
-		options.SetLimit(10)
-		txs := readFunc()
-		if len(txs) > 0 {
-			for _, tx := range txs {
-				es.Render(tx)
-			}
-		} else {
-			es.Render(nil)
-		}
-		es.Run(observer.BlockTransactionObserver, event)
-		return
-	}
-
 	txs := readFunc()
 
 	list := p.ResourceList(txs, cursor)

--- a/lib/node/runner/api/transaction.go
+++ b/lib/node/runner/api/transaction.go
@@ -64,18 +64,6 @@ func (api NetworkHandlerAPI) GetTransactionByHashHandler(w http.ResponseWriter, 
 		return payload, nil
 	}
 
-	if httputils.IsEventStream(r) {
-		event := fmt.Sprintf("hash-%s", key)
-		es := NewEventStream(w, r, renderEventStream, DefaultContentType)
-		payload, err := readFunc()
-		if err == nil {
-			es.Render(payload)
-		} else {
-			es.Render(nil)
-		}
-		es.Run(observer.BlockTransactionObserver, event)
-		return
-	}
 	payload, err := readFunc()
 	if err == nil {
 		httputils.MustWriteJSON(w, 200, payload)
@@ -109,22 +97,6 @@ func (api NetworkHandlerAPI) GetTransactionsByAccountHandler(w http.ResponseWrit
 		}
 		closeFunc()
 		return txs
-	}
-
-	if httputils.IsEventStream(r) {
-		event := fmt.Sprintf("source-%s", address)
-		es := NewEventStream(w, r, renderEventStream, DefaultContentType)
-		options.SetLimit(10)
-		txs := readFunc()
-		if len(txs) > 0 {
-			for _, tx := range txs {
-				es.Render(tx)
-			}
-		} else {
-			es.Render(nil)
-		}
-		es.Run(observer.BlockTransactionObserver, event)
-		return
 	}
 
 	txs := readFunc()

--- a/lib/node/runner/api/tx_operations.go
+++ b/lib/node/runner/api/tx_operations.go
@@ -1,14 +1,11 @@
 package api
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 
 	"github.com/gorilla/mux"
 
 	"boscoin.io/sebak/lib/block"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
@@ -31,51 +28,6 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter,
 	}
 
 	options := p.ListOptions()
-
-	if httputils.IsEventStream(r) {
-		var blk *block.Block
-		es := NewEventStream(
-			w,
-			r,
-			func(args ...interface{}) ([]byte, error) {
-				if len(args) <= 1 {
-					return nil, fmt.Errorf("render: value is empty")
-				}
-				i := args[1]
-
-				if i == nil {
-					return []byte{}, nil
-				}
-
-				if blk == nil {
-					if blk, err = api.getBlockByTxHash(hash); err != nil {
-						return nil, err
-					}
-				}
-
-				r := resource.NewOperation(i.(*block.BlockOperation))
-				r.Block = blk
-				return json.Marshal(r.Resource())
-			},
-			DefaultContentType,
-		)
-
-		var err error
-		var ops []resource.Resource
-		if blk, err = api.getBlockByTxHash(hash); err == nil {
-			ops, _ = api.getOperationsByTxHash(hash, blk, options)
-		}
-
-		if len(ops) > 0 {
-			for _, op := range ops {
-				es.Render(op)
-			}
-		} else {
-			es.Render(nil)
-		}
-		es.Run(observer.BlockOperationObserver, fmt.Sprintf("txhash-%s", hash))
-		return
-	}
 
 	var blk *block.Block
 	if blk, err = api.getBlockByTxHash(hash); err != nil {

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -42,17 +42,18 @@ func (c CheckerStopCloseConsensus) Checker() common.Checker {
 type BallotChecker struct {
 	common.DefaultChecker
 
-	NodeRunner         *NodeRunner
-	LocalNode          *node.LocalNode
-	Message            common.NetworkMessage
-	IsNew              bool
-	IsMine             bool
-	Ballot             ballot.Ballot
-	VotingHole         voting.Hole
-	Result             consensus.RoundVoteResult
-	VotingFinished     bool
-	FinishedVotingHole voting.Hole
-	LatestBlockSources []string
+	NodeRunner                 *NodeRunner
+	LocalNode                  *node.LocalNode
+	Message                    common.NetworkMessage
+	IsNew                      bool
+	IsMine                     bool
+	Ballot                     ballot.Ballot
+	VotingHole                 voting.Hole
+	Result                     consensus.RoundVoteResult
+	VotingFinished             bool
+	FinishedVotingHole         voting.Hole
+	LatestBlockSources         []string
+	StoredProposedTransactions []*transaction.Transaction
 
 	Log logging.Logger
 }
@@ -683,6 +684,8 @@ func saveBlock(checker *BallotChecker) error {
 		checker.LatestBlockSources = append(checker.LatestBlockSources, tx.B.Source)
 	}
 	checker.NodeRunner.SavingBlockOperations().Save(*theBlock)
+
+	checker.StoredProposedTransactions = proposedTransactions
 
 	return nil
 }

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -43,18 +43,17 @@ func (c CheckerStopCloseConsensus) Checker() common.Checker {
 type BallotChecker struct {
 	common.DefaultChecker
 
-	NodeRunner                 *NodeRunner
-	LocalNode                  *node.LocalNode
-	Message                    common.NetworkMessage
-	IsNew                      bool
-	IsMine                     bool
-	Ballot                     ballot.Ballot
-	VotingHole                 voting.Hole
-	Result                     consensus.RoundVoteResult
-	VotingFinished             bool
-	FinishedVotingHole         voting.Hole
-	LatestBlockSources         []string
-	StoredProposedTransactions []*transaction.Transaction
+	NodeRunner         *NodeRunner
+	LocalNode          *node.LocalNode
+	Message            common.NetworkMessage
+	IsNew              bool
+	IsMine             bool
+	Ballot             ballot.Ballot
+	VotingHole         voting.Hole
+	Result             consensus.RoundVoteResult
+	VotingFinished     bool
+	FinishedVotingHole voting.Hole
+	LatestBlockSources []string
 
 	Log logging.Logger
 }
@@ -662,8 +661,6 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 	}
 	delete(checker.NodeRunner.Consensus().RunningRounds, basis.Index())
 
-	go api.TriggerEvent(checker.NodeRunner.Storage(), checker.StoredProposedTransactions)
-
 	return err
 }
 
@@ -688,7 +685,7 @@ func saveBlock(checker *BallotChecker) error {
 	}
 	checker.NodeRunner.SavingBlockOperations().Save(*theBlock)
 
-	checker.StoredProposedTransactions = proposedTransactions
+	go api.TriggerEvent(checker.NodeRunner.Storage(), proposedTransactions)
 
 	return nil
 }

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"boscoin.io/sebak/lib/node/runner/api"
 	"bufio"
 	"bytes"
 	"io"
@@ -660,6 +661,8 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 		return errors.New("invalid voting.Hole, `NOTYET`")
 	}
 	delete(checker.NodeRunner.Consensus().RunningRounds, basis.Index())
+
+	go api.TriggerEvent(checker.NodeRunner.Storage(), checker.StoredProposedTransactions)
 
 	return err
 }

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -552,8 +552,6 @@ func (nr *NodeRunner) handleBallotMessage(msg interface{}) (err error) {
 			nr.log.Debug("failed to handle ballot", "error", err, "state", baseChecker.Ballot.State())
 			return
 		}
-
-		api.TriggerEvent(nr.storage, checker.StoredProposedTransactions)
 	}
 
 	return

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -313,6 +313,10 @@ func (nr *NodeRunner) Ready() {
 		apiHandler.HandlerURLPattern(api.GetTransactionStatusHandlerPattern),
 		listCache.WrapHandlerFunc(apiHandler.GetTransactionStatusByHashHandler),
 	).Methods("GET", "OPTIONS")
+	nr.network.AddHandler(
+		apiHandler.HandlerURLPattern(api.PostSubscribePattern),
+		listCache.WrapHandlerFunc(apiHandler.PostSubscribeHandler),
+	).Methods("POST", "OPTIONS")
 
 	TransactionsHandler := func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == "POST" {
@@ -548,6 +552,8 @@ func (nr *NodeRunner) handleBallotMessage(msg interface{}) (err error) {
 			nr.log.Debug("failed to handle ballot", "error", err, "state", baseChecker.Ballot.State())
 			return
 		}
+
+		api.TriggerEvent(nr.storage, checker.StoredProposedTransactions)
 	}
 
 	return

--- a/lib/storage/statedb/state_object.go
+++ b/lib/storage/statedb/state_object.go
@@ -3,10 +3,8 @@ package statedb
 import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/storage/statedb/trie"
 	"bytes"
-	"fmt"
 )
 
 type Storage map[common.Hash]common.Hash
@@ -209,11 +207,6 @@ func (so *stateObject) Save() (err error) {
 		err = st.New(key, so.data)
 		createdKey := block.GetBlockAccountCreatedKey(common.GetUniqueIDFromUUID())
 		err = st.New(createdKey, so.Address())
-	}
-	if err == nil {
-		event := "saved"
-		event += " " + fmt.Sprintf("address-%s", so.Address())
-		observer.BlockAccountObserver.Trigger(event, &so.data)
 	}
 
 	bac := block.BlockAccountSequenceID{

--- a/lib/transaction/operation/operation.go
+++ b/lib/transaction/operation/operation.go
@@ -109,6 +109,10 @@ type Payable interface {
 	GetAmount() common.Amount
 }
 
+type Tagetable interface {
+	TargetAddress() string
+}
+
 func (o Operation) MakeHash() []byte {
 	return common.MustMakeObjectHash(o)
 }

--- a/tests/client/account_test.go
+++ b/tests/client/account_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"strconv"
 	"testing"
-	"time"
 
 	"boscoin.io/sebak/lib/client"
 	"boscoin.io/sebak/lib/common"
@@ -57,28 +56,11 @@ func TestAccount(t *testing.T) {
 		body, err := tx.Serialize()
 		require.NoError(t, err)
 
-		_, err = c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.NoError(t, err)
 
-		var e error
-		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
-			_, e = c.LoadTransaction(tx.H.Hash)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
-
-		var targetAccount client.Account
-		for second := time.Duration(0); second < time.Second*3; second = second + time.Millisecond*500 {
-			targetAccount, e = c.LoadAccount(account1Addr)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
+		targetAccount, err := c.LoadAccount(account1Addr)
+		require.NoError(t, err)
 
 		targetBalance, err := strconv.ParseUint(targetAccount.Balance, 10, 64)
 		require.NoError(t, err)
@@ -116,28 +98,11 @@ func TestAccount(t *testing.T) {
 		body, err := tx.Serialize()
 		require.NoError(t, err)
 
-		_, err = c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.NoError(t, err)
 
-		var e error
-		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
-			_, e = c.LoadTransaction(tx.H.Hash)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
-
-		var account2Account client.Account
-		for second := time.Duration(0); second < time.Second*3; second = second + time.Millisecond*500 {
-			account2Account, e = c.LoadAccount(account2Addr)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
+		account2Account, err := c.LoadAccount(account2Addr)
+		require.NoError(t, err)
 
 		targetBalance, err := strconv.ParseUint(account2Account.Balance, 10, 64)
 		require.NoError(t, err)
@@ -176,28 +141,11 @@ func TestAccount(t *testing.T) {
 		body, err := tx.Serialize()
 		require.NoError(t, err)
 
-		_, err = c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.NoError(t, err)
 
-		var e error
-		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
-			_, e = c.LoadTransaction(tx.H.Hash)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
-
-		var account2Account client.Account
-		for second := time.Duration(0); second < time.Second*3; second = second + time.Millisecond*500 {
-			account2Account, e = c.LoadAccount(account2Addr)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
+		account2Account, err := c.LoadAccount(account2Addr)
+		require.NoError(t, err)
 
 		targetBalance, err := strconv.ParseUint(account2Account.Balance, 10, 64)
 		require.NoError(t, err)
@@ -236,19 +184,8 @@ func TestAccount(t *testing.T) {
 		body, err := tx.Serialize()
 		require.Nil(t, err)
 
-		pt, err := c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.Nil(t, err)
-
-		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
-			th, err := c.LoadTransactionStatus(pt.Hash)
-			if err != nil {
-				t.Log(err)
-			}
-			if th.Status == "confimed" {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
 
 		account2Account, err := c.LoadAccount(account2Addr)
 		require.Nil(t, err)

--- a/tests/client/congressvoting_inflationpf_test.go
+++ b/tests/client/congressvoting_inflationpf_test.go
@@ -3,20 +3,16 @@
 package client
 
 import (
-	"net/http"
-	"strconv"
-	"testing"
-	"time"
-
-	"encoding/json"
-
-	"github.com/stellar/go/keypair"
-	"github.com/stretchr/testify/require"
-
 	"boscoin.io/sebak/lib/client"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"
+	"encoding/json"
+	"github.com/stellar/go/keypair"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"strconv"
+	"testing"
 )
 
 func TestInflationPF(t *testing.T) {
@@ -73,18 +69,8 @@ func TestInflationPF(t *testing.T) {
 		body, err := tx.Serialize()
 		require.NoError(t, err)
 
-		_, err = c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.NoError(t, err)
-
-		var e error
-		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
-			_, e = c.LoadTransaction(tx.H.Hash)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
 
 		opage, err := c.LoadOperationsByAccount(CongressAddr, client.Q{Key: client.QueryType, Value: "congress-voting"})
 		require.NoError(t, err)
@@ -138,18 +124,8 @@ func TestInflationPF(t *testing.T) {
 		body, err := tx.Serialize()
 		require.NoError(t, err)
 
-		_, err = c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.NoError(t, err)
-
-		var e error
-		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
-			_, e = c.LoadTransaction(tx.H.Hash)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
 
 		opage, err := c.LoadOperationsByAccount(CongressAddr, client.Q{Key: client.QueryType, Value: "congress-voting-result"})
 		require.NoError(t, err)
@@ -203,18 +179,8 @@ func TestInflationPF(t *testing.T) {
 		body, err := tx.Serialize()
 		require.NoError(t, err)
 
-		_, err = c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.NoError(t, err)
-
-		var e error
-		for second := time.Duration(0); second < time.Second*10; second = second + time.Millisecond*500 {
-			_, e = c.LoadTransaction(tx.H.Hash)
-			if e == nil {
-				break
-			}
-			time.Sleep(time.Millisecond * 500)
-		}
-		require.Nil(t, e)
 
 		targetAccount, err = c.LoadAccount(account1Addr)
 		require.Nil(t, err)

--- a/tests/client/const.go
+++ b/tests/client/const.go
@@ -1,6 +1,8 @@
+// +build client_integration_tests
+
 package client
 
 const (
 	NETWORK_ID = "sebak-test-network"
-	fee        = 10000
+	fee        = uint64(10000)
 )

--- a/tests/client/freezing_test.go
+++ b/tests/client/freezing_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestFreezingAccount(t *testing.T) {
@@ -97,7 +98,7 @@ func TestFreezingAccount(t *testing.T) {
 
 	// Refund
 	{
-
+		time.Sleep(time.Second * 10 ) //wait for block period
 		account2Account, err := c.LoadAccount(account2Addr)
 		require.NoError(t, err)
 

--- a/tests/client/freezing_test.go
+++ b/tests/client/freezing_test.go
@@ -64,7 +64,7 @@ func TestFreezingAccount(t *testing.T) {
 		var account2Account client.Account
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamAccount(ctx, account2Addr, nil, func(account client.Account) {
+			err = c.StreamAccount(ctx, account2Addr, func(account client.Account) {
 				if account.Address != "" {
 					account2Account = account
 					cancel()
@@ -145,7 +145,7 @@ func TestFreezingAccount(t *testing.T) {
 
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamAccount(ctx, account1Addr, nil, func(account client.Account) {
+			err = c.StreamAccount(ctx, account1Addr, func(account client.Account) {
 				if account1Account.Balance != account.Balance {
 					account1Account = account
 					cancel()
@@ -157,7 +157,7 @@ func TestFreezingAccount(t *testing.T) {
 
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamAccount(ctx, account2Addr, nil, func(account client.Account) {
+			err = c.StreamAccount(ctx, account2Addr, func(account client.Account) {
 				if account2Account.Balance != account.Balance {
 					account2Account = account
 					cancel()

--- a/tests/client/test.go
+++ b/tests/client/test.go
@@ -58,7 +58,7 @@ func createAccount(t *testing.T, fromAddr, fromSecret, toAddr string, balance ui
 	var toAccount client.Account
 	go func() {
 		ctx, cancel := context.WithCancel(context.Background())
-		err = c.StreamAccount(ctx, toAddr, nil, func(account client.Account) {
+		err = c.StreamAccount(ctx, toAddr, func(account client.Account) {
 			toAccount = account
 			cancel()
 		})
@@ -68,7 +68,7 @@ func createAccount(t *testing.T, fromAddr, fromSecret, toAddr string, balance ui
 
 	go func() {
 		ctx, cancel := context.WithCancel(context.Background())
-		err = c.StreamAccount(ctx, fromAddr, nil, func(account client.Account) {
+		err = c.StreamAccount(ctx, fromAddr, func(account client.Account) {
 			if account.SequenceID != fromAccount.SequenceID {
 				fromAccount = account
 				cancel()

--- a/tests/client/transaction_status_test.go
+++ b/tests/client/transaction_status_test.go
@@ -7,12 +7,10 @@ import (
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"
-	"context"
 	"github.com/stellar/go/keypair"
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"strconv"
-	"sync"
 	"testing"
 )
 
@@ -55,51 +53,18 @@ func TestTransactionStatus(t *testing.T) {
 		body, err := tx.Serialize()
 		require.NoError(t, err)
 
-		var wg sync.WaitGroup
-		wg.Add(3)
-
-		go func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamTransactionStatus(ctx, tx.H.Hash, nil, func(status client.TransactionStatus) {
-				if status.Status == "confirmed" {
-					cancel()
-				}
-			})
-			require.NoError(t, err)
-			wg.Done()
-		}()
-
-		var targetAccount client.Account
-		go func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamAccount(ctx, account1Addr, func(account client.Account) {
-				targetAccount = account
-				cancel()
-			})
-			require.NoError(t, err)
-			wg.Done()
-		}()
-
-		go func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamAccount(ctx, genesisAddr, func(account client.Account) {
-				if account.SequenceID != genesisAccount.SequenceID {
-					genesisAccount = account
-					cancel()
-				}
-			})
-			require.NoError(t, err)
-			wg.Done()
-		}()
-
-		_, err = c.SubmitTransaction(body)
+		_, err = c.SubmitTransactionAndWait(tx.H.Hash, body)
 		require.NoError(t, err)
 
-		wg.Wait()
+		targetAccount, err := c.LoadAccount(account1Addr)
+		require.NoError(t, err)
 
 		targetBalance, err := strconv.ParseUint(targetAccount.Balance, 10, 64)
 		require.NoError(t, err)
 		require.Equal(t, uint64(genesisToAccount1), targetBalance)
+
+		genesisAccount, err = c.LoadAccount(genesisAddr)
+		require.NoError(t, err)
 
 		genesisBalance2, err := strconv.ParseUint(genesisAccount.Balance, 10, 64)
 		require.NoError(t, err)

--- a/tests/client/transaction_status_test.go
+++ b/tests/client/transaction_status_test.go
@@ -72,7 +72,7 @@ func TestTransactionStatus(t *testing.T) {
 		var targetAccount client.Account
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamAccount(ctx, account1Addr, nil, func(account client.Account) {
+			err = c.StreamAccount(ctx, account1Addr, func(account client.Account) {
 				targetAccount = account
 				cancel()
 			})
@@ -82,7 +82,7 @@ func TestTransactionStatus(t *testing.T) {
 
 		go func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			err = c.StreamAccount(ctx, genesisAddr, nil, func(account client.Account) {
+			err = c.StreamAccount(ctx, genesisAddr, func(account client.Account) {
 				if account.SequenceID != genesisAccount.SequenceID {
 					genesisAccount = account
 					cancel()


### PR DESCRIPTION
### Github Issue
#788 

### Background
* `Streaming mode` for API is very complicated and not easy to use
* Event and DB writing time issue #788 

### Solution
* Remove Streaming mode from APIs
* Add `Subscribe` API to handle the requirements
* one Observer is needed
* Event structure for register and trigger event
* client code is revised

* NOW easy to use the streaming MODE~

### Possible Drawbacks
Need to update API documentation

