### PR TITLE
Fix `reverse=true`

### DIFF
--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -312,7 +312,7 @@ func (st *LevelDBBackend) GetIterator(prefix string, option ListOptions) (func()
 	var funcNext func() bool
 	var hasUnsent bool
 	if reverse {
-		if !iter.Last() {
+		if cursor == nil && !iter.Last() {
 			iter.Release()
 			return func() (IterItem, bool) { return IterItem{}, false }, func() {}
 		}


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

Fixes #758 

### Background

https://godoc.org/github.com/syndtr/goleveldb/leveldb/iterator

```
    // Last moves the iterator to the last key/value pair. If the iterator
    // only contains one key/value pair then First and Last would moves
    // to the same key/value pair.
    // It returns whether such pair exist.
    Last() bool

    // Seek moves the iterator to the first key/value pair whose key is greater
    // than or equal to the given key.
    // It returns whether such pair exist.
    //
    // It is safe to modify the contents of the argument after Seek returns.
    Seek(key []byte) bool
```


### Solution

- `if cursor == nil && !iter.Last() {`
- Add `reverse=true` test

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

Iter is so hard for me. ㅠㅠ
