### PR TITLE
Prevent confirming different ballot

### DIFF
--- a/lib/consensus/ballot_send_record.go
+++ b/lib/consensus/ballot_send_record.go
@@ -1,0 +1,56 @@
+package consensus
+
+import (
+	"sync"
+
+	logging "github.com/inconshreveable/log15"
+)
+
+// Record the ballot sent by ISAACstate
+// This is to avoid sending another voting result in the same ISAACState.
+type BallotSendRecord struct {
+	sync.RWMutex
+
+	record map[ISAACState]bool
+	log    logging.Logger
+}
+
+func NewBallotSendRecord(nodeAlias string) *BallotSendRecord {
+	p := &BallotSendRecord{
+		record: make(map[ISAACState]bool),
+		log:    log.New(logging.Ctx{"node": nodeAlias}),
+	}
+
+	return p
+}
+
+func (r *BallotSendRecord) SetSent(state ISAACState) {
+	r.Lock()
+	defer r.Unlock()
+	log.Debug("BallotSendRecord.SetSent()", "state", state)
+	r.record[state] = true
+
+	return
+}
+
+func (r *BallotSendRecord) Sent(state ISAACState) bool {
+	r.RLock()
+	defer r.RUnlock()
+	log.Debug("BallotSendRecord.Sent()", "state", state)
+
+	return r.record[state]
+}
+
+func (r *BallotSendRecord) RemoveLowerThanOrEqualHeight(height uint64) {
+	r.Lock()
+	defer r.Unlock()
+	log.Debug("BallotSendRecord.RemoveLowerThanOrEqualHeight()", "height", height)
+
+	for state := range r.record {
+		if state.Height <= height {
+			delete(r.record, state)
+		}
+	}
+
+	return
+}

--- a/lib/consensus/ballot_send_record_test.go
+++ b/lib/consensus/ballot_send_record_test.go
@@ -1,0 +1,74 @@
+package consensus
+
+import (
+	"testing"
+
+	"boscoin.io/sebak/lib/ballot"
+	"github.com/stretchr/testify/require"
+)
+
+func pushISAACState(states *[]ISAACState, height uint64, round uint64, ballotState ballot.State) {
+	is := ISAACState{
+		Height:      height,
+		Round:       round,
+		BallotState: ballotState,
+	}
+
+	*states = append(*states, is)
+}
+
+func TestBallotSendRecord(t *testing.T) {
+	r := NewBallotSendRecord("n1")
+
+	states := []ISAACState{}
+
+	pushISAACState(&states, 1, 0, ballot.StateINIT)
+	pushISAACState(&states, 1, 0, ballot.StateSIGN)
+	pushISAACState(&states, 1, 0, ballot.StateACCEPT)
+
+	pushISAACState(&states, 1, 1, ballot.StateINIT)
+	pushISAACState(&states, 1, 1, ballot.StateSIGN)
+
+	pushISAACState(&states, 2, 0, ballot.StateINIT)
+	pushISAACState(&states, 2, 0, ballot.StateSIGN)
+	pushISAACState(&states, 2, 0, ballot.StateACCEPT)
+	pushISAACState(&states, 3, 0, ballot.StateINIT)
+
+	require.Equal(t, 9, len(states))
+	for _, state := range states {
+		r.SetSent(state)
+	}
+
+	for _, state := range states {
+		require.True(t, r.Sent(state))
+	}
+
+	require.True(t, r.Sent(ISAACState{
+		Height:      1,
+		Round:       0,
+		BallotState: ballot.StateINIT,
+	}))
+
+	require.False(t, r.Sent(ISAACState{
+		Height:      1,
+		Round:       1,
+		BallotState: ballot.StateACCEPT,
+	}))
+
+	r.RemoveLowerThanOrEqualHeight(1)
+
+	require.False(t, r.Sent(ISAACState{
+		Height:      1,
+		Round:       0,
+		BallotState: ballot.StateINIT,
+	}))
+
+	r.RemoveLowerThanOrEqualHeight(2)
+
+	require.True(t, r.Sent(ISAACState{
+		Height:      3,
+		Round:       0,
+		BallotState: ballot.StateINIT,
+	}))
+
+}

--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -224,11 +224,32 @@ func (is *ISAAC) LatestBlock() block.Block {
 	return block.GetLatestBlock(is.storage)
 }
 
