### PR TITLE
Fixed Panic Error: returned `RunningRound` is not found

### DIFF
--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -2,7 +2,6 @@ package consensus
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -11,6 +10,7 @@ import (
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
@@ -210,7 +210,14 @@ func (is *ISAAC) Vote(b ballot.Ballot) (isNew bool, err error) {
 func (is *ISAAC) CanGetVotingResult(b ballot.Ballot) (RoundVoteResult, voting.Hole, bool) {
 	is.RLock()
 	defer is.RUnlock()
-	runningRound, _ := is.RunningRounds[b.VotingBasis().Index()]
+
+	is.log.Debug("CanGetVotingResult", "ballot", b)
+	runningRound, found := is.RunningRounds[b.VotingBasis().Index()]
+	if !found {
+		// if RunningRound is not found, this ballot will be stopped.
+		return nil, voting.NOTYET, true
+	}
+
 	if roundVote, err := runningRound.RoundVote(b.Proposer()); err == nil {
 		return roundVote.CanGetVotingResult(is.policy, b.State(), is.log)
 	} else {
@@ -221,7 +228,12 @@ func (is *ISAAC) CanGetVotingResult(b ballot.Ballot) (RoundVoteResult, voting.Ho
 func (is *ISAAC) IsVotedByNode(b ballot.Ballot, node string) (bool, error) {
 	is.RLock()
 	defer is.RUnlock()
-	runningRound, _ := is.RunningRounds[b.VotingBasis().Index()]
+
+	runningRound, found := is.RunningRounds[b.VotingBasis().Index()]
+	if !found {
+		return false, errors.RoundVoteNotFound
+	}
+
 	if roundVote, err := runningRound.RoundVote(b.Proposer()); err == nil {
 		return roundVote.IsVotedByNode(b.State(), node), nil
 	} else {

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -374,6 +374,10 @@ func BallotCheckResult(c common.Checker, args ...interface{}) (err error) {
 	}
 
 	result, votingHole, finished := checker.NodeRunner.Consensus().CanGetVotingResult(checker.Ballot)
+	if votingHole == voting.NOTYET && finished {
+		err = NewCheckerStopCloseConsensus(checker, "ballot already finished")
+		return
+	}
 
 	checker.Result = result
 	checker.VotingFinished = finished


### PR DESCRIPTION
### Github Issue

Resolves #792 

### Background

See #792 , especially check this comment, https://github.com/bosnet/sebak/issues/792#issuecomment-441146625 .

### Solution

Added checking part whether the returned `RunningRound` exists or not.