### PR TITLE
Refactor serialization code to be more compact

### DIFF
--- a/lib/block/account.go
+++ b/lib/block/account.go
@@ -1,7 +1,6 @@
 package block
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
@@ -82,13 +81,6 @@ func (b *BlockAccount) Save(st *storage.LevelDBBackend) (err error) {
 	err = bac.Save(st)
 
 	return
-}
-
-func (b *BlockAccount) Serialize() (encoded []byte, err error) {
-	return json.Marshal(b)
-}
-func (b *BlockAccount) Deserialize(encoded []byte) (err error) {
-	return json.Unmarshal(encoded, b)
 }
 
 func GetBlockAccountKey(address string) string {

--- a/lib/block/account.go
+++ b/lib/block/account.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
@@ -84,11 +85,10 @@ func (b *BlockAccount) Save(st *storage.LevelDBBackend) (err error) {
 }
 
 func (b *BlockAccount) Serialize() (encoded []byte, err error) {
-	encoded, err = common.EncodeJSONValue(b)
-	return
+	return json.Marshal(b)
 }
 func (b *BlockAccount) Deserialize(encoded []byte) (err error) {
-	return common.DecodeJSONValue(encoded, b)
+	return json.Unmarshal(encoded, b)
 }
 
 func GetBlockAccountKey(address string) string {

--- a/lib/block/account.go
+++ b/lib/block/account.go
@@ -51,7 +51,7 @@ func (b *BlockAccount) IncreaseSequenceID() {
 }
 
 func (b *BlockAccount) String() string {
-	return string(common.MustJSONMarshal(b))
+	return string(common.MustMarshalJSON(b))
 }
 
 func (b *BlockAccount) Save(st *storage.LevelDBBackend) (err error) {
@@ -236,7 +236,7 @@ func GetBlockAccountSequenceIDByAddressKeyPrefix(address string) string {
 }
 
 func (b *BlockAccountSequenceID) String() string {
-	return string(common.MustJSONMarshal(b))
+	return string(common.MustMarshalJSON(b))
 }
 
 func (b *BlockAccountSequenceID) Save(st *storage.LevelDBBackend) (err error) {

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -1,7 +1,6 @@
 package block
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
@@ -160,10 +159,6 @@ func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 	bo.isSaved = true
 
 	return nil
-}
-
-func (bo BlockOperation) Serialize() (encoded []byte, err error) {
-	return json.Marshal(bo)
 }
 
 func GetBlockOperationKey(hash string) string {

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
@@ -162,8 +163,7 @@ func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 }
 
 func (bo BlockOperation) Serialize() (encoded []byte, err error) {
-	encoded, err = common.EncodeJSONValue(bo)
-	return
+	return json.Marshal(bo)
 }
 
 func GetBlockOperationKey(hash string) string {

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -100,7 +100,7 @@ func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 		return errors.AlreadySaved
 	}
 
-	key := GetBlockOperationKey(bo.Hash)
+	key := key(bo.Hash)
 
 	var exists bool
 	if exists, err = st.Has(key); err != nil {
@@ -161,7 +161,7 @@ func (bo *BlockOperation) Save(st *storage.LevelDBBackend) (err error) {
 	return nil
 }
 
-func GetBlockOperationKey(hash string) string {
+func key(hash string) string {
 	return fmt.Sprintf("%s%s", common.BlockOperationPrefixHash, hash)
 }
 
@@ -174,7 +174,7 @@ func GetBlockOperationCreateFrozenKey(hash string, height uint64) string {
 	)
 }
 
-func GetBlockOperationKeyPrefixFrozenLinked(hash string) string {
+func keyPrefixFrozenLinked(hash string) string {
 	return fmt.Sprintf(
 		"%s%s",
 		common.BlockOperationPrefixFrozenLinked,
@@ -182,42 +182,42 @@ func GetBlockOperationKeyPrefixFrozenLinked(hash string) string {
 	)
 }
 
-func GetBlockOperationKeyPrefixTxHash(txHash string) string {
+func keyPrefixTxHash(txHash string) string {
 	return fmt.Sprintf("%s%s-", common.BlockOperationPrefixTxHash, txHash)
 }
 
-func GetBlockOperationKeyPrefixSource(source string) string {
+func keyPrefixSource(source string) string {
 	return fmt.Sprintf("%s%s-", common.BlockOperationPrefixSource, source)
 }
 
-func GetBlockOperationKeyPrefixSourceAndType(source string, ty operation.OperationType) string {
+func keyPrefixSourceAndType(source string, ty operation.OperationType) string {
 	return fmt.Sprintf("%s%s%s-", common.BlockOperationPrefixTypeSource, string(ty), source)
 }
 
-func GetBlockOperationKeyPrefixBlockHeight(height uint64) string {
+func keyPrefixBlockHeight(height uint64) string {
 	return fmt.Sprintf("%s%s-", common.BlockOperationPrefixBlockHeight, common.EncodeUint64ToByteSlice(height))
 }
 
-func GetBlockOperationKeyPrefixTarget(target string) string {
+func keyPrefixTarget(target string) string {
 	return fmt.Sprintf("%s%s-", common.BlockOperationPrefixTarget, target)
 }
 
-func GetBlockOperationKeyPrefixTargetAndType(target string, ty operation.OperationType) string {
+func keyPrefixTargetAndType(target string, ty operation.OperationType) string {
 	return fmt.Sprintf("%s%s%s-", common.BlockOperationPrefixTypeTarget, string(ty), target)
 }
 
-func GetBlockOperationKeyPrefixPeers(addr string) string {
+func keyPrefixPeers(addr string) string {
 	return fmt.Sprintf("%s%s-", common.BlockOperationPrefixPeers, addr)
 }
 
-func GetBlockOperationKeyPrefixPeersAndType(addr string, ty operation.OperationType) string {
+func keyPrefixPeersAndType(addr string, ty operation.OperationType) string {
 	return fmt.Sprintf("%s%s%s-", common.BlockOperationPrefixTypePeers, string(ty), addr)
 }
 
 func (bo BlockOperation) NewBlockOperationTxHashKey() string {
 	return fmt.Sprintf(
 		"%s%s%s%s",
-		GetBlockOperationKeyPrefixTxHash(bo.TxHash),
+		keyPrefixTxHash(bo.TxHash),
 		common.EncodeUint64ToByteSlice(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
@@ -227,7 +227,7 @@ func (bo BlockOperation) NewBlockOperationTxHashKey() string {
 func (bo BlockOperation) NewBlockOperationSourceKey() string {
 	return fmt.Sprintf(
 		"%s%s%s%s",
-		GetBlockOperationKeyPrefixSource(bo.Source),
+		keyPrefixSource(bo.Source),
 		common.EncodeUint64ToByteSlice(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
@@ -237,7 +237,7 @@ func (bo BlockOperation) NewBlockOperationSourceKey() string {
 func (bo BlockOperation) NewBlockOperationFrozenLinkedKey(hash string) string {
 	return fmt.Sprintf(
 		"%s%s",
-		GetBlockOperationKeyPrefixFrozenLinked(hash),
+		keyPrefixFrozenLinked(hash),
 		common.EncodeUint64ToByteSlice(bo.Height),
 	)
 }
@@ -245,7 +245,7 @@ func (bo BlockOperation) NewBlockOperationFrozenLinkedKey(hash string) string {
 func (bo BlockOperation) NewBlockOperationSourceAndTypeKey() string {
 	return fmt.Sprintf(
 		"%s%s%s%s",
-		GetBlockOperationKeyPrefixSourceAndType(bo.Source, bo.Type),
+		keyPrefixSourceAndType(bo.Source, bo.Type),
 		common.EncodeUint64ToByteSlice(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
@@ -254,7 +254,7 @@ func (bo BlockOperation) NewBlockOperationSourceAndTypeKey() string {
 func (bo BlockOperation) NewBlockOperationTargetKey(target string) string {
 	return fmt.Sprintf(
 		"%s%s%s%s",
-		GetBlockOperationKeyPrefixTarget(target),
+		keyPrefixTarget(target),
 		common.EncodeUint64ToByteSlice(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
@@ -264,7 +264,7 @@ func (bo BlockOperation) NewBlockOperationTargetKey(target string) string {
 func (bo BlockOperation) NewBlockOperationTargetAndTypeKey(target string) string {
 	return fmt.Sprintf(
 		"%s%s%s%s",
-		GetBlockOperationKeyPrefixTargetAndType(target, bo.Type),
+		keyPrefixTargetAndType(target, bo.Type),
 		common.EncodeUint64ToByteSlice(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
@@ -274,7 +274,7 @@ func (bo BlockOperation) NewBlockOperationTargetAndTypeKey(target string) string
 func (bo BlockOperation) NewBlockOperationPeersKey(addr string) string {
 	return fmt.Sprintf(
 		"%s%s%s%s",
-		GetBlockOperationKeyPrefixPeers(addr),
+		keyPrefixPeers(addr),
 		common.EncodeUint64ToByteSlice(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
@@ -284,7 +284,7 @@ func (bo BlockOperation) NewBlockOperationPeersKey(addr string) string {
 func (bo BlockOperation) NewBlockOperationPeersAndTypeKey(addr string) string {
 	return fmt.Sprintf(
 		"%s%s%s%s",
-		GetBlockOperationKeyPrefixPeersAndType(addr, bo.Type),
+		keyPrefixPeersAndType(addr, bo.Type),
 		common.EncodeUint64ToByteSlice(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
@@ -293,18 +293,18 @@ func (bo BlockOperation) NewBlockOperationPeersAndTypeKey(addr string) string {
 func (bo BlockOperation) NewBlockOperationBlockHeightKey() string {
 	return fmt.Sprintf(
 		"%s%s%s",
-		GetBlockOperationKeyPrefixBlockHeight(bo.Height),
+		keyPrefixBlockHeight(bo.Height),
 		common.EncodeUint64ToByteSlice(bo.transaction.B.SequenceID),
 		common.GetUniqueIDFromUUID(),
 	)
 }
 
 func ExistsBlockOperation(st *storage.LevelDBBackend, hash string) (bool, error) {
-	return st.Has(GetBlockOperationKey(hash))
+	return st.Has(key(hash))
 }
 
 func GetBlockOperation(st *storage.LevelDBBackend, hash string) (bo BlockOperation, err error) {
-	if err = st.Get(GetBlockOperationKey(hash), &bo); err != nil {
+	if err = st.Get(key(hash), &bo); err != nil {
 		return
 	}
 
@@ -367,7 +367,7 @@ func GetBlockOperationsByTxHash(st *storage.LevelDBBackend, txHash string, optio
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixTxHash(txHash), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixTxHash(txHash), options)
 
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
@@ -376,7 +376,7 @@ func GetBlockOperationsBySource(st *storage.LevelDBBackend, source string, optio
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixSource(source), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixSource(source), options)
 
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
@@ -395,7 +395,7 @@ func GetBlockOperationsByLinked(st *storage.LevelDBBackend, hash string, options
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixFrozenLinked(hash), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixFrozenLinked(hash), options)
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
 
@@ -403,7 +403,7 @@ func GetBlockOperationsBySourceAndType(st *storage.LevelDBBackend, source string
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixSourceAndType(source, ty), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixSourceAndType(source, ty), options)
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
 
@@ -411,7 +411,7 @@ func GetBlockOperationsByTarget(st *storage.LevelDBBackend, target string, optio
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixTarget(target), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixTarget(target), options)
 
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
@@ -420,7 +420,7 @@ func GetBlockOperationsByTargetAndType(st *storage.LevelDBBackend, target string
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixTargetAndType(target, ty), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixTargetAndType(target, ty), options)
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
 
@@ -428,7 +428,7 @@ func GetBlockOperationsByPeers(st *storage.LevelDBBackend, addr string, options 
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixPeers(addr), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixPeers(addr), options)
 
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
@@ -437,7 +437,7 @@ func GetBlockOperationsByPeersAndType(st *storage.LevelDBBackend, addr string, t
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixPeersAndType(addr, ty), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixPeersAndType(addr, ty), options)
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }
 
@@ -445,6 +445,6 @@ func GetBlockOperationsByBlockHeight(st *storage.LevelDBBackend, height uint64, 
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {
-	iterFunc, closeFunc := st.GetIterator(GetBlockOperationKeyPrefixBlockHeight(height), options)
+	iterFunc, closeFunc := st.GetIterator(keyPrefixBlockHeight(height), options)
 	return LoadBlockOperationsInsideIterator(st, iterFunc, closeFunc)
 }

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
@@ -42,7 +43,7 @@ func NewBlockOperationKey(opHash, txHash string) string {
 }
 
 func NewBlockOperationFromOperation(op operation.Operation, tx transaction.Transaction, blockHeight uint64, opIndex int) (BlockOperation, error) {
-	body, err := op.B.Serialize()
+	body, err := json.Marshal(op.B)
 	if err != nil {
 		return BlockOperation{}, err
 	}

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -22,8 +22,7 @@ func TestNewBlockOperationFromOperation(t *testing.T) {
 	require.Equal(t, bo.Type, op.H.Type)
 	require.Equal(t, bo.TxHash, tx.H.Hash)
 	require.Equal(t, bo.Source, tx.B.Source)
-	encoded, err := op.B.Serialize()
-	require.NoError(t, err)
+	encoded := common.MustMarshalJSON(op.B)
 	require.Equal(t, bo.Body, encoded)
 }
 
@@ -125,8 +124,7 @@ func TestBlockOperationSaveByTransaction(t *testing.T) {
 		require.Equal(t, bo.Type, op.H.Type)
 		require.Equal(t, bo.TxHash, tx.H.Hash)
 		require.Equal(t, bo.Source, tx.B.Source)
-		encoded, err := op.B.Serialize()
-		require.NoError(t, err)
+		encoded := common.MustMarshalJSON(op.B)
 		require.Equal(t, bo.Body, encoded)
 	}
 }

--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
@@ -139,13 +140,15 @@ func (bt *BlockTransaction) Save(st *storage.LevelDBBackend) (err error) {
 }
 
 func (bt BlockTransaction) Serialize() (encoded []byte, err error) {
-	encoded, err = common.EncodeJSONValue(bt)
-	return
+	return json.Marshal(bt)
 }
 
 func (bt BlockTransaction) String() string {
-	encoded, _ := common.EncodeJSONValue(bt)
-	return string(encoded)
+	if encoded, err := json.Marshal(bt); err != nil {
+		panic(err)
+	} else {
+		return string(encoded)
+	}
 }
 
 func (bt BlockTransaction) Transaction() transaction.Transaction {
@@ -155,7 +158,7 @@ func (bt BlockTransaction) Transaction() transaction.Transaction {
 			return tx
 		}
 
-		if err := common.DecodeJSONValue(bt.Message, &tx); err != nil {
+		if err := json.Unmarshal(bt.Message, &tx); err != nil {
 			return tx
 		}
 

--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -139,10 +139,6 @@ func (bt *BlockTransaction) Save(st *storage.LevelDBBackend) (err error) {
 	return nil
 }
 
-func (bt BlockTransaction) Serialize() (encoded []byte, err error) {
-	return json.Marshal(bt)
-}
-
 func (bt BlockTransaction) String() string {
 	if encoded, err := json.Marshal(bt); err != nil {
 		panic(err)

--- a/lib/block/transaction_pool.go
+++ b/lib/block/transaction_pool.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"boscoin.io/sebak/lib/common"
@@ -24,7 +25,7 @@ type TransactionPool struct {
 
 func NewTransactionPool(tx transaction.Transaction) (tp TransactionPool, err error) {
 	var b []byte
-	if b, err = common.EncodeJSONValue(tx); err != nil {
+	if b, err = json.Marshal(tx); err != nil {
 		return
 	}
 
@@ -60,18 +61,21 @@ func (tp TransactionPool) Save(st *storage.LevelDBBackend) (err error) {
 }
 
 func (tp TransactionPool) Serialize() ([]byte, error) {
-	return common.EncodeJSONValue(tp)
+	return json.Marshal(tp)
 }
 
 func (tp TransactionPool) String() string {
-	encoded, _ := common.EncodeJSONValue(tp)
-	return string(encoded)
+	if encoded, err := json.Marshal(tp); err != nil {
+		panic(err)
+	} else {
+		return string(encoded)
+	}
 }
 
 func (tp TransactionPool) Transaction() transaction.Transaction {
 	if tp.transaction.IsEmpty() {
 		var tx transaction.Transaction
-		if err := common.DecodeJSONValue(tp.Message, &tx); err != nil {
+		if err := json.Unmarshal(tp.Message, &tx); err != nil {
 			return tx
 		}
 

--- a/lib/block/transaction_pool_test.go
+++ b/lib/block/transaction_pool_test.go
@@ -32,7 +32,7 @@ func TestTransactionPool(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, rtp.Hash, tx.GetHash())
 
-		b := common.MustJSONMarshal(tx)
+		b := common.MustMarshalJSON(tx)
 		require.Equal(t, rtp.Message, b)
 	}
 

--- a/lib/block/transaction_pool_test.go
+++ b/lib/block/transaction_pool_test.go
@@ -32,7 +32,7 @@ func TestTransactionPool(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, rtp.Hash, tx.GetHash())
 
-		b, _ := common.EncodeJSONValue(tx)
+		b := common.MustJSONMarshal(tx)
 		require.Equal(t, rtp.Message, b)
 	}
 

--- a/lib/common/data.go
+++ b/lib/common/data.go
@@ -1,18 +1,5 @@
 package common
 
-import "encoding/json"
-
-func EncodeJSONValue(v interface{}) (b []byte, err error) {
-	return json.Marshal(v)
-}
-
-func DecodeJSONValue(b []byte, v interface{}) (err error) {
-	if err = json.Unmarshal(b, v); err != nil {
-		return
-	}
-	return
-}
-
 type Serializable interface {
 	Serialize() ([]byte, error)
 }

--- a/lib/common/data.go
+++ b/lib/common/data.go
@@ -1,5 +1,0 @@
-package common
-
-type Serializable interface {
-	Serialize() ([]byte, error)
-}

--- a/lib/common/log.go
+++ b/lib/common/log.go
@@ -39,7 +39,7 @@ func formatJSONValue(value interface{}) (result interface{}) {
 	}()
 
 	switch v := value.(type) {
-	case json.Marshaler, Serializable, *errors.Error:
+	case json.Marshaler, *errors.Error:
 		return v
 	case time.Time:
 		return FormatISO8601(v)

--- a/lib/common/net.go
+++ b/lib/common/net.go
@@ -184,7 +184,3 @@ func NewRateLimitRule(rate limiter.Rate) RateLimitRule {
 		ByIPAddress: map[string]limiter.Rate{},
 	}
 }
-
-func (r RateLimitRule) Serializable() ([]byte, error) {
-	return json.Marshal(r)
-}

--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -74,7 +74,7 @@ func MustUnmarshalJSON(data []byte, v interface{}) {
 	}
 }
 
-func MustJSONMarshal(o interface{}) []byte {
+func MustMarshalJSON(o interface{}) []byte {
 	b, _ := json.Marshal(o)
 	return b
 }

--- a/lib/network/base.go
+++ b/lib/network/base.go
@@ -37,9 +37,9 @@ type NetworkClient interface {
 
 	Connect(node node.Node) ([]byte, error)
 	GetNodeInfo() ([]byte, error)
-	SendMessage(common.Serializable) ([]byte, error)
-	SendTransaction(common.Serializable) ([]byte, error)
-	SendBallot(common.Serializable) ([]byte, error)
+	SendMessage(interface{}) ([]byte, error)
+	SendTransaction(interface{}) ([]byte, error)
+	SendBallot(interface{}) ([]byte, error)
 	GetTransactions([]string) ([]byte, error)
 }
 

--- a/lib/network/http2_client.go
+++ b/lib/network/http2_client.go
@@ -77,12 +77,12 @@ func (c *HTTP2NetworkClient) GetNodeInfo() (body []byte, err error) {
 	return
 }
 
-func (c *HTTP2NetworkClient) Send(path string, message common.Serializable) (retBody []byte, err error) {
+func (c *HTTP2NetworkClient) Send(path string, message interface{}) (retBody []byte, err error) {
 	headers := c.DefaultHeaders()
 	headers.Set("Content-Type", "application/json")
 
 	var body []byte
-	if body, err = message.Serialize(); err != nil {
+	if body, err = json.Marshal(message); err != nil {
 		return
 	}
 
@@ -107,15 +107,15 @@ func (c *HTTP2NetworkClient) Connect(n node.Node) (body []byte, err error) {
 	return c.Send(UrlPathPrefixNode+"/connect", n)
 }
 
-func (c *HTTP2NetworkClient) SendMessage(message common.Serializable) (retBody []byte, err error) {
+func (c *HTTP2NetworkClient) SendMessage(message interface{}) (retBody []byte, err error) {
 	return c.Send(UrlPathPrefixNode+"/message", message)
 }
 
-func (c *HTTP2NetworkClient) SendTransaction(message common.Serializable) (retBody []byte, err error) {
+func (c *HTTP2NetworkClient) SendTransaction(message interface{}) (retBody []byte, err error) {
 	return c.Send(resource.URLTransactions, message)
 }
 
-func (c *HTTP2NetworkClient) SendBallot(message common.Serializable) (retBody []byte, err error) {
+func (c *HTTP2NetworkClient) SendBallot(message interface{}) (retBody []byte, err error) {
 	return c.Send(UrlPathPrefixNode+"/ballot", message)
 }
 

--- a/lib/network/http2_config.go
+++ b/lib/network/http2_config.go
@@ -82,5 +82,5 @@ func (config HTTP2NetworkConfig) IsHTTPS() bool {
 }
 
 func (config HTTP2NetworkConfig) String() string {
-	return string(common.MustJSONMarshal(config))
+	return string(common.MustMarshalJSON(config))
 }

--- a/lib/network/memory.go
+++ b/lib/network/memory.go
@@ -9,10 +9,11 @@ import (
 	"github.com/gorilla/mux"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/node"
 )
 
 type MemoryNetwork struct {
-	localNode  common.Serializable
+	localNode  *node.LocalNode
 	endpoint   *common.Endpoint
 	connWriter chan common.NetworkMessage
 	close      chan bool
@@ -98,7 +99,7 @@ func (p *MemoryNetwork) receiveMessage() {
 	}
 }
 
-func (p *MemoryNetwork) SetLocalNode(localNode common.Serializable) {
+func (p *MemoryNetwork) SetLocalNode(localNode *node.LocalNode) {
 	p.localNode = localNode
 }
 

--- a/lib/network/memory_client.go
+++ b/lib/network/memory_client.go
@@ -1,6 +1,8 @@
 package network
 
 import (
+	"encoding/json"
+
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/node"
@@ -33,9 +35,9 @@ func (m *MemoryTransportClient) GetNodeInfo() (b []byte, err error) {
 	return
 }
 
-func (m *MemoryTransportClient) SendMessage(message common.Serializable) (body []byte, err error) {
+func (m *MemoryTransportClient) SendMessage(message interface{}) (body []byte, err error) {
 	var s []byte
-	if s, err = message.Serialize(); err != nil {
+	if s, err = json.Marshal(message); err != nil {
 		return
 	}
 	m.server.Send(common.TransactionMessage, s)
@@ -43,13 +45,13 @@ func (m *MemoryTransportClient) SendMessage(message common.Serializable) (body [
 	return
 }
 
-func (m *MemoryTransportClient) SendTransaction(message common.Serializable) (body []byte, err error) {
+func (m *MemoryTransportClient) SendTransaction(message interface{}) (body []byte, err error) {
 	return m.SendMessage(message)
 }
 
-func (m *MemoryTransportClient) SendBallot(message common.Serializable) (body []byte, err error) {
+func (m *MemoryTransportClient) SendBallot(message interface{}) (body []byte, err error) {
 	var s []byte
-	if s, err = message.Serialize(); err != nil {
+	if s, err = json.Marshal(message); err != nil {
 		return
 	}
 	m.server.Send(common.BallotMessage, s)

--- a/lib/node/runner/api/account.go
+++ b/lib/node/runner/api/account.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"net/http"
 
@@ -53,7 +54,7 @@ func (api NetworkHandlerAPI) GetAccountsHandler(w http.ResponseWriter, r *http.R
 	}
 
 	var addresses []string
-	if err := common.DecodeJSONValue(body, &addresses); err != nil {
+	if err := json.Unmarshal(body, &addresses); err != nil {
 		httputils.WriteJSONError(w, errors.BadRequestParameter.Clone().SetData("error", err.Error()))
 		return
 	}

--- a/lib/node/runner/api/account_test.go
+++ b/lib/node/runner/api/account_test.go
@@ -67,7 +67,7 @@ func TestGetNonExistentAccountHandler(t *testing.T) {
 		reader := bufio.NewReader(respBody)
 		readByte, err := ioutil.ReadAll(reader)
 		require.NoError(t, err)
-		pByte := common.MustJSONMarshal(p)
+		pByte := common.MustMarshalJSON(p)
 		require.Equal(t, pByte, readByte)
 	}
 }
@@ -98,7 +98,7 @@ func TestGetAccountsHandler(t *testing.T) {
 	}
 
 	{ // request with empty list
-		b := common.MustJSONMarshal([]string{})
+		b := common.MustMarshalJSON([]string{})
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
@@ -126,7 +126,7 @@ func TestGetAccountsHandler(t *testing.T) {
 			}
 		}
 
-		b := common.MustJSONMarshal(expectedAddresses)
+		b := common.MustMarshalJSON(expectedAddresses)
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
@@ -152,7 +152,7 @@ func TestGetAccountsHandler(t *testing.T) {
 			expectedAddresses = append(expectedAddresses, address)
 		}
 
-		b := common.MustJSONMarshal(expectedAddresses)
+		b := common.MustMarshalJSON(expectedAddresses)
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
@@ -187,7 +187,7 @@ func TestGetAccountsHandler(t *testing.T) {
 		}
 		expectedAddresses = append(expectedAddresses, unknownAddresses...)
 
-		b := common.MustJSONMarshal(expectedAddresses)
+		b := common.MustMarshalJSON(expectedAddresses)
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)

--- a/lib/node/runner/api/account_test.go
+++ b/lib/node/runner/api/account_test.go
@@ -98,7 +98,7 @@ func TestGetAccountsHandler(t *testing.T) {
 	}
 
 	{ // request with empty list
-		b, _ := common.EncodeJSONValue([]string{})
+		b := common.MustJSONMarshal([]string{})
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
@@ -126,7 +126,7 @@ func TestGetAccountsHandler(t *testing.T) {
 			}
 		}
 
-		b, _ := common.EncodeJSONValue(expectedAddresses)
+		b := common.MustJSONMarshal(expectedAddresses)
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
@@ -152,7 +152,7 @@ func TestGetAccountsHandler(t *testing.T) {
 			expectedAddresses = append(expectedAddresses, address)
 		}
 
-		b, _ := common.EncodeJSONValue(expectedAddresses)
+		b := common.MustJSONMarshal(expectedAddresses)
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)
@@ -187,7 +187,7 @@ func TestGetAccountsHandler(t *testing.T) {
 		}
 		expectedAddresses = append(expectedAddresses, unknownAddresses...)
 
-		b, _ := common.EncodeJSONValue(expectedAddresses)
+		b := common.MustJSONMarshal(expectedAddresses)
 		respBody := request(ts, GetAccountsHandlerPattern, false, b)
 		defer respBody.Close()
 		reader := bufio.NewReader(respBody)

--- a/lib/node/runner/api/stream.go
+++ b/lib/node/runner/api/stream.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"boscoin.io/sebak/lib/common/observer"
-	"boscoin.io/sebak/lib/errors"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,7 +9,8 @@ import (
 
 	"github.com/GianlucaGuarini/go-observable"
 
-	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/observer"
+	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network/httputils"
 )
 
@@ -62,20 +61,6 @@ type EventStream struct {
 
 type RenderFunc func(args ...interface{}) ([]byte, error)
 
-// RenderSerializableFunc takes common.Serializable and serialize it for rendering.
-var RenderSerializableFunc = func(args ...interface{}) ([]byte, error) {
-	s, ok := args[1].(common.Serializable)
-	if !ok {
-		return nil, fmt.Errorf("this is not serializable") // TODO(anarcher): Error type
-	}
-
-	bs, err := s.Serialize()
-	if err != nil {
-		return nil, err
-	}
-	return bs, nil
-}
-
 // NewDefaultEventStream uses RenderJSONFunc by default
 var RenderJSONFunc = func(args ...interface{}) ([]byte, error) {
 	if len(args) <= 1 {
@@ -92,7 +77,7 @@ var RenderJSONFunc = func(args ...interface{}) ([]byte, error) {
 	return bs, nil
 }
 
-// NewDefaultEventStream returns *EventStream with RenderSerializableFunc and DefaultContentType
+// NewDefaultEventStream returns *EventStream with RenderJSONFunc and DefaultContentType
 func NewDefaultEventStream(w http.ResponseWriter, r *http.Request) *EventStream {
 	return NewEventStream(w, r, RenderJSONFunc, DefaultContentType)
 }

--- a/lib/node/runner/api/stream_test.go
+++ b/lib/node/runner/api/stream_test.go
@@ -51,11 +51,7 @@ func TestAPIStreamRun(t *testing.T) {
 					if !ok {
 						return nil, fmt.Errorf("this is not serializable")
 					}
-					bs, err := s.Serialize()
-					if err != nil {
-						return nil, err
-					}
-					return bs, nil
+					return common.MustMarshalJSON(s), nil
 				}
 				es := NewEventStream(w, r, renderFunc, DefaultContentType)
 				return es

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -287,7 +287,7 @@ func TestGetNodeTransactionsHandlerWithMultipleHashes(t *testing.T) {
 		var postData []string
 		postData = append(postData, txHashes...)
 
-		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(common.MustJSONMarshal(postData)))
+		req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(common.MustMarshalJSON(postData)))
 		req.Header.Set("Content-Type", "application/json")
 		require.NoError(t, err)
 		resp, err := p.server.Client().Do(req)

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -9,7 +9,6 @@ import (
 	leveldbStorage "github.com/syndtr/goleveldb/leveldb/storage"
 	leveldbUtil "github.com/syndtr/goleveldb/leveldb/util"
 
-	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/errors"
 )
 
@@ -171,12 +170,7 @@ func (st *LevelDBBackend) New(k string, v interface{}) (err error) {
 	}
 
 	var encoded []byte
-	serializable, ok := v.(common.Serializable)
-	if ok {
-		encoded, err = serializable.Serialize()
-	} else {
-		encoded, err = json.Marshal(v)
-	}
+	encoded, err = json.Marshal(v)
 	if err != nil {
 		return setLevelDBCoreError(err)
 	}

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -261,19 +261,14 @@ func (st *LevelDBBackend) Sets(vs ...Item) (err error) {
 	return
 }
 
-func (st *LevelDBBackend) Remove(k string) (err error) {
-	var exists bool
-	if exists, err = st.Has(k); !exists || err != nil {
-		if !exists {
-			err = errors.StorageRecordDoesNotExist
-			return
-		}
-		return
+func (st *LevelDBBackend) Remove(k string) error {
+	if exists, err := st.Has(k); err != nil {
+		return err
+	} else if !exists {
+		return errors.StorageRecordDoesNotExist
+	} else {
+		return setLevelDBCoreError(st.Core.Delete(st.makeKey(k), nil))
 	}
-
-	err = setLevelDBCoreError(st.Core.Delete(st.makeKey(k), nil))
-
-	return
 }
 
 func (st *LevelDBBackend) GetIterator(prefix string, option ListOptions) (func() (IterItem, bool), func()) {

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -175,7 +175,7 @@ func (st *LevelDBBackend) New(k string, v interface{}) (err error) {
 	if ok {
 		encoded, err = serializable.Serialize()
 	} else {
-		encoded, err = common.EncodeJSONValue(v)
+		encoded, err = json.Marshal(v)
 	}
 	if err != nil {
 		return setLevelDBCoreError(err)
@@ -203,9 +203,8 @@ func (st *LevelDBBackend) News(vs ...Item) (err error) {
 	batch := new(leveldb.Batch)
 	for _, v := range vs {
 		var encoded []byte
-		if encoded, err = common.EncodeJSONValue(v); err != nil {
-			err = setLevelDBCoreError(err)
-			return
+		if encoded, err = json.Marshal(v); err != nil {
+			return setLevelDBCoreError(err)
 		}
 
 		batch.Put(st.makeKey(v.Key), encoded)
@@ -218,9 +217,8 @@ func (st *LevelDBBackend) News(vs ...Item) (err error) {
 
 func (st *LevelDBBackend) Set(k string, v interface{}) (err error) {
 	var encoded []byte
-	if encoded, err = common.EncodeJSONValue(v); err != nil {
-		err = setLevelDBCoreError(err)
-		return
+	if encoded, err = json.Marshal(v); err != nil {
+		return setLevelDBCoreError(err)
 	}
 
 	var exists bool
@@ -257,9 +255,8 @@ func (st *LevelDBBackend) Sets(vs ...Item) (err error) {
 	batch := new(leveldb.Batch)
 	for _, v := range vs {
 		var encoded []byte
-		if encoded, err = common.EncodeJSONValue(v); err != nil {
-			err = setLevelDBCoreError(err)
-			return
+		if encoded, err = json.Marshal(v); err != nil {
+			return setLevelDBCoreError(err)
 		}
 
 		batch.Put(st.makeKey(v.Key), encoded)

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -178,13 +178,10 @@ func (st *LevelDBBackend) New(k string, v interface{}) (err error) {
 		encoded, err = common.EncodeJSONValue(v)
 	}
 	if err != nil {
-		err = setLevelDBCoreError(err)
-		return
+		return setLevelDBCoreError(err)
 	}
 
-	err = setLevelDBCoreError(st.Core.Put(st.makeKey(k), encoded, nil))
-
-	return
+	return setLevelDBCoreError(st.Core.Put(st.makeKey(k), encoded, nil))
 }
 
 func (st *LevelDBBackend) News(vs ...Item) (err error) {

--- a/lib/storage/statedb/state_object.go
+++ b/lib/storage/statedb/state_object.go
@@ -1,10 +1,12 @@
 package statedb
 
 import (
+	"bytes"
+	"encoding/json"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/storage/statedb/trie"
-	"bytes"
 )
 
 type Storage map[common.Hash]common.Hash
@@ -41,11 +43,11 @@ func newObject(addr string, data block.BlockAccount, db *trie.EthDatabase, onDir
 }
 
 func (so *stateObject) Serialize() ([]byte, error) {
-	return so.data.Serialize()
+	return json.Marshal(so.data)
 }
 
 func (so *stateObject) Deserialize(encoded []byte) error {
-	return so.data.Deserialize(encoded)
+	return json.Unmarshal(encoded, so.data)
 }
 
 /* GETTERS */

--- a/lib/storage/statedb/statedb.go
+++ b/lib/storage/statedb/statedb.go
@@ -1,10 +1,12 @@
 package statedb
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/storage/statedb/trie"
-	"fmt"
 )
 
 type StateDB struct {
@@ -150,7 +152,7 @@ func (stateDB *StateDB) getStateObject(addr string) (stateObject *stateObject) {
 	}
 	var data block.BlockAccount
 
-	if err := data.Deserialize(enc); err != nil {
+	if err := json.Unmarshal(enc, &data); err != nil {
 		return nil
 	}
 	obj := newObject(addr, data, stateDB.db, stateDB.MarkStateObjectDirty)

--- a/lib/transaction/operation/collect_tx_fee.go
+++ b/lib/transaction/operation/collect_tx_fee.go
@@ -1,8 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
-
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
@@ -70,10 +68,6 @@ func (o CollectTxFee) TargetAddress() string {
 
 func (o CollectTxFee) GetAmount() common.Amount {
 	return o.Amount
-}
-
-func (o CollectTxFee) Serialize() (encoded []byte, err error) {
-	return json.Marshal(o)
 }
 
 func (o CollectTxFee) HasFee() bool {

--- a/lib/transaction/operation/congress_voting.go
+++ b/lib/transaction/operation/congress_voting.go
@@ -1,8 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
-
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/errors"
 )
@@ -33,10 +31,6 @@ func NewCongressVoting(contract string, start, end uint64, amount common.Amount,
 	}
 }
 
-func (o CongressVoting) Serialize() (encoded []byte, err error) {
-	encoded, err = json.Marshal(o)
-	return
-}
 func (o CongressVoting) IsWellFormed(common.Config) (err error) {
 	if len(o.Contract) == 0 {
 		return errors.OperationBodyInsufficient

--- a/lib/transaction/operation/congress_voting_result.go
+++ b/lib/transaction/operation/congress_voting_result.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -61,9 +60,6 @@ func NewCongressVotingResult(
 	}
 }
 
-func (o CongressVotingResult) Serialize() (encoded []byte, err error) {
-	return json.Marshal(o)
-}
 func (o CongressVotingResult) IsWellFormed(common.Config) (err error) {
 	if len(o.BallotStamps.Hash) == 0 {
 		return errors.OperationBodyInsufficient

--- a/lib/transaction/operation/create_account.go
+++ b/lib/transaction/operation/create_account.go
@@ -1,8 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
-
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
@@ -20,10 +18,6 @@ func NewCreateAccount(target string, amount common.Amount, linked string) Create
 		Amount: amount,
 		Linked: linked,
 	}
-}
-
-func (o CreateAccount) Serialize() (encoded []byte, err error) {
-	return json.Marshal(o)
 }
 
 // Implement transaction/operation : IsWellFormed

--- a/lib/transaction/operation/inflation.go
+++ b/lib/transaction/operation/inflation.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
 	"strings"
 
 	"boscoin.io/sebak/lib/common"
@@ -77,10 +76,6 @@ func (o Inflation) TargetAddress() string {
 
 func (o Inflation) GetAmount() common.Amount {
 	return o.Amount
-}
-
-func (o Inflation) Serialize() (encoded []byte, err error) {
-	return json.Marshal(o)
 }
 
 func (o Inflation) HasFee() bool {

--- a/lib/transaction/operation/inflation_pf.go
+++ b/lib/transaction/operation/inflation_pf.go
@@ -1,7 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
 	"strconv"
 	"strings"
 
@@ -50,10 +49,6 @@ func (o InflationPF) IsWellFormed(common.Config) (err error) {
 
 func (o InflationPF) GetAmount() common.Amount {
 	return o.Amount
-}
-
-func (o InflationPF) Serialize() (encoded []byte, err error) {
-	return json.Marshal(o)
 }
 
 func (o InflationPF) HasFee() bool {

--- a/lib/transaction/operation/operation.go
+++ b/lib/transaction/operation/operation.go
@@ -99,7 +99,6 @@ type Body interface {
 	//   An `error` if that transaction is invalid, `nil` otherwise
 	//
 	IsWellFormed(common.Config) error
-	Serialize() ([]byte, error)
 	HasFee() bool
 }
 
@@ -123,10 +122,6 @@ func (o Operation) MakeHashString() string {
 
 func (o Operation) IsWellFormed(conf common.Config) (err error) {
 	return o.B.IsWellFormed(conf)
-}
-
-func (o Operation) Serialize() (encoded []byte, err error) {
-	return json.Marshal(o)
 }
 
 func (o Operation) String() string {

--- a/lib/transaction/operation/operation_test.go
+++ b/lib/transaction/operation/operation_test.go
@@ -46,12 +46,11 @@ func TestIsWellFormedOperationLowerAmount(t *testing.T) {
 
 func TestSerializeOperation(t *testing.T) {
 	op := MakeTestPayment(-1)
-	b, err := op.Serialize()
-	require.NoError(t, err)
+	b := common.MustMarshalJSON(op)
 	require.Equal(t, len(b) > 0, true)
 
 	var o Operation
-	err = json.Unmarshal(b, &o)
+	err := json.Unmarshal(b, &o)
 	require.NoError(t, err)
 }
 

--- a/lib/transaction/operation/payment.go
+++ b/lib/transaction/operation/payment.go
@@ -1,8 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
-
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
@@ -18,10 +16,6 @@ func NewPayment(target string, amount common.Amount) Payment {
 		Target: target,
 		Amount: amount,
 	}
-}
-
-func (o Payment) Serialize() (encoded []byte, err error) {
-	return json.Marshal(o)
 }
 
 // Implement transaction/operation : IsWellFormed

--- a/lib/transaction/operation/unfreezing_request.go
+++ b/lib/transaction/operation/unfreezing_request.go
@@ -1,8 +1,6 @@
 package operation
 
 import (
-	"encoding/json"
-
 	"boscoin.io/sebak/lib/common"
 )
 
@@ -10,11 +8,6 @@ type UnfreezeRequest struct{}
 
 func NewUnfreezeRequest() UnfreezeRequest {
 	return UnfreezeRequest{}
-}
-
-func (o UnfreezeRequest) Serialize() (encoded []byte, err error) {
-	encoded, err = json.Marshal(o)
-	return
 }
 
 func (o UnfreezeRequest) IsWellFormed(common.Config) (err error) {


### PR DESCRIPTION
This is a preliminary to fixing #434 

While working on reducing the memory / disk consumption, I had to deal with the `Serialize` method a lot. One problem we have is that serialization should not be done a single way. E.g. we don't really want to have binary serialization for the HTTP endpoints.

This leads to the issue with `Serialize`: It is a wrong abstraction, as the caller of the method (e.g. the LevelDB code or the HTTP code) should select the right serialization method for the data structure, not the other way around (`BlockOperation` should not defined how it is serialized, but it should define that it can be serialized as Binary/JSON/etc...).

This PR removes `Serialize` methods and `Serialized`, pushed the `json` code where needed and remove needless wrapper.