### PR TITLE
Logging sebak version

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -28,6 +28,7 @@ import (
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/sync"
 	"boscoin.io/sebak/lib/transaction"
+	"boscoin.io/sebak/lib/version"
 )
 
 const (
@@ -512,7 +513,7 @@ func parseFlagsNode() {
 		cmdcommon.PrintFlagsError(nodeCmd, "--rate-limit-node", err)
 	}
 
-	log.Info("Starting Sebak")
+	log.Info("Starting Sebak", "version", version.Version, "gitcommit", version.GitCommit)
 
 	// print flags
 	parsedFlags := []interface{}{}


### PR DESCRIPTION

### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

Logging sebak version in logs 

```
t=2018-11-26T16:43:21+0900 lvl=info msg="Starting Sebak" module=main version=0.1.0 git=ca97589 caller=run.go:495
```


### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

