### PR TITLE
Sync latest nodes

### DIFF
--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	connectionManager network.ConnectionManager
 	tp                *transaction.Pool
 	localNode         *node.LocalNode
+	nodelist          *NodeList
 	logger            log15.Logger
 	commonCfg         common.Config
 
@@ -49,6 +50,7 @@ func NewConfig(localNode *node.LocalNode,
 		logger:            log.New(log15.Ctx{"node": localNode.Alias()}),
 		commonCfg:         cfg,
 		localNode:         localNode,
+		nodelist:          &NodeList{},
 
 		SyncPoolSize:             SyncPoolSize,
 		FetchTimeout:             FetchTimeout,
@@ -62,6 +64,7 @@ func (c *Config) NewSyncer() *Syncer {
 	f := c.NewFetcher()
 	v := c.NewValidator()
 	s := NewSyncer(f, v, c.storage, func(s *Syncer) {
+		s.nodelist = c.nodelist
 		s.poolSize = c.SyncPoolSize
 		s.checkInterval = c.CheckBlockHeightInterval
 		s.logger = c.logger.New("submodule", "syncer")
@@ -78,6 +81,7 @@ func (c *Config) NewFetcher() Fetcher {
 		c.storage,
 		c.localNode,
 		func(f *BlockFetcher) {
+			f.nodelist = c.nodelist
 			f.fetchTimeout = c.FetchTimeout
 			f.logger = c.logger.New("submodule", "fetcher")
 		},

--- a/lib/sync/fetcher.go
+++ b/lib/sync/fetcher.go
@@ -33,6 +33,7 @@ type BlockFetcher struct {
 	apiClient         Doer
 	storage           *storage.LevelDBBackend
 	localNode         *node.LocalNode
+	nodelist          *NodeList
 
 	fetchTimeout  time.Duration
 	retryInterval time.Duration
@@ -93,6 +94,7 @@ func (f *BlockFetcher) Fetch(ctx context.Context, syncInfo *SyncInfo) (*SyncInfo
 				case <-ctx.Done():
 					return false, ctx.Err()
 				case <-c:
+					syncInfo.NodeAddrs = f.nodelist.LatestNodes()
 					return true, err
 				}
 			}

--- a/lib/sync/nodelist.go
+++ b/lib/sync/nodelist.go
@@ -7,7 +7,7 @@ type NodeList struct {
 	addrsMu sync.RWMutex
 }
 
-func (l *NodeList) SetLatestNodes(addrs []string) {
+func (l *NodeList) SetLatestNodeAddrs(addrs []string) {
 	if len(addrs) <= 0 {
 		return
 	}
@@ -15,7 +15,7 @@ func (l *NodeList) SetLatestNodes(addrs []string) {
 	l.addrs = addrs
 	l.addrsMu.Unlock()
 }
-func (l *NodeList) LatestNodes() []string {
+func (l *NodeList) NodeAddrs() []string {
 	l.addrsMu.RLock()
 	defer l.addrsMu.RUnlock()
 	return l.addrs

--- a/lib/sync/nodelist.go
+++ b/lib/sync/nodelist.go
@@ -1,0 +1,22 @@
+package sync
+
+import "sync"
+
+type NodeList struct {
+	addrs   []string
+	addrsMu sync.RWMutex
+}
+
+func (l *NodeList) SetLatestNodes(addrs []string) {
+	if len(addrs) <= 0 {
+		return
+	}
+	l.addrsMu.Lock()
+	l.addrs = addrs
+	l.addrsMu.Unlock()
+}
+func (l *NodeList) LatestNodes() []string {
+	l.addrsMu.RLock()
+	defer l.addrsMu.RUnlock()
+	return l.addrs
+}

--- a/lib/sync/syncer.go
+++ b/lib/sync/syncer.go
@@ -24,6 +24,8 @@ type Syncer struct {
 	fetcher   Fetcher
 	validator Validator
 
+	nodelist *NodeList
+
 	poolSize      uint64
 	checkInterval time.Duration
 
@@ -157,6 +159,7 @@ func (s *Syncer) loop() {
 			if height > syncProgress.CurrentBlock {
 				syncProgress.HighestBlock = height
 				s.sync(syncProgress, nodeAddrs)
+				s.nodelist.SetLatestNodes(nodeAddrs)
 			}
 		case c := <-s.getSyncProgress:
 			c <- syncProgress

--- a/lib/sync/syncer_test.go
+++ b/lib/sync/syncer_test.go
@@ -34,7 +34,7 @@ func TestSyncerSetSyncTarget(t *testing.T) {
 
 		syncer.validator = &mockValidator{
 			validateFunc: func(ctx context.Context, si *SyncInfo) error {
-				assert.Equal(t, len(si.NodeAddrs), 2)
+				assert.Equal(t, len(si.NodeAddrs()), 2)
 				infoc <- si
 				return nil
 			},

--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -26,9 +26,13 @@ type SyncInfo struct {
 	Txs    []*transaction.Transaction
 	Ptx    *ballot.ProposerTransaction
 
-	// Fetching target node addresses, `NodeAddrs` is  the validators which
+	// Fetching target node addresses, NodeList is  the validators which
 	// participated and confirmed the consensus of latest ballot.
-	NodeAddrs []string
+	NodeList *NodeList
+}
+
+func (s *SyncInfo) NodeAddrs() []string {
+	return s.NodeList.NodeAddrs()
 }
 
 type Doer interface {


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

Current sync doesn't share latest node address from the latest consensus's result with every fetching height. Sebak has static validator's address list ( It means without restarting the node, validators are not changed).  

But If some validator is Byzantine validator or  the node can update validators dynamically,  The consensus or node can know that and can update new latest nodes to syncer. With this, the syncer can try re-fetching with new latest nodes when the syncer has still failed heights or heights not fetched.


### Solution

- Syncer updates latest node address. 
- Fetcher uses the latest node address every time it try.
- And some refactoring about unused objects and `NewXXX`


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

- `NodeList` has `RWMutex`. So It could decrease a litte bit of performance.

