### PR TITLE
Api query encoding/decoding and prev cursor patch

### DIFF
--- a/lib/block/transaction_test.go
+++ b/lib/block/transaction_test.go
@@ -482,7 +482,7 @@ func TestMultipleBlockTransactionsOrderByBlockHeightAndCursor(t *testing.T) {
 		}
 
 		halfSaved = saved[len(saved)/2:]
-		theCursor = cursors[len(saved)/2]
+		theCursor = cursors[len(saved)/2-1]
 	}
 
 	// Check transactions filtered by cursor

--- a/lib/node/runner/api/account.go
+++ b/lib/node/runner/api/account.go
@@ -97,6 +97,7 @@ func (api NetworkHandlerAPI) GetFrozenAccountsByAccountHandler(w http.ResponseWr
 	}
 
 	var options = p.ListOptions()
+	var firstCursor []byte
 	var cursor []byte
 
 	readFunc := func() []resource.Resource {
@@ -116,9 +117,12 @@ func (api NetworkHandlerAPI) GetFrozenAccountsByAccountHandler(w http.ResponseWr
 			)
 
 			bo, hasNext, c := iterFunc()
-			cursor = c
 			if !hasNext {
 				break
+			}
+			cursor = c
+			if len(firstCursor) == 0 {
+				firstCursor = append(firstCursor, c...)
 			}
 			var (
 				casted operation.CreateAccount
@@ -190,7 +194,7 @@ func (api NetworkHandlerAPI) GetFrozenAccountsByAccountHandler(w http.ResponseWr
 
 	txs := readFunc()
 
-	list := p.ResourceList(txs, cursor)
+	list := p.ResourceList(txs, firstCursor, cursor)
 	httputils.MustWriteJSON(w, 200, list)
 }
 
@@ -202,6 +206,7 @@ func (api NetworkHandlerAPI) GetFrozenAccountsHandler(w http.ResponseWriter, r *
 	}
 
 	var options = p.ListOptions()
+	var firstCursor []byte
 	var cursor []byte
 
 	readFunc := func() []resource.Resource {
@@ -221,9 +226,12 @@ func (api NetworkHandlerAPI) GetFrozenAccountsHandler(w http.ResponseWriter, r *
 			)
 
 			bo, hasNext, c := iterFunc()
-			cursor = c
 			if !hasNext {
 				break
+			}
+			cursor = c
+			if len(firstCursor) == 0 {
+				firstCursor = append(firstCursor, c...)
 			}
 			var (
 				casted operation.CreateAccount
@@ -294,6 +302,6 @@ func (api NetworkHandlerAPI) GetFrozenAccountsHandler(w http.ResponseWriter, r *
 	}
 
 	txs := readFunc()
-	list := p.ResourceList(txs, cursor)
+	list := p.ResourceList(txs, firstCursor, cursor)
 	httputils.MustWriteJSON(w, 200, list)
 }

--- a/lib/node/runner/api/account.go
+++ b/lib/node/runner/api/account.go
@@ -120,7 +120,7 @@ func (api NetworkHandlerAPI) GetFrozenAccountsByAccountHandler(w http.ResponseWr
 			if !hasNext {
 				break
 			}
-			cursor = c
+			cursor = append([]byte{}, c...)
 			if len(firstCursor) == 0 {
 				firstCursor = append(firstCursor, c...)
 			}
@@ -229,7 +229,7 @@ func (api NetworkHandlerAPI) GetFrozenAccountsHandler(w http.ResponseWriter, r *
 			if !hasNext {
 				break
 			}
-			cursor = c
+			cursor = append([]byte{}, c...)
 			if len(firstCursor) == 0 {
 				firstCursor = append(firstCursor, c...)
 			}

--- a/lib/node/runner/api/base_test.go
+++ b/lib/node/runner/api/base_test.go
@@ -94,15 +94,18 @@ func prepareBlkTxOpWithoutSave(st *storage.LevelDBBackend) (*keypair.Full, block
 
 	return kp, theBlock, bt, bo
 }
-
-func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, *keypair.Full, []block.BlockTransaction) {
-	kp := keypair.Random()
-	kpTarget := keypair.Random()
+func prepareTxsWithKeyPair(storage *storage.LevelDBBackend, source, target *keypair.Full, count int) (*keypair.Full, *keypair.Full, []block.BlockTransaction) {
+	if source == nil {
+		source = keypair.Random()
+	}
+	if target == nil {
+		target = keypair.Random()
+	}
 	var txs []transaction.Transaction
 	var txHashes []string
 	var btList []block.BlockTransaction
 	for i := 0; i < count; i++ {
-		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, kp, kpTarget)
+		tx := transaction.TestMakeTransactionWithKeypair(networkID, 1, source, target)
 		txs = append(txs, tx)
 		txHashes = append(txHashes, tx.GetHash())
 	}
@@ -117,7 +120,12 @@ func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, *key
 		}
 		btList = append(btList, bt)
 	}
-	return kp, kpTarget, btList
+	return source, target, btList
+
+}
+
+func prepareTxs(storage *storage.LevelDBBackend, count int) (*keypair.Full, *keypair.Full, []block.BlockTransaction) {
+	return prepareTxsWithKeyPair(storage, nil, nil, count)
 }
 
 func prepareTxsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full, []block.BlockTransaction) {

--- a/lib/node/runner/api/blocks.go
+++ b/lib/node/runner/api/blocks.go
@@ -19,8 +19,9 @@ func (api NetworkHandlerAPI) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 	}
 
 	var (
-		cursor []byte // cursor as height
-		blocks []resource.Resource
+		firstCursor []byte
+		cursor      []byte // cursor as height
+		blocks      []resource.Resource
 	)
 
 	var option *storage.WalkOption
@@ -44,6 +45,9 @@ func (api NetworkHandlerAPI) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 				}
 			}
 			cursor = []byte(strconv.FormatUint(height, 10))
