### PR TITLE
API document update. 

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -8,9 +8,9 @@ SEBAK, the next BOScoin network with ISAAC consensus protocol.
 <!-- partial(API_v1/models.md) -->
 <!-- partial(API_v1/transactions.md) -->
 
+
 <!-- include(API_v1/paging.md) -->
 <!-- include(API_v1/models.md) -->
 <!-- include(API_v1/accounts.md) -->
 <!-- include(API_v1/transactions.md) -->
-<!-- include(API_v1/operations.md) -->
 <!-- include(API_v1/blocks.md) -->

--- a/docs/API.md
+++ b/docs/API.md
@@ -8,7 +8,6 @@ SEBAK, the next BOScoin network with ISAAC consensus protocol.
 <!-- partial(API_v1/models.md) -->
 <!-- partial(API_v1/transactions.md) -->
 
-
 <!-- include(API_v1/paging.md) -->
 <!-- include(API_v1/models.md) -->
 <!-- include(API_v1/accounts.md) -->

--- a/docs/API_v1/accounts.md
+++ b/docs/API_v1/accounts.md
@@ -1,7 +1,7 @@
 # Group Accounts
 Account API
 
-## Account Details [/api/v1/accounts/{address}]
+## Account Details [/api/v1/accounts/{address}] 
 <p> In the BOScoin network, users interact by using accounts </p>
 
 + Parameters
@@ -75,4 +75,3 @@ Account API
 + Response 500 (application/problem+json; charset=utf-8)
 
     + Attributes (Problem)
-

--- a/docs/API_v1/accounts.md
+++ b/docs/API_v1/accounts.md
@@ -1,7 +1,7 @@
 # Group Accounts
 Account API
 
-## Account Details [/api/v1/accounts/{address}] 
+## Account Details [/api/v1/accounts/{address}]
 <p> In the BOScoin network, users interact by using accounts </p>
 
 + Parameters

--- a/docs/API_v1/models.md
+++ b/docs/API_v1/models.md
@@ -57,7 +57,7 @@
 ### Transaction Payment
 + T: transaction
 + H 
-    + version: `` - Transaction version
+    + version: `1` - Transaction version
     + created: `2018-01-01T00:00:00.000000000Z` - Created time of the transaction.
     + signature: `4ty1Pv7Phc3CEeGLCP8mjZfEC259VR1MBgyVHzQXTcWjuSiwxVQ2AQKxy2HjGTCDrmdE29z8ZNZ6GxuDyEay2p9M` - Signature signed by source account
 + B

--- a/docs/API_v1/models.md
+++ b/docs/API_v1/models.md
@@ -28,7 +28,7 @@
                     + templated: true
                 + self
                     + href: `/api/v1/transactions`
-        + block: ``
+        + block: `241`
         + created: `2018-11-02T14:09:33.019606000+09:00`
         + fee: 10000
         + hash: `7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs`
@@ -101,7 +101,7 @@
         + templated: true
     + self
         + href: `/api/v1/transactions/`
-+ block: 
++ block: `241`
 + created: `2018-09-12T09:08:35.157472400Z` - Created time of the transaction. It is set by wallet
 + fee: `10000` (string) - The fee paid by the source account
 + hash: `ghf6msRhE4jRf5DPib9UHD1msadvmZs9o53V9FQTb11` (string,required) - Hash of transaction. //TODO: link for the details
@@ -123,9 +123,9 @@
             + target: GDEPYGGALPJ5HENXCNOQJPPDOQMA2YAXPERZ4XEAKVFFJJEVP4ZBK6QI - The funded account's public key
             + amount: `1000000000000` - amount in GON
         
-        + confirmed: 
+        + confirmed: `2018-11-27T07:49:05.971799020Z`
         + hash: F6SEv2QhgwZwxUARbRacxyZaufzcTxdYDXJBpvf7pNAj-7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs - Hash of operation
-        + proposed_time:
+        + proposed_time: `2018-11-27T07:49:05.942922134Z`
         + source: GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ - Source account
         + tx_hash: 7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs - Hash of transaction
         + type: create-account  - operation type. ex. payment, create-account

--- a/docs/API_v1/models.md
+++ b/docs/API_v1/models.md
@@ -12,8 +12,9 @@
         + templated: true (boolean)
 + address: GDEPYGGALPJ5HENXCNOQJPPDOQMA2YAXPERZ4XEAKVFFJJEVP4ZBK6QI (string, required) - The account’s public key encoded into a base32 string representation.
 + balance: 500000000000 (string) - GON. 1 BOS = 10,000,000 GON
-+ sequence_id: 0 (number) - The Current sequence number. It needed to submitting a transaction from this account
 + linked: "" - linked with freezing account. 
++ sequence_id: 0 (number) - The Current sequence number. It needed to submitting a transaction from this account
+
 
 ### Transactions
 + _embedded
@@ -27,9 +28,10 @@
                     + templated: true
                 + self
                     + href: `/api/v1/transactions`
+        + block: ``
         + created: `2018-11-02T14:09:33.019606000+09:00`
         + fee: 10000
