### PR TITLE
Support CORS for node-info api

### DIFF
--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -68,6 +68,14 @@ var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
 	FinishedBallotStore,
 }
 
+var (
+	corsAllowedOrigins ghandlers.CORSOption = ghandlers.AllowedOrigins([]string{"*"})
+	corsAllowedMethods ghandlers.CORSOption = ghandlers.AllowedMethods([]string{"GET", "POST"})
+	corsAllowedHeaders ghandlers.CORSOption = ghandlers.AllowedHeaders(
+		[]string{"Content-Type", "X-Requested-With", "Cache-Control", "Access-Control"},
+	)
+)
+
 type NodeRunner struct {
 	sync.RWMutex
 
@@ -189,13 +197,13 @@ func (nr *NodeRunner) Ready() {
 		return
 	}
 
+	cors := ghandlers.CORS(corsAllowedOrigins, corsAllowedMethods, corsAllowedHeaders)
 	{ //CORS
-		allowedOrigins := ghandlers.AllowedOrigins([]string{"*"})
-		allowedMethods := ghandlers.AllowedMethods([]string{"GET", "POST"})
-		allowedHeaders := ghandlers.AllowedHeaders([]string{"Content-Type", "X-Requested-With", "Cache-Control", "Access-Control"})
-
-		cors := ghandlers.CORS(allowedOrigins, allowedMethods, allowedHeaders)
 		if err := nr.network.AddMiddleware(network.RouterNameAPI, cors); err != nil {
+			nr.log.Error("failed to add middleware", "err", err)
+			return
+		}
+		if err := nr.network.AddMiddleware("", cors); err != nil {
 			nr.log.Error("failed to add middleware", "err", err)
 			return
 		}
@@ -360,9 +368,9 @@ func (nr *NodeRunner) Ready() {
 		nr.network.AddHandler(network.UrlPathPrefixDebug+"/pprof/*", pprof.Index)
 	}
 
-	nr.network.AddHandler(api.GetNodeInfoPattern, apiHandler.GetNodeInfoHandler).Methods("GET")
-
 	nr.network.Ready()
+
+	nr.network.AddHandler(api.GetNodeInfoPattern, apiHandler.GetNodeInfoHandler).Methods("GET", "OPTIONS")
 }
 
 func (nr *NodeRunner) Start() (err error) {


### PR DESCRIPTION
### Github Issue
Resolves #840 

### Background

See #840; the node info api, `/` does not support CORS.

### Solution

Attach `cors` middleware to base router.

```sh
$ curl -H "Origin: http://example.com" -H "Access-Control-Request-Method: GET" -H "Access-Control-Request-Headers: X-Requested-With" -X OPTIONS --verbose http://localhost:12345
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 12345 (#0)
> OPTIONS / HTTP/1.1
> Host: localhost:12345
> User-Agent: curl/7.62.0
> Accept: */*
> Origin: http://example.com
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: X-Requested-With
>
< HTTP/1.1 200 OK
< Access-Control-Allow-Headers: X-Requested-With
< Access-Control-Allow-Origin: *
< Date: Wed, 28 Nov 2018 07:54:52 GMT
< Content-Length: 0
<
* Connection #0 to host localhost left intact


$ curl -H "Origin: http://example.com" -H "Access-Control-Request-Method: GET" -H "Access-Control-Request-Headers: X-Requested-With" -X GET --verbose http://localhost:12345
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 12345 (#0)
> GET / HTTP/1.1
> Host: localhost:12345
> User-Agent: curl/7.62.0
> Accept: */*
> Origin: http://example.com
> Access-Control-Request-Method: GET
> Access-Control-Request-Headers: X-Requested-With
>
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: *
< Date: Wed, 28 Nov 2018 07:55:03 GMT
< Content-Length: 1525
< Content-Type: text/plain; charset=utf-8
<
{
  "node": {
 ...
}
* Connection #0 to host localhost left intact
}


$ curl --verbose http://localhost:12345
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 12345 (#0)
> GET / HTTP/1.1
> Host: localhost:12345
> User-Agent: curl/7.62.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Wed, 28 Nov 2018 07:55:25 GMT
< Content-Length: 1525
< Content-Type: text/plain; charset=utf-8
<
{
  "node": {
 ...
}
```