### PR TITLE
Add hash to infolog in finish ballot

### DIFF
--- a/lib/node/runner/finish_ballot.go
+++ b/lib/node/runner/finish_ballot.go
@@ -92,6 +92,7 @@ func finishBallotWithProposedTxs(st *storage.LevelDBBackend, b ballot.Ballot, pr
 	infoLog.Info("NewBlock created",
 		"height", blk.Height,
 		"round", blk.Round,
+		"hash", blk.Hash,
 		"confirmed", blk.Confirmed,
 		"total-txs", blk.TotalTxs,
 		"total-ops", blk.TotalOps,


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->
Related: #796 

### Background

```
t=2018-11-23T19:29:33+0900 lvl=info msg="NewBlock created" module=noderunner node=GDTE.6RAE height=1182 round=0 confirmed=2018-11-23T19:29:33.891366000+09:00 total-txs=1182 total-ops=2364 proposer=GCDCXYUTLFOZSRQ4K6DTZ3R7ZJMD6CHVL3ZM7KGOG52NOTNHWBKYPCIO caller=finish_ballot.go:92
```

Current `NewBlock created` log doesn't logging `block.Hash`.  It makes easy to check `(hash,height)`.

After:

```
t=2018-11-23T19:28:47+0900 lvl=info msg="NewBlock created" module=noderunner node=GBFS.FZCV height=2 round=0 hash=6exDTbygTWt1tKkiaSyzEoEBABFUELejNQNp3kzhtfuu confirmed=2018-11-23T19:28:47.851399000+09:00 total-txs=2 total-ops=2 proposer=GBFSSMFOCC7WLX5ZUO5ILM44RKAXNWF6TND3XULPDQTGCSYZFZCVGVL2
```

### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

