### PR TITLE
Clean up txs  in txpool when sync up

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -27,6 +27,7 @@ import (
 	"boscoin.io/sebak/lib/node/runner"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/sync"
+	"boscoin.io/sebak/lib/transaction"
 )
 
 const (
@@ -630,8 +631,9 @@ func runNode() error {
 		log.Crit("failed to initialize storage", "error", err)
 		return err
 	}
+	tp := transaction.NewPool(conf)
 
-	c := sync.NewConfig(localNode, st, nt, connectionManager, conf)
+	c := sync.NewConfig(localNode, st, nt, connectionManager, tp, conf)
 	//Place setting config
 	c.SyncPoolSize = syncPoolSize
 	c.FetchTimeout = syncFetchTimeout
@@ -650,7 +652,7 @@ func runNode() error {
 	// Execution group.
 	var g run.Group
 	{
-		nr, err := runner.NewNodeRunner(localNode, policy, nt, isaac, st, conf)
+		nr, err := runner.NewNodeRunner(localNode, policy, nt, isaac, st, tp, conf)
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -27,6 +27,7 @@ import (
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
 )
 
 func getPort() string {
@@ -106,7 +107,8 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Netw
 
 	st := block.InitTestBlockchain()
 	is, _ := consensus.NewISAAC(localNode, p, connectionManager, st, conf, nil)
-	if nodeRunner, err = NewNodeRunner(localNode, p, n, is, st, conf); err != nil {
+	tp := transaction.NewPool(conf)
+	if nodeRunner, err = NewNodeRunner(localNode, p, n, is, st, tp, conf); err != nil {
 		panic(err)
 	}
 

--- a/lib/node/runner/finish_ballot_test.go
+++ b/lib/node/runner/finish_ballot_test.go
@@ -66,7 +66,9 @@ func createNodeRunnerForTestingWithFileStorage(n int, conf common.Config, recv c
 	is, _ := consensus.NewISAAC(localNode, policy, connectionManager, st, conf, nil)
 	is.SetProposerSelector(FixedSelector{localNode.Address()})
 
-	nr, err := NewNodeRunner(localNode, policy, ns[0], is, st, conf)
+	tp := transaction.NewPool(conf)
+
+	nr, err := NewNodeRunner(localNode, policy, ns[0], is, st, tp, conf)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -101,6 +101,7 @@ func NewNodeRunner(
 	n network.Network,
 	c *consensus.ISAAC,
 	storage *storage.LevelDBBackend,
+	tp *transaction.Pool,
 	conf common.Config,
 ) (nr *NodeRunner, err error) {
 	nr = &NodeRunner{
@@ -108,7 +109,7 @@ func NewNodeRunner(
 		policy:          policy,
 		network:         n,
 		consensus:       c,
-		TransactionPool: transaction.NewPool(conf),
+		TransactionPool: tp,
 		storage:         storage,
 		log:             log.New(logging.Ctx{"node": localNode.Alias()}),
 		Conf:            conf,

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -16,6 +16,7 @@ import (
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/voting"
 )
 
@@ -62,7 +63,8 @@ func createTestNodeRunner(n int, conf common.Config) []*NodeRunner {
 
 		st := block.InitTestBlockchain()
 		is, _ := consensus.NewISAAC(localNode, policy, connectionManager, st, conf, nil)
-		nr, err := NewNodeRunner(localNode, policy, ns[i], is, st, conf)
+		tp := transaction.NewPool(conf)
+		nr, err := NewNodeRunner(localNode, policy, ns[i], is, st, tp, conf)
 		if err != nil {
 			panic(err)
 		}
@@ -152,7 +154,8 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 		conf := common.NewTestConfig()
 		st := block.InitTestBlockchain()
 		is, _ := consensus.NewISAAC(node, policy, connectionManager, st, conf, nil)
-		nodeRunner, _ := NewNodeRunner(node, policy, n, is, st, conf)
+		tp := transaction.NewPool(conf)
+		nodeRunner, _ := NewNodeRunner(node, policy, n, is, st, tp, conf)
 		nodeRunners = append(nodeRunners, nodeRunner)
 	}
 

--- a/lib/node/runner/test.go
+++ b/lib/node/runner/test.go
@@ -32,7 +32,8 @@ func MakeNodeRunner() (*NodeRunner, *node.LocalNode) {
 
 	st := block.InitTestBlockchain()
 	is, _ := consensus.NewISAAC(localNode, policy, connectionManager, st, conf, nil)
-	nodeRunner, _ := NewNodeRunner(localNode, policy, n, is, st, conf)
+	tp := transaction.NewPool(conf)
+	nodeRunner, _ := NewNodeRunner(localNode, policy, n, is, st, tp, conf)
 	return nodeRunner, localNode
 }
 
@@ -156,8 +157,9 @@ func createNodeRunnerForTesting(n int, conf common.Config, recv chan struct{}) (
 	st := block.InitTestBlockchain()
 	is, _ := consensus.NewISAAC(localNode, policy, connectionManager, st, common.NewTestConfig(), nil)
 	is.SetProposerSelector(FixedSelector{localNode.Address()})
+	tp := transaction.NewPool(conf)
 
-	nr, err := NewNodeRunner(localNode, policy, ns[0], is, st, conf)
+	nr, err := NewNodeRunner(localNode, policy, ns[0], is, st, tp, conf)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -7,6 +7,7 @@ import (
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
 	"github.com/inconshreveable/log15"
 )
 
@@ -22,6 +23,7 @@ type Config struct {
 	storage           *storage.LevelDBBackend
 	network           network.Network
 	connectionManager network.ConnectionManager
+	tp                *transaction.Pool
 	localNode         *node.LocalNode
 	logger            log15.Logger
 	commonCfg         common.Config
@@ -37,11 +39,13 @@ func NewConfig(localNode *node.LocalNode,
 	st *storage.LevelDBBackend,
 	nt network.Network,
 	cm network.ConnectionManager,
+	tp *transaction.Pool,
 	cfg common.Config) *Config {
 	c := &Config{
 		storage:           st,
 		network:           nt,
 		connectionManager: cm,
+		tp:                tp,
 		logger:            log.New(log15.Ctx{"node": localNode.Alias()}),
 		commonCfg:         cfg,
 		localNode:         localNode,
@@ -85,6 +89,7 @@ func (c *Config) NewValidator() Validator {
 	v := NewBlockValidator(
 		c.network,
 		c.storage,
+		c.tp,
 		c.commonCfg,
 		func(v *BlockValidator) {
 			v.prevBlockWaitTimeout = c.CheckPrevBlockInterval

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -9,6 +9,7 @@ import (
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
 	"boscoin.io/sebak/lib/storage"
+	"boscoin.io/sebak/lib/transaction"
 
 	"github.com/stretchr/testify/require"
 )
@@ -18,13 +19,14 @@ func TestNewConfig(t *testing.T) {
 	st := storage.NewTestStorage()
 	_, nt, _ := network.CreateMemoryNetwork(nil)
 	cm := &mockConnectionManager{}
+	tp := transaction.NewPool(conf)
 
 	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
 	require.Equal(t, nil, err)
 
 	node, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
 
-	cfg := NewConfig(node, st, nt, cm, conf)
+	cfg := NewConfig(node, st, nt, cm, tp, conf)
 	cfg.SyncPoolSize = 100
 	cfg.logger = common.NopLogger()
 

--- a/lib/sync/fetcher.go
+++ b/lib/sync/fetcher.go
@@ -125,6 +125,7 @@ func (f *BlockFetcher) fetch(ctx context.Context, si *SyncInfo) error {
 		f.logger.Error("request err", "err", err, "height", height)
 		return err
 	}
+	req = req.WithContext(ctx)
 
 	resp, err := f.apiClient.Do(req)
 	if err != nil {

--- a/lib/sync/validator_test.go
+++ b/lib/sync/validator_test.go
@@ -7,6 +7,7 @@ import (
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/network"
+	"boscoin.io/sebak/lib/transaction"
 	"github.com/stretchr/testify/require"
 )
 
@@ -15,8 +16,9 @@ func TestValidator(t *testing.T) {
 	st := block.InitTestBlockchain()
 	defer st.Close()
 	_, nw, _ := network.CreateMemoryNetwork(nil)
+	tp := transaction.NewPool(conf)
 
-	v := NewBlockValidator(nw, st, conf)
+	v := NewBlockValidator(nw, st, tp, conf)
 
 	ctx := context.Background()
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

Clean up txs in  txpool when sync up 
When sync up,  synced block's txs and proposerTx should be removed within txpool if a node state is `sync` and the node recv txs.


### Solution

In `finishBlock`,  `txpool.Remove(blk.Transactions...)` and `txpool.Remove(blk.ProposerTransaction)` too.


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

To use `txpool` with `syncer`, txpoll is created in   `cmd/run.go`.  It makes a change of `NewNodeRunnder`.  :->