-func (is *ISAAC) RemoveRunningRoundsWithSameHeight(height uint64) {
+func (is *ISAAC) RemoveRunningRoundsLowerOrEqualHeight(height uint64) {
 	for hash, runningRound := range is.RunningRounds {
 		if runningRound.VotingBasis.Height > height {
 			continue
 		}
+
+		is.log.Debug("remove running rounds lower than or equal to height", "votingBasis", runningRound.VotingBasis)
+
+		delete(runningRound.Transactions, runningRound.Proposer)
+		delete(runningRound.Voted, runningRound.Proposer)
+		delete(is.RunningRounds, hash)
+	}
+}
+
+func (is *ISAAC) RemoveRunningRoundsLowerOrEqualBasis(basis voting.Basis) {
+	for hash, runningRound := range is.RunningRounds {
+		if runningRound.VotingBasis.Height > basis.Height {
+			continue
+		}
+
+		if runningRound.VotingBasis.Height == basis.Height &&
+			runningRound.VotingBasis.Round > basis.Round {
+			continue
+		}
+
+		is.log.Debug("remove running rounds lower than or equal to basis", "votingBasis", runningRound.VotingBasis)
 
 		delete(runningRound.Transactions, runningRound.Proposer)
 		delete(runningRound.Voted, runningRound.Proposer)

--- a/lib/consensus/remove_running_round_test.go
+++ b/lib/consensus/remove_running_round_test.go
@@ -1,0 +1,117 @@
+package consensus
+
+import (
+	"testing"
+
+	"boscoin.io/sebak/lib/ballot"
+	"boscoin.io/sebak/lib/voting"
+	"github.com/stretchr/testify/require"
+)
+
+func insertRunningRound(t *testing.T, is *ISAAC, source string, proposer string, height uint64, round uint64, ballotState ballot.State, vote voting.Hole) {
+	basis := voting.Basis{
+		Height: height,
+		Round:  round,
+	}
+
+	b := *ballot.NewBallot(source, proposer, basis, []string{})
+	b.SetVote(ballotState, vote)
+
+	if runningRound, found := is.RunningRounds[basis.Index()]; !found {
+		rr, err := NewRunningRound(proposer, b)
+		require.NoError(t, err)
+		is.RunningRounds[basis.Index()] = rr
+	} else {
+		runningRound.Vote(b)
+	}
+
+}
+
+func TestRunningRoundsLowerOrEqualHeight(t *testing.T) {
+	is := ISAAC{
+		RunningRounds: map[string]*RunningRound{},
+		log:           log.New(),
+	}
+
+	nodes := []string{"node1", "node2", "node3"}
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateACCEPT, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateACCEPT, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+
+	require.Equal(t, 3, len(is.RunningRounds))
+
+	is.RemoveRunningRoundsLowerOrEqualHeight(10)
+	require.Equal(t, 1, len(is.RunningRounds))
+
+	is.RemoveRunningRoundsLowerOrEqualHeight(9)
+	require.Equal(t, 1, len(is.RunningRounds))
+
+	is.RemoveRunningRoundsLowerOrEqualHeight(11)
+	require.Equal(t, 0, len(is.RunningRounds))
+}
+
+func TestRunningRoundsLowerOrEqualBasis(t *testing.T) {
+	is := ISAAC{
+		RunningRounds: map[string]*RunningRound{},
+		log:           log.New(),
+	}
+
+	nodes := []string{"node1", "node2", "node3"}
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+	insertRunningRound(t, &is, nodes[1], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+	insertRunningRound(t, &is, nodes[2], nodes[0], 10, 0, ballot.StateACCEPT, voting.NO)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 10, 1, ballot.StateACCEPT, voting.EXP)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 10, 1, ballot.StateACCEPT, voting.EXP)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 10, 1, ballot.StateACCEPT, voting.EXP)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateSIGN, voting.YES)
+
+	insertRunningRound(t, &is, nodes[0], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[1], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+	insertRunningRound(t, &is, nodes[2], nodes[1], 11, 0, ballot.StateACCEPT, voting.YES)
+
+	require.Equal(t, 3, len(is.RunningRounds))
+
+	votingBasis := voting.Basis{Height: 10, Round: 0}
+
+	is.RemoveRunningRoundsLowerOrEqualBasis(votingBasis)
+	require.Equal(t, 2, len(is.RunningRounds))
+
+	votingBasis.Height = 11
+
+	is.RemoveRunningRoundsLowerOrEqualBasis(votingBasis)
+	require.Equal(t, 0, len(is.RunningRounds))
+}

--- a/lib/node/runner/isaac_state_transit_test.go
+++ b/lib/node/runner/isaac_state_transit_test.go
@@ -101,7 +101,7 @@ func TestStateINITTimeoutNotProposer(t *testing.T) {
 // 3. When `ISAACStateManager` starts, the node proposes B(`INIT`, `YES`) to validators.
 // 4. Then ISAACState will be changed to `SIGN`.
 // 5. But TimeoutSIGN is a millisecond.
-// 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`)
+// 6. After timeout, the node broadcasts B(`SIGN`, `EXP`)
 func TestStateSIGNTimeoutProposer(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
@@ -122,12 +122,13 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 
 	<-recv
 	require.Equal(t, 1, len(cm.Messages()))
+	require.Equal(t, ballot.StateINIT, nr.isaacStateManager.State().BallotState)
 
 	state := nr.isaacStateManager.State()
 	nr.isaacStateManager.TransitISAACState(state.Height, state.Round, ballot.StateSIGN)
 
 	<-recv
-	require.Equal(t, ballot.StateACCEPT, nr.isaacStateManager.State().BallotState)
+	require.Equal(t, ballot.StateSIGN, nr.isaacStateManager.State().BallotState)
 	require.Equal(t, 2, len(cm.Messages()))
 
 	init, sign, accept := 0, 0, 0
@@ -148,8 +149,8 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 		}
 	}
 	require.Equal(t, 1, init)
-	require.Equal(t, 0, sign)
-	require.Equal(t, 1, accept)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 0, accept)
 }
 
 // 1. All 3 Nodes.
