### PR TITLE
modify blockOperation

### DIFF
--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -55,7 +55,7 @@ func NewBlockOperationFromOperation(op operation.Operation, tx transaction.Trans
 	}
 
 	linked := ""
-	if createAccount, ok := op.B.(*operation.CreateAccount); ok {
+	if createAccount, ok := op.B.(operation.CreateAccount); ok {
 		if createAccount.Linked != "" {
 			linked = createAccount.Linked
 		}


### PR DESCRIPTION
### Background
This PR is made to resolve frozen account issue.
The problem was that `/accounts/{addr}/frozen-accounts` return no records even if creating frozen accounts are a success.