### PR TITLE
Remove cache middleware for GetNodeInfoHandler

### DIFF
--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -360,7 +360,7 @@ func (nr *NodeRunner) Ready() {
 		nr.network.AddHandler(network.UrlPathPrefixDebug+"/pprof/*", pprof.Index)
 	}
 
-	nr.network.AddHandler(api.GetNodeInfoPattern, cache.WrapHandlerFunc(apiHandler.GetNodeInfoHandler)).Methods("GET")
+	nr.network.AddHandler(api.GetNodeInfoPattern, apiHandler.GetNodeInfoHandler).Methods("GET")
 
 	nr.network.Ready()
 }


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

For fest watching,  node info endpoint is always fresh.


### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