@@ -158,7 +159,7 @@ func TestStateSIGNTimeoutProposer(t *testing.T) {
 // 4. TimeoutINIT is a millisecond.
 // 5. ISAACState is changed to `SIGN`.
 // 6. TimeoutSIGN is a millisecond.
-// 7. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+// 7. After timeout, the node broadcasts B(`SIGN`, `EXP`).
 func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = 200 * time.Millisecond
@@ -211,8 +212,8 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 		}
 	}
 	require.Equal(t, 0, init)
-	require.Equal(t, 0, sign)
-	require.Equal(t, 1, accept)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 0, accept)
 }
 
 // 1. All 3 Nodes.
@@ -220,7 +221,7 @@ func TestStateSIGNTimeoutNotProposer(t *testing.T) {
 // 3. When `ISAACStateManager` starts, the node proposes a ballot.
 // 4. ISAACState is changed to `SIGN`.
 // 5. TimeoutSIGN is a millisecond.
-// 6. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+// 6. After timeout, the node broadcasts B(`SIGN`, `EXP`).
 func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
@@ -269,8 +270,8 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 	}
 
 	require.Equal(t, 1, init)
-	require.Equal(t, 0, sign)
-	require.Equal(t, 1, accept)
+	require.Equal(t, 1, sign)
+	require.Equal(t, 0, accept)
 }
 
 // 1. All 3 Nodes.
@@ -279,7 +280,7 @@ func TestStateACCEPTTimeoutProposerThenNotProposer(t *testing.T) {
 // 4. TransitISAACState(SIGN) method is called.
 // 5. ISAACState is changed to `SIGN`.
 // 6. TimeoutSIGN is a millisecond.
-// 7. After timeout, the node broadcasts B(`ACCEPT`, `EXP`).
+// 7. After timeout, the node broadcasts B(`SIGN`, `EXP`).
 func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.TimeoutINIT = time.Hour
@@ -320,7 +321,7 @@ func TestStateTransitFromTimeoutInitToAccept(t *testing.T) {
 		b, ok := message.(ballot.Ballot)
 		require.True(t, ok)
 		require.NotEqual(t, nr.localNode.Address(), b.Proposer())
-		require.Equal(t, ballot.StateACCEPT, b.State())
+		require.Equal(t, ballot.StateSIGN, b.State())
 		require.Equal(t, voting.EXP, b.Vote())
 	}
 }
@@ -366,11 +367,24 @@ func TestStateTransitFromTimeoutSignToAccept(t *testing.T) {
 	<-recv
 
 	require.Equal(t, 2, len(cm.Messages()))
+	init, sign, accept := 0, 0, 0
 	for _, message := range cm.Messages() {
 		b, ok := message.(ballot.Ballot)
 		require.True(t, ok)
 		require.Equal(t, nr.localNode.Address(), b.Proposer())
-		require.Equal(t, ballot.StateINIT, b.State())
-		require.Equal(t, voting.YES, b.Vote())
+		switch b.State() {
+		case ballot.StateINIT:
+			require.Equal(t, voting.YES, b.Vote())
+			init++
+		case ballot.StateSIGN:
+			sign++
+		case ballot.StateACCEPT:
+			require.Equal(t, voting.EXP, b.Vote())
+			accept++
+		}
 	}
+
+	require.Equal(t, 1, init)
+	require.Equal(t, 0, sign)
+	require.Equal(t, 1, accept)
 }


### PR DESCRIPTION
fixes #755

### Features
* A node moves to the next round only by voting(https://github.com/bosnet/sebak/issues/796#issuecomment-441367038 is good reference. Thanks to @anarcher).
* If a node sent a ballot in a state, then it never send a ballot again that has the same state -> managed by consensus.BallotSendRecord.
* If node state is expired by voting, the node goes to the next round and removes current round voting result.
* If expired in SIGN by voting, go to the next round.

It contains https://github.com/bosnet/sebak/pull/803. I'll rebase after #803 merged.

I run long-term test more than 20 times, and do not failed.

And I'm running 5 nodes(with block time 3 sec) in local and push transactions with sebak-hot-body(50 tx, 100 op), now the height is 610 and It's okay.
I'm going to keep watching this test result.