### PR TITLE
Fix to use LatestVotingBasis in NextRound()

### DIFF
--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -428,9 +428,9 @@ func ExpiredInSIGN(c common.Checker, args ...interface{}) (err error) {
 
 	checker.NodeRunner.BroadcastBallot(newBallot)
 
-	checker.NodeRunner.isaacStateManager.NextRound()
 	basis := checker.Ballot.VotingBasis()
 	checker.NodeRunner.Consensus().SetLatestVotingBasis(basis)
+	checker.NodeRunner.isaacStateManager.NextRound()
 	checker.NodeRunner.Consensus().RemoveRunningRoundsLowerOrEqualBasis(basis)
 
 	err = NewCheckerStopCloseConsensus(checker, fmt.Sprintf("ballot expired in SIGN, basis:%s", basis.Index()))
@@ -710,8 +710,8 @@ func FinishedBallotStore(c common.Checker, args ...interface{}) error {
 
 		err = NewCheckerStopCloseConsensus(checker, "ballot got consensus and will be stored")
 	case voting.NO, voting.EXP:
-		checker.NodeRunner.isaacStateManager.NextRound()
 		checker.NodeRunner.Consensus().SetLatestVotingBasis(basis)
+		checker.NodeRunner.isaacStateManager.NextRound()
 
 		checker.NodeRunner.Consensus().RemoveRunningRoundsLowerOrEqualBasis(basis)
 

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -321,7 +321,7 @@ func BallotCheckBasis(c common.Checker, args ...interface{}) (err error) {
 		checker.NodeRunner.Log().Debug(
 			"voting basis is invalid",
 			"ballot-basis", checker.Ballot.VotingBasis(),
-			"voting-basis", checker.NodeRunner.Consensus().LatestVotingBasis,
+			"voting-basis", checker.NodeRunner.Consensus().LatestVotingBasis(),
 			"latest-block-height", blk.Height,
 			"latest-block-hash", blk.Hash,
 		)

--- a/lib/node/runner/isaac_state_manager.go
+++ b/lib/node/runner/isaac_state_manager.go
@@ -173,7 +173,8 @@ func (sm *ISAACStateManager) TransitISAACState(height uint64, round uint64, ball
 func (sm *ISAACStateManager) NextRound() {
 	state := sm.State()
 	sm.nr.Log().Debug("begin ISAACStateManager.NextRound()", "height", state.Height, "round", state.Round, "state", state.BallotState)
-	sm.TransitISAACState(state.Height, state.Round+1, ballot.StateINIT)
+	newRound := sm.nr.Consensus().LatestVotingBasis().Round + 1
+	sm.TransitISAACState(state.Height, newRound, ballot.StateINIT)
 }
 
 func (sm *ISAACStateManager) NextHeight() {


### PR DESCRIPTION
## Background

We found a bug from testnet. There are four nodes(n0 ~ n3), so the `threshold` is 3.
But n3 was already gone.

n0
```
{"_links":{"self":{"href":"/api/v1/blocks/B5HC3Yb5pKNyGNkxvz6djNvarpTzEL6GEDom7LgD7Q4s"}},"confirmed":"2018-11-26T16:30:47.967127922Z","hash":"B5HC3Yb5pKNyGNkxvz6djNvarpTzEL6GEDom7LgD7Q4s","height":2462,"prev_block_hash":"73o4rn1jXxHzAgJVVauRVsrTMZZRtkzGLvsJ9BofbPi2","proposed_time":"2018-11-26T16:30:47.937006959Z","proposer":"GC2XLJ53VQLVRJJOBWEKTCHHNSIQCDLXVKKTNH2RLPLGZW4LKKKUEZP4","proposer_transaction":"DE46iT3y5mjHg7ypr2VNvr2Uan9mCyfEP8nrJretjowu","round":1,"transactions":null,"transactions_root":"3UEuXKbMjJX7PuZeKAx3sNCoYogiagkr5wzB88GqySxs","version":0}
```

n1
```
{"_links":{"self":{"href":"/api/v1/blocks/2Jb1A9wK9UDbq8y1aGFLXSZzFhzZoK3AKb99NF9BCBKF"}},"confirmed":"2018-11-26T16:30:47.976398039Z","hash":"2Jb1A9wK9UDbq8y1aGFLXSZzFhzZoK3AKb99NF9BCBKF","height":2462,"prev_block_hash":"73o4rn1jXxHzAgJVVauRVsrTMZZRtkzGLvsJ9BofbPi2","proposed_time":"2018-11-26T16:30:47.958997149Z","proposer":"GCFDGVJ4I7GS2CK2TQGWDOIBSF6L7EX6UDJSAOQHEDNB4JIKSEQAGOBW","proposer_transaction":"Awk1wLg56nMLr8J2CU5peZGq5cZit5fZE7jJxncEqEpo","round":2,"transactions":null,"transactions_root":"AaakctTS3qg1Lu8gy7W4VwSLRQpU9DdiPMcGpnv2BqtC","version":0}
```

n2
```
{"_links":{"self":{"href":"/api/v1/blocks/B5HC3Yb5pKNyGNkxvz6djNvarpTzEL6GEDom7LgD7Q4s"}},"confirmed":"2018-11-26T16:30:47.960934076Z","hash":"B5HC3Yb5pKNyGNkxvz6djNvarpTzEL6GEDom7LgD7Q4s","height":2462,"prev_block_hash":"73o4rn1jXxHzAgJVVauRVsrTMZZRtkzGLvsJ9BofbPi2","proposed_time":"2018-11-26T16:30:47.937006959Z","proposer":"GC2XLJ53VQLVRJJOBWEKTCHHNSIQCDLXVKKTNH2RLPLGZW4LKKKUEZP4","proposer_transaction":"DE46iT3y5mjHg7ypr2VNvr2Uan9mCyfEP8nrJretjowu","round":1,"transactions":null,"transactions_root":"3UEuXKbMjJX7PuZeKAx3sNCoYogiagkr5wzB88GqySxs","version":0}
```

The `n1` confirms in round:2 but the others confirms in round:1. So this network is forked.

## Reason
### Log
```
1:  {"log":"t=2018-11-26T16:30:39+0000 lvl=info msg=\"NewBlock created\" node=n1 state=ACCEPT proposer=n0 votingBasis=\"{Round:0 Height:2460 BlockHash:HEaLD8Cvf9BnYx8RyxTBYSS1WnUSRJnNN4UGS52ns6tS TotalTxs:2460 TotalOps:4920}\" n2 vote=YES isMine=false height=2461 round=0 hash=73o4rn1jXxHzAgJVVauRVsrTMZZRtkzGLvsJ9BofbPi2 confirmed=2018-11-26T16:30:39.954483187Z total-txs=2461 total-ops=4922 proposer=n0 caller=finish_ballot.go:85\n"}
2:
3:  {"log":"t=2018-11-26T16:30:39+0000 lvl=dbug msg=ISAACStateManager.TransitISAACState() node=n1 current=\"{Height:2460 Round:0 BallotState:ALLCONFIRM}\" height=2461 round=0 ballotState=INIT caller=isaac_state_manager.go:147\n"}
4:
5:  {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"message is verified\" node=n1 state=SIGN proposer=n3 votingBasis=\"{Round:0 Height:2461}\" from=n1 vote=EXPIRED isMine=true caller=checker.go:89\n"}
6:  {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"ballot voted\" node=n1 state=SIGN proposer=n3 votingBasis=\"{Round:0 Height:2461}\" from=n1 vote=EXPIRED isMine=true new=true caller=checker.go:351\n"}
7:  {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=CanGetVotingResult module=consensus node=n1 round-vote-result=map[n1:EXPIRED] voting-hole=NOT-YET finished=false caller=isaac.go:177\n"}
8:
9:  {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"message is verified\" node=n1 votingBasis=\"{Round:0 Height:2461}\" from=n0 vote=EXPIRED isMine=false state=SIGN proposer=n3 caller=checker.go:89\n"}
10: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"ballot voted\" node=n1 votingBasis=\"{Round:0 Height:2461}\" from=n0 vote=EXPIRED isMine=false state=SIGN proposer=n3 new=false caller=checker.go:351\n"}
11: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=CanGetVotingResult module=consensus node=n1 round-vote-result=\"map[n0:EXPIRED n1:EXPIRED]\" voting-hole=NOT-YET finished=false caller=isaac.go:177\n"}
12:
13: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"message is verified\" node=n1 state=INIT proposer=n0 votingBasis=\"{Round:1 Height:2461}\" n2 vote=YES isMine=false caller=checker.go:89\n"}
14: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"ballot voted\" node=n1 state=INIT proposer=n0 votingBasis=\"{Round:1 Height:2461}\" n2 vote=YES isMine=false new=true caller=checker.go:351\n"}
15: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=BallotSendRecord.Sent() module=consensus state=\"{Height:2461 Round:1 BallotState:SIGN}\" caller=ballot_send_record.go:39\n"}
16:
17: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=ISAACStateManager.TransitISAACState() node=n1 current=\"{Height:2461 Round:0 BallotState:SIGN}\" height=2461 round=1 ballotState=SIGN caller=isaac_state_manager.go:147\n"}
18:
19: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"message is verified\" node=n1 isMine=false state=SIGN proposer=n3 votingBasis=\"{Round:0 Height:2461}\" n2 vote=EXPIRED caller=checker.go:89\n"}
20: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"ballot voted\" node=n1 isMine=false state=SIGN proposer=n3 votingBasis=\"{Round:0 Height:2461}\" n2 vote=EXPIRED new=false caller=checker.go:351\n"}
21: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"check threshold in isaac\" module=consensus node=n1 threshold=3 yes=0 no=0 expired=3 state=SIGN caller=round_vote.go:91\n"}
22: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=CanGetVotingResult module=consensus node=n1 round-vote-result=\"map[n1:EXPIRED n0:EXPIRED n2:EXPIRED]\" voting-hole=EXPIRED finished=true caller=isaac.go:177\n"}
23: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"get result\" node=n1 isMine=false state=SIGN proposer=n3 votingBasis=\"{Round:0 Height:2461 BlockHash:73o4rn1jXxHzAgJVVauRVsrTMZZRtkzGLvsJ9BofbPi2 TotalTxs:2461 TotalOps:4922}\" from=n2 vote=EXPIRED finished voting.Hole=EXPIRED result=\"map[n2:EXPIRED n1:EXPIRED n0:EXPIRED]\" caller=checker.go:406\n"}
24: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"Expired in SIGN\" node=n1 caller=checker.go:422\n"}
25:
26: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=ISAACStateManager.TransitISAACState() node=n1 current=\"{Height:2461 Round:1 BallotState:SIGN}\" height=2461 round=2 ballotState=INIT caller=isaac_state_manager.go:147\n"}
27:
28: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"message is verified\" node=n1 vote=YES isMine=false state=SIGN proposer=n0 votingBasis=\"{Round:1 Height:2461}\" caller=checker.go:89\n"}
29: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=\"ballot voted\" node=n1 vote=YES isMine=false state=SIGN proposer=n0 votingBasis=\"{Round:1 Height:2461}\" new=false caller=checker.go:351\n"}
30: {"log":"t=2018-11-26T16:30:47+0000 lvl=dbug msg=CanGetVotingResult module=consensus node=n1 round-vote-result=map[n0:YES] voting-hole=NOT-YET finished=false caller=isaac.go:177\n"}
```

### Explain
* Why does the `n1` confirm in round 2?
   1. `n1` receives B(2461(height), 0(round), `SIGN`(ballotState), `EXP`(votingHole)), from `n0` and `n1`(self) because proposer is `n3`(dead) -> 11 line
   1. `n1` gets B(2461, 1, `INIT`, `YES`) from `n1` and voted -> 13~14 line
   1. `n1` transits state to S(2461, 1, `SIGN`) -> 17 line
   1. `n1` got B(2461, 0, `SIGN`, `EXP`), from `n2` and voted ->  19~20 line
   1. `n1` has three B(2461, 0, `SIGN`, `EXP`) -> 22 line so,
   1. `n1` calls `ExpiredInSIGN` and goes to the next round 2 because current round was 1 -> 26 line
   1. `n1` proposes B(2461, 2, `INIT`, `YES`) and gets ballots then goes to confirm.

### Solution
* `NextRound()` increases the round based on the `LatestVotingBasis`, not current round.
* For example,
   * `n1` calls `ExpiredInSIGN` and goes to the next round 2 because current round was 1
   * to 
   * `n1` calls `ExpiredInSIGN` and goes to the next round 1(because `LatestVotingBasis.Round` == 0)
* Therefore, `NextRound()` must be called after `SetLatestVotingBasis()`