-        + hash: 7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs`
+        + hash: `7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs`
         + operation_count: 1
         + sequence_id: 0
         + source: `GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ`
@@ -99,6 +101,7 @@
         + templated: true
     + self
         + href: `/api/v1/transactions/`
++ block: 
 + created: `2018-09-12T09:08:35.157472400Z` - Created time of the transaction. It is set by wallet
 + fee: `10000` (string) - The fee paid by the source account
 + hash: `ghf6msRhE4jRf5DPib9UHD1msadvmZs9o53V9FQTb11` (string,required) - Hash of transaction. //TODO: link for the details
@@ -115,11 +118,14 @@
                     + href: `/api/v1/operations/F6SEv2QhgwZwxUARbRacxyZaufzcTxdYDXJBpvf7pNAj-7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs`
                 + transaction
                     + href: `/api/v1/transactions/7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs` 
+        + block_height: 241,
         + body
             + target: GDEPYGGALPJ5HENXCNOQJPPDOQMA2YAXPERZ4XEAKVFFJJEVP4ZBK6QI - The funded account's public key
             + amount: `1000000000000` - amount in GON
         
+        + confirmed: 
         + hash: F6SEv2QhgwZwxUARbRacxyZaufzcTxdYDXJBpvf7pNAj-7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs - Hash of operation
+        + proposed_time:
         + source: GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ - Source account
         + tx_hash: 7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs - Hash of transaction
         + type: create-account  - operation type. ex. payment, create-account

--- a/docs/API_v1/models.md
+++ b/docs/API_v1/models.md
@@ -105,20 +105,6 @@
 + operation_count: 1 (number) - The number of operations in this transaction.
 + sequence_id: 0 (number) - the Sequence number of the source account.
 + source: `GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ` (string) -
-
-### TransactionHistory
-+ _links
-    + account
-        + href: `/api/v1/accounts/GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ`
-    + self
-        + href: `/api/v1/transactions`
-    + transaction
-        + href: `/api/v1/transactions/7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs`
-    + confirmed: `2018-11-02T14:09:33.021645000+09:00` - Modified time of the transaction history.
-    + created: `2018-11-02T14:09:33.019606000+09:00` - Created time of the transaction. It is set by wallet
-    + hash: `7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs` (string,required) - Hash of transaction. //TODO: link for the details
-    + source: `GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ` (string) - source account
-    + status: `confirmed` (string) - three categories of status; submitted, confirmed, rejected
         
 ### Operation
 + _embedded

--- a/docs/API_v1/operations.md
+++ b/docs/API_v1/operations.md
@@ -1,8 +1,0 @@
-# Group Operations
-Operations API
-
-
-## Transactions [/api/v1/operations]
-
-
-

--- a/docs/API_v1/transactions.md
+++ b/docs/API_v1/transactions.md
@@ -6,8 +6,40 @@ Transactions API
 
 
 ### Payment transaction  [POST] 
-//TODO: How to make a transaction and sign 
 
++ Data Body consist of 3 parts, ; T, H, B
+    + T : ‘transaction’
+
+    + H : H means Header. it consists of version, hash, signature & created.
+
+        + Version means to transaction version. At the moment 1.
+        + Hash means transaction hash.
+        + signature is signed data from client.
+            + How can you make signature? 
+            
+            Please check this link first. 
+            
+            You need 3 variables to make signature; RLPdata which is hashing, network id and source’s secret seed. 
+            
+            You can see that Which kinds of variables necessary. 
+            
+            You can use [JavaScript SDK] to make signature or [Python SDK]. Please check above SDKs.
+
+        + created means to transcation created time.
+    + B : B means Body.  It is RLP data.  so you have to encode B data to RLP format.   It contains; source , fee, sequence id, and operations.
+
+        + source; means that public address which will BOScoin withdraw .
+        + fee : data type is String.
+        + sequence id
+            + How can you get sequence id? 
+            
+            When you finished account creation, you can access http(or https)://{IP that you set up sebak node}/api/v1/accounts/{Public address that account you created}. 
+            
+            Then you can see sequence_id in response.
+        + operations: It is json array consist of H & B. H include type, which means operation type. B include target & amount.
+        + H : type ( type should be set ‘payment’ )
+        + B : target ( Public address you want to send.) , amount ( amount data type is String .)
+ 
 + Request (application/json)
     
     + Attributes (Transaction Payment)

--- a/docs/API_v1/transactions.md
+++ b/docs/API_v1/transactions.md
@@ -82,25 +82,3 @@ Transactions API
 + Response 500 (application/problem+json; charset=utf-8)
 
     + Attributes (Problem)
-
-## History for Trasaction [/api/v1/transactions/{hash}/history?limit={limit}&reverse={reverse}&cursor={cursor}]
-
-+ Parameters
-    
-    + hash: `7nLuyg8radTExzBM2WhG37AwohBwEySBw4vj2xdtdjAs` (string,required) - Transaction hash
-    
-    + limit: `100` (integer, optional)
-        
-    + reverse: `false` (string, optional)
-        
-    + cursor: `` (string, optional)
-
-#### Get history of transaction [GET]
-
-+ Response 200 (application/hal+json; charset=utf-8)
-    
-    + Attributes (TransactionHistory)
-
-+ Response 500 (application/problem+json; charset=utf-8)
-
-    + Attributes (Problem)


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background
As API updated, I apply api which updated. 
`/api/v1/blocks/` and block parameter, proposed_time .. etc. 

But as from @kfangw 's request, I don't add status api description yet. 
Please note this point. 

### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

