### PR TITLE
Empty `X-SEBAK-RESULT-COUNT` header in apis

### DIFF
--- a/lib/node/runner/api_block.go
+++ b/lib/node/runner/api_block.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"strconv"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/errors"
@@ -106,7 +107,7 @@ func (nh NetworkHandlerNode) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 
 	// set header; `X-SEBAK-xxx` indicates the basic explanation of the
 	// response.
-	w.Header().Set("X-SEBAK-RESULT-COUNT", string(len(bs)))
+	w.Header().Set("X-SEBAK-RESULT-COUNT", strconv.FormatInt(int64(len(bs)), 10))
 
 	for _, b := range bs {
 		var itemType NodeItemDataType

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -123,6 +124,11 @@ func TestGetBlocksHandler(t *testing.T) {
 	rbs, err := unmarshalFromNodeItemResponseBody(resp.Body)
 	require.NoError(t, err)
 	require.Equal(t, len(p.blocks), len(rbs[NodeItemBlockHeader]))
+	require.Equal(
+		t,
+		resp.Header.Get("X-SEBAK-RESULT-COUNT"),
+		strconv.FormatInt(int64(len(rbs[NodeItemBlockHeader])), 10),
+	)
 
 	for i, b := range p.blocks {
 		rb := rbs[NodeItemBlockHeader][i].(block.Header)

--- a/lib/node/runner/api_transaction.go
+++ b/lib/node/runner/api_transaction.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strconv"
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/errors"
@@ -46,7 +47,7 @@ func (nh NetworkHandlerNode) GetNodeTransactionsHandler(w http.ResponseWriter, r
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("X-SEBAK-RESULT-COUNT", string(len(hashes)))
+	w.Header().Set("X-SEBAK-RESULT-COUNT", strconv.FormatInt(int64(len(hashes)), 10))
 
 	// check in `block.TransactionPool`
 	for _, hash := range hashes {


### PR DESCRIPTION
### Github Issue

Resolves #815 

### Background

Current 2 apis, `/api/v1/blocks` and `/api/v1/transactions` returns with empty header, `X-SEBAK-RESULT-COUNT`. In http2, it occurs error, especially in sync.fetcher.

### Solution

Fixed bugs.