### PR TITLE
Set log output for HTTP request & response

### DIFF
--- a/lib/network/http2.go
+++ b/lib/network/http2.go
@@ -9,12 +9,13 @@ import (
 	"strings"
 	"time"
 
-	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/errors"
-	"boscoin.io/sebak/lib/node"
 	"github.com/gorilla/mux"
 	logging "github.com/inconshreveable/log15"
 	"golang.org/x/net/http2"
+
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
+	"boscoin.io/sebak/lib/node"
 )
 
 type Handlers map[string]func(http.ResponseWriter, *http.Request)
@@ -77,8 +78,8 @@ type HTTP2Network struct {
 type HandlerFunc func(w http.ResponseWriter, r *http.Request)
 
 func NewHTTP2Network(config *HTTP2NetworkConfig) (h2n *HTTP2Network) {
-	httpLog := log.New(logging.Ctx{"module": "http", "node": config.NodeName})
-	errorLog := goLog.New(HTTP2ErrorLog15Writer{httpLog}, "", 0)
+	hLog := httpLog.New(logging.Ctx{"node": config.NodeName})
+	errorLog := goLog.New(HTTP2ErrorLog15Writer{hLog}, "", 0)
 
 	server := &http.Server{
 		Addr:              config.Addr,
@@ -107,7 +108,7 @@ func NewHTTP2Network(config *HTTP2NetworkConfig) (h2n *HTTP2Network) {
 		tlsCertFile:    config.TLSCertFile,
 		tlsKeyFile:     config.TLSKeyFile,
 		receiveChannel: make(chan common.NetworkMessage),
-		log:            httpLog,
+		log:            hLog,
 	}
 	h2n.handlers = map[string]func(http.ResponseWriter, *http.Request){}
 	h2n.routers = map[string]*mux.Router{

--- a/lib/network/http2_network_log.go
+++ b/lib/network/http2_network_log.go
@@ -109,6 +109,7 @@ func (l HTTP2Log15Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"remote", r.RemoteAddr,
 		"uri", uri,
 		"user-agent", r.UserAgent(),
+		"x-forwarded-for", strings.Split(r.Header.Get("X-Forwarded-For"), ",")[0],
 	)
 
 	writer := &HTTP2ResponseLog15Writer{w: w}

--- a/lib/network/init.go
+++ b/lib/network/init.go
@@ -1,17 +1,24 @@
 package network
 
 import (
-	"boscoin.io/sebak/lib/common"
 	logging "github.com/inconshreveable/log15"
+
+	"boscoin.io/sebak/lib/common"
 )
 
 var VerboseLogs bool
 var log logging.Logger = logging.New("module", "network")
+var httpLog logging.Logger = logging.New("module", "http")
 
 func init() {
 	SetLogging(common.DefaultLogLevel, common.DefaultLogHandler)
+	SetHTTPLogging(common.DefaultLogLevel, common.DefaultLogHandler)
 }
 
 func SetLogging(level logging.Lvl, handler logging.Handler) {
 	log.SetHandler(logging.LvlFilterHandler(level, handler))
+}
+
+func SetHTTPLogging(level logging.Lvl, handler logging.Handler) {
+	httpLog.SetHandler(logging.LvlFilterHandler(level, handler))
 }


### PR DESCRIPTION
### Background

Currently http request and response log messages are mixed with other messages, and they are produced huge messages.

But most of all, http request and response log should be able to be separated to another output, because http log has client's information and we should keep it safe and managing.

### Solution

* add new `--http-log`, it set the http request and response log output.
* basically the output format is 'json' list

### log 
```json
{
  "content-length": 0,
  "content-type": "",
  "headers": {},
  "host": "localhost:12345",
  "id": "1a712c78-fa80-4f4a-b291-09dc24a4839f",
  "lvl": "dbug",
  "method": "GET",
  "module": "http",
  "msg": "request",
  "node": "GCPQ.7DUR",
  "proto": "HTTP/1.1",
  "referer": "",
  "remote": "127.0.0.1:55083",
  "t": "2018-11-24T19:20:42.3382+09:00",
  "uri": "/",
  "user-agent": "curl/7.62.0",
  "x-forwarded-for": ""
}
{
  "elapsed": "1.583469ms",
  "id": "1a712c78-fa80-4f4a-b291-09dc24a4839f",
  "lvl": "dbug",
  "module": "http",
  "msg": "response",
  "node": "GCPQ.7DUR",
  "size": 1147,
  "status": 200,
  "t": "2018-11-24T19:20:42.339759+09:00"
}
```

There are 2 log for one request, first one is request itself and the second is it's response. In request, there are the basic informations and 'x-forwarded-for'. In response, there is 'elapsed' time. The request and response can be joined by `id`.