+			if len(firstCursor) == 0 {
+				firstCursor = append(firstCursor, cursor...)
+			}
 			return true, nil
 		})
 		if err != nil {
@@ -53,6 +57,6 @@ func (api NetworkHandlerAPI) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 		}
 	}
 
-	list := p.ResourceList(blocks, cursor)
+	list := p.ResourceList(blocks, firstCursor, cursor)
 	httputils.MustWriteJSON(w, 200, list)
 }

--- a/lib/node/runner/api/operation.go
+++ b/lib/node/runner/api/operation.go
@@ -52,7 +52,7 @@ func (api NetworkHandlerAPI) GetOperationsByAccountHandler(w http.ResponseWriter
 			if len(firstCursor) == 0 {
 				firstCursor = append(firstCursor, c...)
 			}
-			lastCursor = c
+			lastCursor = append([]byte{}, c...)
 
 			var blk *block.Block
 			var ok bool

--- a/lib/node/runner/api/operation.go
+++ b/lib/node/runner/api/operation.go
@@ -32,7 +32,46 @@ func (api NetworkHandlerAPI) GetOperationsByAccountHandler(w http.ResponseWriter
 
 	blockCache := map[ /* block.Height */ uint64]*block.Block{}
 	oType := operation.OperationType(oTypeStr)
-	var cursor []byte
+	var firstCursor []byte
+	var lastCursor []byte
+	readFunc := func() []resource.Resource {
+		var txs []resource.Resource
+
+		var iterFunc func() (block.BlockOperation, bool, []byte)
+		var closeFunc func()
+		if len(oType) > 0 {
+			iterFunc, closeFunc = block.GetBlockOperationsByPeersAndType(api.storage, address, oType, options)
+		} else {
+			iterFunc, closeFunc = block.GetBlockOperationsByPeers(api.storage, address, options)
+		}
+		for {
+			t, hasNext, c := iterFunc()
+			if !hasNext {
+				break
+			}
+			if len(firstCursor) == 0 {
+				firstCursor = append(firstCursor, c...)
+			}
+			lastCursor = c
+
+			var blk *block.Block
+			var ok bool
+			if blk, ok = blockCache[t.Height]; !ok {
+				if blk0, err := block.GetBlockByHeight(api.storage, t.Height); err != nil {
+					break
+				} else {
+					blockCache[t.Height] = &blk0
+					blk = &blk0
+				}
+			}
+
+			r := resource.NewOperation(&t)
+			r.Block = blk
+			txs = append(txs, r)
+		}
+		closeFunc()
+		return txs
+	}
 
 	if found, err := block.ExistsBlockAccount(api.storage, address); err != nil {
 		httputils.WriteJSONError(w, err)
@@ -42,39 +81,7 @@ func (api NetworkHandlerAPI) GetOperationsByAccountHandler(w http.ResponseWriter
 		return
 	}
 
-	var txs []resource.Resource
-
-	var iterFunc func() (block.BlockOperation, bool, []byte)
-	var closeFunc func()
-	if len(oType) > 0 {
-		iterFunc, closeFunc = block.GetBlockOperationsByPeersAndType(api.storage, address, oType, options)
-	} else {
-		iterFunc, closeFunc = block.GetBlockOperationsByPeers(api.storage, address, options)
-	}
-	for {
-		t, hasNext, c := iterFunc()
-		cursor = c
-		if !hasNext {
-			break
-		}
-
-		var blk *block.Block
-		var ok bool
-		if blk, ok = blockCache[t.Height]; !ok {
-			if blk0, err := block.GetBlockByHeight(api.storage, t.Height); err != nil {
-				break
-			} else {
-				blockCache[t.Height] = &blk0
-				blk = &blk0
-			}
-		}
-
-		r := resource.NewOperation(&t)
-		r.Block = blk
-		txs = append(txs, r)
-	}
-	closeFunc()
-
-	list := p.ResourceList(txs, cursor)
+	txs := readFunc()
+	list := p.ResourceList(txs, firstCursor, lastCursor)
 	httputils.MustWriteJSON(w, 200, list)
 }

--- a/lib/node/runner/api/operation_test.go
+++ b/lib/node/runner/api/operation_test.go
@@ -201,10 +201,6 @@ func TestGetOperationsByAccountHandlerPage(t *testing.T) {
 		ba.MustSave(storage)
 	}
 
-	for i, bo := range boList {
-		t.Log(i, bo.Hash)
-	}
-
 	// Do a Request for source account
 	prev := ""
 	next := ""
@@ -241,8 +237,6 @@ func TestGetOperationsByAccountHandlerPage(t *testing.T) {
 		records := recv["_embedded"].(map[string]interface{})["records"].([]interface{})
 		prev = recv["_links"].(map[string]interface{})["prev"].(map[string]interface{})["href"].(string)
 		next = recv["_links"].(map[string]interface{})["next"].(map[string]interface{})["href"].(string)
-		t.Log(prev)
-		t.Log(next)
 		for i, r := range records {
 			bt := r.(map[string]interface{})
 			require.Equal(t, boList[i+20].Hash, bt["hash"], "hash is not same")
@@ -263,15 +257,13 @@ func TestGetOperationsByAccountHandlerPage(t *testing.T) {
 		records := recv["_embedded"].(map[string]interface{})["records"].([]interface{})
 		prev = recv["_links"].(map[string]interface{})["prev"].(map[string]interface{})["href"].(string)
 		next = recv["_links"].(map[string]interface{})["next"].(map[string]interface{})["href"].(string)
-		t.Log(prev)
-		t.Log(next)
 		for i, r := range records {
 			bt := r.(map[string]interface{})
 			require.Equal(t, boList[i+40].Hash, bt["hash"], "hash is not same")
 		}
 	}
 
-	// 40 ~ 21
+	// 39 ~ 20
 	{
 		respBody := request(ts, prev, false)
 		defer respBody.Close()
@@ -284,15 +276,13 @@ func TestGetOperationsByAccountHandlerPage(t *testing.T) {
 		records := recv["_embedded"].(map[string]interface{})["records"].([]interface{})
 		prev = recv["_links"].(map[string]interface{})["prev"].(map[string]interface{})["href"].(string)
 		next = recv["_links"].(map[string]interface{})["next"].(map[string]interface{})["href"].(string)
-		t.Log(prev)
-		t.Log(next)
 		for i, r := range records {
 			bt := r.(map[string]interface{})
-			require.Equal(t, boList[40-i].Hash, bt["hash"], "hash is not same")
+			require.Equal(t, boList[40-1-i].Hash, bt["hash"], "hash is not same")
 		}
 	}
 
-	// 20 ~ 1
+	// 19 ~ 0
 	{
 		respBody := request(ts, prev, false)
 		defer respBody.Close()
@@ -305,11 +295,9 @@ func TestGetOperationsByAccountHandlerPage(t *testing.T) {
 		records := recv["_embedded"].(map[string]interface{})["records"].([]interface{})
 		prev = recv["_links"].(map[string]interface{})["prev"].(map[string]interface{})["href"].(string)
 		next = recv["_links"].(map[string]interface{})["next"].(map[string]interface{})["href"].(string)
-		t.Log(prev)
-		t.Log(next)
 		for i, r := range records {
 			bt := r.(map[string]interface{})
-			require.Equal(t, boList[20-i].Hash, bt["hash"], "hash is not same")
+			require.Equal(t, boList[20-1-i].Hash, bt["hash"], "hash is not same")
 		}
 	}
 }

--- a/lib/node/runner/api/transaction.go
+++ b/lib/node/runner/api/transaction.go
@@ -32,7 +32,7 @@ func (api NetworkHandlerAPI) GetTransactionsHandler(w http.ResponseWriter, r *ht
 			if !hasNext {
 				break
 			}
-			cursor = c
+			cursor = append([]byte{}, c...)
 			if len(firstCursor) == 0 {
 				firstCursor = append(firstCursor, c...)
 			}
@@ -97,7 +97,7 @@ func (api NetworkHandlerAPI) GetTransactionsByAccountHandler(w http.ResponseWrit
 			if !hasNext {
 				break
 			}
-			cursor = c
+			cursor = append([]byte{}, c...)
 			if len(firstCursor) == 0 {
 				firstCursor = append(firstCursor, c...)
 			}

--- a/lib/node/runner/api/transaction_test.go
+++ b/lib/node/runner/api/transaction_test.go
@@ -226,8 +226,8 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 
 			for i, r := range records {
 				bt := r.(map[string]interface{})
-				require.Equal(t, bt["hash"], btList[5+i].Hash, "hash is not the same")
-				require.Equal(t, bt["block"], btList[5+i].Block, "block is not the same")
+				require.Equal(t, bt["hash"], btList[4+i].Hash, "hash is not the same")
+				require.Equal(t, bt["block"], btList[4+i].Block, "block is not the same")
 			}
 		}
 	}

--- a/lib/node/runner/api/transaction_test.go
+++ b/lib/node/runner/api/transaction_test.go
@@ -171,7 +171,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 	defer storage.Close()
 	defer ts.Close()
 
-	_, _, btList := prepareTxs(storage, 10)
+	_, _, btList := prepareTxs(storage, 11)
 
 	requestFunction := func(url string) ([]interface{}, map[string]interface{}) {
 		respBody := request(ts, url, false)
@@ -185,7 +185,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 		common.MustUnmarshalJSON(readByte, &recv)
 		records := recv["_embedded"].(map[string]interface{})["records"].([]interface{})
 		links := recv["_links"].(map[string]interface{})
-		return records, links
+		return records[:], links
 	}
 
 	testFunction := func(query string) ([]interface{}, map[string]interface{}) {
@@ -197,7 +197,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 		query = strings.Replace(query, "{limit}", "0", 1)
 		query = strings.Replace(query, "{reverse}", "false", 1)
 		records, _ := testFunction(query)
-		require.Equal(t, len(btList), len(records[1:]), "length is not the same")
+		require.Equal(t, len(btList), len(records[1:]), "length is not the same") // 1: remove genesis transaction
 
 		for i, r := range records[1:] {
 			bt := r.(map[string]interface{})
@@ -207,10 +207,10 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 	}
 	{
 		query := strings.Replace(QueryPattern, "{cursor}", "", 1)
-		query = strings.Replace(query, "{limit}", "6", 1)
+		query = strings.Replace(query, "{limit}", "5", 1)
 		query = strings.Replace(query, "{reverse}", "false", 1)
 		records, links := testFunction(query)
-		require.Equal(t, len(btList[:5]), len(records[1:]), "length is not the same")
+		require.Equal(t, len(btList[:4]), len(records[1:]), "length is not the same") // 1: remove genesis Transaction
 
 		for i, r := range records[1:] {
 			bt := r.(map[string]interface{})
@@ -222,7 +222,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 
 		{
 			records, _ := requestFunction(nextLink)
-			require.Equal(t, len(btList[5:]), len(records), "length is not the same")
+			require.Equal(t, len(btList[4:9]), len(records), "length is not the same")
 
 			for i, r := range records {
 				bt := r.(map[string]interface{})
@@ -236,7 +236,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 		query = strings.Replace(query, "{limit}", "0", 1)
 		query = strings.Replace(query, "{reverse}", "true", 1)
 		records, _ := testFunction(query)
-		require.Equal(t, len(btList), len(records[:len(records)-1]), "length is not the same")
+		require.Equal(t, 11, len(records[:len(records)-1]), "length is not the same") // 1: remove genesis Transaction
 
 		for i, r := range records[:len(records)-1] {
 			bt := r.(map[string]interface{})
@@ -249,7 +249,7 @@ func TestGetTransactionsHandlerPage(t *testing.T) {
 		query = strings.Replace(query, "{limit}", "5", 1)
 		query = strings.Replace(query, "{reverse}", "true", 1)
 		records, _ := testFunction(query)
-		require.Equal(t, len(btList[5:]), len(records), "length is not the same")
+		require.Equal(t, 5, len(records), "length is not the same")
 
 		for i, r := range records {
 			bt := r.(map[string]interface{})

--- a/lib/node/runner/api/tx_operations.go
+++ b/lib/node/runner/api/tx_operations.go
@@ -52,7 +52,7 @@ func (api NetworkHandlerAPI) getOperationsByTxHash(txHash string, blk *block.Blo
 		if !hasNext {
 			break
 		}
-		cursor = c
+		cursor = append([]byte{}, c...)
 		if len(firstCursor) == 0 {
 			firstCursor = append(firstCursor, c...)
 		}

--- a/lib/node/runner/api_block_test.go
+++ b/lib/node/runner/api_block_test.go
@@ -225,7 +225,7 @@ func TestGetBlocksHandlerOptions(t *testing.T) {
 
 		options, err := NewGetBlocksOptionsFromRequest(nil)
 		require.NoError(t, err)
-		options.SetMode(GetBlocksOptionsModeBlock).SetCursor([]byte(p.blocks[cursorIndex].Hash))
+		options.SetMode(GetBlocksOptionsModeBlock).SetCursor([]byte(p.blocks[cursorIndex-1].Hash))
 		u := p.URL(options.URLValues())
 
 		req, _ := http.NewRequest("GET", u.String(), nil)

--- a/lib/storage/leveldb_test.go
+++ b/lib/storage/leveldb_test.go
@@ -174,16 +174,13 @@ func TestLevelDBIterator(t *testing.T) {
 	}
 
 	var collected []string
-	it, closeFunc := st.GetIterator("", &DefaultListOptions{reverse: false})
+	it, closeFunc := st.GetIterator("", &DefaultListOptions{reverse: false, limit: uint64(filteredCount)})
 	for {
 		v, hasNext := it()
 		if !hasNext {
 			break
 		}
 
-		if v.N > uint64(filteredCount) {
-			break
-		}
 		collected = append(collected, string(v.Key))
 	}
 	closeFunc()
@@ -193,6 +190,8 @@ func TestLevelDBIterator(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(expected, collected) {
+		t.Log("expected", expected)
+		t.Log("collected", collected)
 		t.Error("failed to fetch the exact sequence of items")
 	}
 
@@ -227,13 +226,13 @@ func TestLevelDBIteratorSeek(t *testing.T) {
 			name:     "reverse=false",
 			cursor:   100,
 			reverse:  false,
-			expected: expected1[100:],
+			expected: expected1[100+1:],
 		},
 		{
 			name:     "reverse=true",
 			cursor:   100,
 			reverse:  true,
-			expected: expected2[300-100-1:],
+			expected: expected2[300-100:],
 		},
 	}
 

--- a/lib/transaction/operation/test.go
+++ b/lib/transaction/operation/test.go
@@ -13,7 +13,7 @@ func MakeTestPayment(amount int) Operation {
 
 func MakeTestPaymentTo(amount int, address string) Operation {
 	for amount < 0 {
-		amount = rand.Intn(5000)
+		amount = rand.Intn(500000000)
 	}
 
 	return Operation{


### PR DESCRIPTION
### Github Issue
#819 #820 #823 

### Background
See issue #819 

### Solution
Encode the cursor with base64 before encoding to query string
Decode the cursor with base64 when parsing the query string

cursor for the `next` `prev` link needs to be different.

LevelDB iterator refactoring #823 

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

