### PR TITLE
`/api/v1/accounts` supports to get multiple accounts at one request

### DIFF
--- a/lib/node/runner/api/api.go
+++ b/lib/node/runner/api/api.go
@@ -1,18 +1,18 @@
 package api
 
 import (
-	obs "boscoin.io/sebak/lib/common/observer"
-	"boscoin.io/sebak/lib/transaction"
-	"boscoin.io/sebak/lib/transaction/operation"
 	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/block"
+	obs "boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
+	"boscoin.io/sebak/lib/transaction/operation"
 )
 
 const APIVersionV1 = "v1"
@@ -21,6 +21,7 @@ const APIVersionV1 = "v1"
 const (
 	GetAccountTransactionsHandlerPattern   = "/accounts/{id}/transactions"
 	GetAccountHandlerPattern               = "/accounts/{id}"
+	GetAccountsHandlerPattern              = "/accounts"
 	GetAccountOperationsHandlerPattern     = "/accounts/{id}/operations"
 	GetAccountFrozenAccountHandlerPattern  = "/accounts/{id}/frozen-accounts"
 	GetFrozenAccountHandlerPattern         = "/frozen-accounts"

--- a/lib/node/runner/api/base_test.go
+++ b/lib/node/runner/api/base_test.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"bytes"
-	"github.com/gorilla/mux"
 	"io"
 	"net/http"
 	"net/http/httptest"
+
+	"github.com/gorilla/mux"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common/keypair"
@@ -25,6 +26,7 @@ func prepareAPIServer() (*httptest.Server, *storage.LevelDBBackend) {
 
 	router := mux.NewRouter()
 	router.HandleFunc(GetAccountHandlerPattern, apiHandler.GetAccountHandler).Methods("GET")
+	router.HandleFunc(GetAccountsHandlerPattern, apiHandler.GetAccountsHandler).Methods("POST")
 	router.HandleFunc(GetAccountTransactionsHandlerPattern, apiHandler.GetTransactionsByAccountHandler).Methods("GET")
 	router.HandleFunc(GetAccountOperationsHandlerPattern, apiHandler.GetOperationsByAccountHandler).Methods("GET")
 	router.HandleFunc(GetTransactionsHandlerPattern, apiHandler.GetTransactionsHandler).Methods("GET")

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -286,6 +286,10 @@ func (nr *NodeRunner) Ready() {
 		baCache.WrapHandlerFunc(apiHandler.GetAccountHandler),
 	).Methods("GET", "OPTIONS")
 	nr.network.AddHandler(
+		apiHandler.HandlerURLPattern(api.GetAccountsHandlerPattern),
+		baCache.WrapHandlerFunc(apiHandler.GetAccountsHandler),
+	).Methods("POST", "OPTIONS").MatcherFunc(common.PostAndJSONMatcher)
+	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetAccountTransactionsHandlerPattern),
 		listCache.WrapHandlerFunc(apiHandler.GetTransactionsByAccountHandler),
 	).Methods("GET", "OPTIONS")


### PR DESCRIPTION
### Background
> This is originated from 3rd party developer(he is developing wallet)

Currently we have narrow limit policy by default (100 requests per minute), the wallet client usually suffers from 429 status(https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429). Most of requests from client are 
* `/accounts/{id}/operations`
* `/accounts/{id}`

This PR tries to reduce the number of requests of `/accounts/{id}`. 

### Solution

To get the multiple accounts at once, 

* `GetAccountsHandler` added for `/accounts` 
* `GetAccountsHandler` only support `POST` and `Content-Type: application/json`
* The result is `resource.ResourceList` and each item is `resource.Account`