### PR TITLE
Fixed to start consensus after nodes restarting simultaneously 

### DIFF
--- a/lib/network/connection_manager.go
+++ b/lib/network/connection_manager.go
@@ -18,4 +18,5 @@ type ConnectionManager interface {
 	AllValidators() []string
 	CountConnected() int
 	GetNode(address string) node.Node
+	IsReady() bool
 }

--- a/lib/network/validator_connection_manager.go
+++ b/lib/network/validator_connection_manager.go
@@ -253,3 +253,7 @@ func (c *ValidatorConnectionManager) watchForMetrics() {
 	}
 	//TODO: stop this goroutine.
 }
+
+func (c *ValidatorConnectionManager) IsReady() bool {
+	return len(c.AllConnected()) >= c.policy.Threshold()
+}

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -667,7 +667,7 @@ func ACCEPTBallotBroadcast(c common.Checker, args ...interface{}) (err error) {
 		"ballot will be broadcasted",
 		"new-ballot", newBallot.GetHash(),
 		"new-state", newBallot.State(),
-		"voting-hole", checker.VotingHole,
+		"voting-hole", checker.FinishedVotingHole,
 	)
 
 	return

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -380,8 +380,12 @@ type irregularIncomingBallot struct {
 	accountA *block.BlockAccount
 }
 
-func (nr *TestNodeRunnerIrregularIncomingBallot) InitRound() {
-	return
+func (nr *TestNodeRunnerIrregularIncomingBallot) Start() error {
+	if err := nr.network.Start(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p *irregularIncomingBallot) prepare() {

--- a/lib/node/runner/checker_test.go
+++ b/lib/node/runner/checker_test.go
@@ -474,6 +474,7 @@ func (p *irregularIncomingBallot) makeBallot(state ballot.State) (blt *ballot.Ba
 func TestRegularIncomingBallots(t *testing.T) {
 	p := &irregularIncomingBallot{}
 	p.prepare()
+	p.nr.StopStateManager()
 	defer p.done()
 
 	cm := p.nr.ConnectionManager().(*TestConnectionManager)
@@ -502,6 +503,7 @@ func TestRegularIncomingBallots(t *testing.T) {
 func TestIrregularIncomingBallots(t *testing.T) {
 	p := &irregularIncomingBallot{}
 	p.prepare()
+	p.nr.StopStateManager()
 	defer p.done()
 
 	cm := p.nr.ConnectionManager().(*TestConnectionManager)

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -557,8 +557,7 @@ func (nr *NodeRunner) InitRound() {
 func (nr *NodeRunner) waitForConnectingEnoughNodes() {
 	ticker := time.NewTicker(time.Millisecond * 5)
 	for _ = range ticker.C {
-		connected := nr.connectionManager.AllConnected()
-		if len(connected) >= nr.policy.Threshold() {
+		if nr.connectionManager.IsReady() {
 			ticker.Stop()
 			break
 		}
@@ -707,6 +706,10 @@ func (nr *NodeRunner) NodeInfo() node.NodeInfo {
 }
 
 func (nr *NodeRunner) BroadcastBallot(b ballot.Ballot) {
+	if nr.Node().State() == node.StateBOOTING && !nr.connectionManager.IsReady() {
+		nr.waitForConnectingEnoughNodes()
+	}
+
 	state := consensus.ISAACState{
 		Height:      b.VotingBasis().Height,
 		Round:       b.VotingBasis().Round,

--- a/lib/node/runner/test_connection_manager.go
+++ b/lib/node/runner/test_connection_manager.go
@@ -50,6 +50,10 @@ func (c *TestConnectionManager) Messages() []common.Message {
 	return messages
 }
 
+func (c *TestConnectionManager) IsReady() bool {
+	return true
+}
+
 type FixedSelector struct {
 	address string
 }

--- a/lib/sync/mock_test.go
+++ b/lib/sync/mock_test.go
@@ -45,6 +45,10 @@ func (m *mockConnectionManager) GetNode(addr string) node.Node {
 	return m.getNodeFunc(addr)
 }
 
+func (m *mockConnectionManager) IsReady() bool {
+	return true
+}
+
 type mockDoer struct {
 	handleFunc func(*http.Request) (*http.Response, error)
 }


### PR DESCRIPTION
### Github Issue
Resolves #828 

### Background

See #828 

This problem is caused by the combination of `NodeRunner.BroadcastBallot()` and `NodeRunner.waitForConnectingEnoughNodes()`. The network was stuck, failed to collect the enough ballots over threshold. Before enough validators are not connected, the incoming ballot or the proposed ballot is received, the node can not broadcast the next ballots.

### Solution

Changes,
* `network.ConnectionManager.IsReady()` added; this new function checks the enough validators are connected
* When broadcasting, if node is in `StateBooting` and does not have enough connected validators, it will wait until having enough validators.