### PR TITLE
remove Subscribe API unit test

### DIFF
--- a/lib/node/runner/api/stream_test.go
+++ b/lib/node/runner/api/stream_test.go
@@ -2,9 +2,7 @@ package api
 
 import (
 	"bufio"
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,102 +10,9 @@ import (
 
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
-	"boscoin.io/sebak/lib/common/observer"
-	"boscoin.io/sebak/lib/transaction"
-
 	"github.com/GianlucaGuarini/go-observable"
 	"github.com/stretchr/testify/require"
 )
-
-func TestSubscribe(t *testing.T) {
-	ts, storage := prepareAPIServer()
-	defer storage.Close()
-	defer ts.Close()
-	kp, _, bt, bo := prepareBlkTxOpWithoutSave(storage)
-	ba := block.TestMakeBlockAccount(kp)
-
-	// Save
-	{
-		ba.MustSave(storage)
-		bt.MustSave(storage)
-		bo.MustSave(storage)
-	}
-
-	// Do a Request
-	var acReader *bufio.Reader
-	var txReader *bufio.Reader
-	var opReader *bufio.Reader
-	{
-		s := []observer.Conditions{{observer.NewCondition(observer.Acc, observer.Address, ba.Address)}}
-		b, err := json.Marshal(s)
-		require.NoError(t, err)
-		respBody := request(ts, PostSubscribePattern, true, b)
-		defer respBody.Close()
-		acReader = bufio.NewReader(respBody)
-	}
-	{
-		s := []observer.Conditions{{observer.NewCondition(observer.Tx, observer.TxHash, bt.Hash)}}
-		b, err := json.Marshal(s)
-		require.NoError(t, err)
-		respBody := request(ts, PostSubscribePattern, true, b)
-		defer respBody.Close()
-		txReader = bufio.NewReader(respBody)
-	}
-	{
-		s := []observer.Conditions{{observer.NewCondition(observer.Op, observer.OpHash, bo.Hash)}}
-		b, err := json.Marshal(s)
-		require.NoError(t, err)
-		respBody := request(ts, PostSubscribePattern, true, b)
-		defer respBody.Close()
-		opReader = bufio.NewReader(respBody)
-	}
-	tx := bt.Transaction()
-	txs := []*transaction.Transaction{&tx}
-	TriggerEvent(storage, txs)
-
-	// Check the output
-	{
-		line, err := acReader.ReadBytes('\n')
-		require.NoError(t, err)
-		line = bytes.Trim(line, "\n")
-		if len(line) == 0 {
-			line, err = acReader.ReadBytes('\n')
-			require.NoError(t, err)
-			line = bytes.Trim(line, "\n")
-		}
-		recv := make(map[string]interface{})
-		common.MustUnmarshalJSON(line, &recv)
-		require.Equal(t, ba.Address, recv["address"], "address is not same")
-	}
-	{
-		line, err := txReader.ReadBytes('\n')
-		require.NoError(t, err)
-		line = bytes.Trim(line, "\n")
-		if len(line) == 0 {
-			line, err = txReader.ReadBytes('\n')
-			require.NoError(t, err)
-			line = bytes.Trim(line, "\n")
-		}
-		recv := make(map[string]interface{})
-		common.MustUnmarshalJSON(line, &recv)
-		require.Equal(t, bt.Hash, recv["hash"], "hash is not the same")
-		require.Equal(t, bt.Block, recv["block"], "block is not the same")
-	}
-	{
-		line, err := opReader.ReadBytes('\n')
-		require.NoError(t, err)
-		line = bytes.Trim(line, "\n")
-		if len(line) == 0 {
-			line, err = opReader.ReadBytes('\n')
-			require.NoError(t, err)
-			line = bytes.Trim(line, "\n")
-		}
-		recv := make(map[string]interface{})
-		common.MustUnmarshalJSON(line, &recv)
-		require.Equal(t, bo.Hash, recv["hash"], "hash is not same")
-	}
-
-}
 
 func TestAPIStreamRun(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
### Github Issue
#808 

### Background
Subscribe testcase fails too often.

### Solution
It is not easy to imitate the observer/triggering environment
Hence, this test case should be moved to the integration test.

The integration test will be added soon.

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

