### PR TITLE
Self-signed ballot will use `network.MessageBroker` instead of `ballotBroadcastChannel`

### DIFF
--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -42,7 +42,6 @@ func (p *ballotCheckerProposedTransaction) Prepare() {
 
 	p.proposerNode = localNodes[1]
 	nr.Consensus().SetProposerSelector(FixedSelector{p.proposerNode.Address()})
-	go p.nr.startBroadcastBallot()
 
 	p.keys = map[string]*keypair.Full{}
 }

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -1,10 +1,11 @@
 package runner
 
 import (
-	"boscoin.io/sebak/lib/node/runner/api"
 	"bufio"
 	"bytes"
 	"io"
+
+	"boscoin.io/sebak/lib/node/runner/api"
 
 	logging "github.com/inconshreveable/log15"
 
@@ -61,20 +62,17 @@ type BallotChecker struct {
 // BallotUnmarshal makes `Ballot` from common.NetworkMessage.
 func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotChecker)
-	if checker.Ballot.IsEmpty() {
-		var b ballot.Ballot
-		if b, err = ballot.NewBallotFromJSON(checker.Message.Data); err != nil {
-			return
-		}
 
-		if err = b.IsWellFormed(checker.NodeRunner.Conf); err != nil {
-			return
-		}
-
-		checker.Log.Debug("message is verified")
-		checker.Ballot = b
+	var b ballot.Ballot
+	if b, err = ballot.NewBallotFromJSON(checker.Message.Data); err != nil {
+		return
 	}
 
+	if err = b.IsWellFormed(checker.NodeRunner.Conf); err != nil {
+		return
+	}
+
+	checker.Ballot = b
 	checker.IsMine = checker.Ballot.Source() == checker.LocalNode.Address()
 
 	checker.Log = checker.Log.New(logging.Ctx{
@@ -87,6 +85,7 @@ func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 		"isMine":      checker.IsMine,
 	})
 
+	checker.Log.Debug("message is verified")
 	return
 }
 

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -266,7 +266,7 @@ func (sm *ISAACStateManager) broadcastExpiredBallot(state consensus.ISAACState) 
 	newExpiredBallot.Sign(sm.nr.localNode.Keypair(), sm.nr.Conf.NetworkID)
 
 	sm.nr.Log().Debug("broadcast", "ballot", *newExpiredBallot)
-	sm.nr.broadcastBallot(*newExpiredBallot)
+	sm.nr.BroadcastBallot(*newExpiredBallot)
 }
 
 func (sm *ISAACStateManager) resetTimer(timer *time.Timer, state ballot.State) {

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -680,5 +680,5 @@ func (nr *NodeRunner) BroadcastBallot(b ballot.Ballot) {
 		nr.Network().MessageBroker().Receive(common.NewNetworkMessage(common.BallotMessage, encoded))
 	}()
 
-	go nr.ConnectionManager().Broadcast(b)
+	nr.ConnectionManager().Broadcast(b)
 }


### PR DESCRIPTION
### Github Issue

Related to #796 

### Background

See #796's comment, https://github.com/bosnet/sebak/issues/796#issuecomment-441344594 .

### Solution

We already patched to prevent node's signed ballot to be broadcasted to itself in #745 . In #745 to pass the ballot to checker, the `ballotBroadcastChannel` was created. @Charleslee522 pointed in https://github.com/bosnet/sebak/issues/796#issuecomment-441344594 , this way made the unexpected problem, conjunction of incoming ballot. This patch uses `network.MessageBroker` like other incoming ballot for self-signed ballot. This will help the consensus to be stable.