### PR TITLE
Use first proposed time in sync and simple refactoring

### DIFF
--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -21,8 +21,8 @@ const (
 	// GenesisBlockHeight set the block height of genesis block
 	GenesisBlockHeight uint64 = 1
 
-	// FirstConsensusBlockHeight is used for calculating block time
-	FirstConsensusBlockHeight uint64 = 2
+	// FirstProposedBlockHeight is used for calculating block time
+	FirstProposedBlockHeight uint64 = 2
 
 	// GenesisBlockConfirmedTime is the time for the confirmed time of genesis
 	// block. This time is of the first commit of SEBAK.


### PR DESCRIPTION
Confirmed time changes when sync.
but proposed time does not.

GCDC.WBKY and GDTE.6RAE are synced node.

```
msg="set first confirmed block time" module=noderunner node=GDIR.M6CC time=2018-11-23T15:31:56+0000
msg="set first proposed block time" module=noderunner node=GDIR.M6CC time=2018-11-23T15:31:56.740989658Z

msg="set first confirmed block time" module=noderunner node=GCDC.WBKY time=2018-11-23T15:32:11+0000
msg="set first proposed block time" module=noderunner node=GCDC.WBKY time=2018-11-23T15:31:56.740989658Z

msg="set first confirmed block time" module=noderunner node=GDTE.6RAE time=2018-11-23T15:32:38+0000
msg="set first proposed block time" module=noderunner node=GDTE.6RAE time=2018-11-23T15:31:56.740989658Z
```

Therefore, we should use ProposedTime to adjust block time.