### PR TITLE
[WIP] Response return HTML character as-is

### DIFF
--- a/lib/common/util.go
+++ b/lib/common/util.go
@@ -83,6 +83,14 @@ func JSONMarshalIndent(o interface{}) ([]byte, error) {
 	return json.MarshalIndent(o, "", "  ")
 }
 
+func JSONMarshalWithoutEscapeHTML(t interface{}) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	err := encoder.Encode(t)
+	return buffer.Bytes(), err
+}
+
 func ReverseStringSlice(a []string) []string {
 	if len(a) < 1 {
 		return []string{}

--- a/lib/network/httputils/json.go
+++ b/lib/network/httputils/json.go
@@ -1,7 +1,7 @@
 package httputils
 
 import (
-	"encoding/json"
+	"boscoin.io/sebak/lib/common"
 	"net/http"
 
 	"github.com/nvellon/hal"
@@ -46,15 +46,8 @@ func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
 		w.Header().Set("Content-Type", "application/json")
 	}
 
-	w.WriteHeader(code)
+	bs, err := common.JSONMarshalWithoutEscapeHTML(v)
 
-	var bs []byte
-	var err error
-	if marshaler, ok := v.(json.Marshaler); ok {
-		bs, err = marshaler.MarshalJSON()
-	} else {
-		bs, err = json.Marshal(v)
-	}
 	if err != nil {
 		return err
 	}
@@ -62,6 +55,5 @@ func WriteJSON(w http.ResponseWriter, code int, v interface{}) error {
 	if _, err := w.Write(bs); err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/lib/node/runner/api/resource/account.go
+++ b/lib/node/runner/api/resource/account.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"boscoin.io/sebak/lib/common"
 	"strings"
 
 	"github.com/nvellon/hal"
@@ -41,4 +42,9 @@ func (a Account) Resource() *hal.Resource {
 func (a Account) LinkSelf() string {
 	address := a.ba.Address
 	return strings.Replace(URLAccounts, "{id}", address, -1)
+}
+
+func (a Account) MarshalJSON() ([]byte, error) {
+	r := a.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
 }

--- a/lib/node/runner/api/resource/block.go
+++ b/lib/node/runner/api/resource/block.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"boscoin.io/sebak/lib/common"
 	"strings"
 
 	"boscoin.io/sebak/lib/block"
@@ -42,4 +43,9 @@ func (blk Block) Resource() *hal.Resource {
 
 func (blk Block) LinkSelf() string {
 	return strings.Replace(URLBlocks, "{id}", blk.b.Hash, -1)
+}
+
+func (blk Block) MarshalJSON() ([]byte, error) {
+	r := blk.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
 }

--- a/lib/node/runner/api/resource/frozen_account.go
+++ b/lib/node/runner/api/resource/frozen_account.go
@@ -69,3 +69,8 @@ func (fa FrozenAccount) LinkSelf() string {
 
 	return strings.Replace(URLAccountFrozenAccounts, "{id}", address, -1)
 }
+
+func (fa FrozenAccount) MarshalJSON() ([]byte, error) {
+	r := fa.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
+}

--- a/lib/node/runner/api/resource/operation.go
+++ b/lib/node/runner/api/resource/operation.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"boscoin.io/sebak/lib/common"
 	"strings"
 
 	"boscoin.io/sebak/lib/block"
@@ -55,4 +56,9 @@ func (o Operation) Resource() *hal.Resource {
 
 func (o Operation) LinkSelf() string {
 	return strings.Replace(URLOperations, "{id}", o.bo.Hash, -1)
+}
+
+func (o Operation) MarshalJSON() ([]byte, error) {
+	r := o.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
 }

--- a/lib/node/runner/api/resource/resource.go
+++ b/lib/node/runner/api/resource/resource.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"boscoin.io/sebak/lib/common"
 	"github.com/nvellon/hal"
 )
 
@@ -55,4 +56,9 @@ func (l ResourceList) LinkPrev() string {
 
 func (l ResourceList) GetMap() hal.Entry {
 	return hal.Entry{}
+}
+
+func (l ResourceList) MarshalJSON() ([]byte, error) {
+	r := l.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
 }

--- a/lib/node/runner/api/resource/transaction.go
+++ b/lib/node/runner/api/resource/transaction.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"boscoin.io/sebak/lib/common"
 	"strings"
 
 	"boscoin.io/sebak/lib/block"
@@ -69,4 +70,9 @@ func (t TransactionStatus) Resource() *hal.Resource {
 
 func (t TransactionStatus) LinkSelf() string {
 	return strings.Replace(URLTransactionStatus, "{id}", t.Hash, -1)
+}
+
+func (t TransactionStatus) MarshalJSON() ([]byte, error) {
+	r := t.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
 }

--- a/lib/node/runner/api/resource/transaction.go
+++ b/lib/node/runner/api/resource/transaction.go
@@ -42,6 +42,11 @@ func (t Transaction) LinkSelf() string {
 	return strings.Replace(URLTransactions, "{id}", t.bt.Hash, -1)
 }
 
+func (t Transaction) MarshalJSON() ([]byte, error) {
+	r := t.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
+}
+
 type TransactionStatus struct {
 	Hash   string
 	Status string

--- a/lib/node/runner/api/resource/transaction_post.go
+++ b/lib/node/runner/api/resource/transaction_post.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"boscoin.io/sebak/lib/common"
 	"strings"
 
 	"boscoin.io/sebak/lib/transaction"
@@ -34,4 +35,9 @@ func (t TransactionPost) Resource() *hal.Resource {
 
 func (t TransactionPost) LinkSelf() string {
 	return strings.Replace(URLTransactions, "{id}", t.tx.H.Hash, -1)
+}
+
+func (t TransactionPost) MarshalJSON() ([]byte, error) {
+	r := t.Resource()
+	return common.JSONMarshalWithoutEscapeHTML(r.GetMap())
 }


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background
APIs returns Resource as JSON encoded byte.
from GoLang 1.7 (https://golang.org/doc/go1.7#encoding_json)  `&, <, and >` characters are escaped by default.

### Solution
If the client decodes the received string as JSON first there is no problem.
But to make it readable and to not make confuse, the escaping does not necessary.


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

