### PR TITLE
Fix a bug about blocks api paging

### DIFF
--- a/lib/node/runner/api/blocks.go
+++ b/lib/node/runner/api/blocks.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/network/httputils"
 	"boscoin.io/sebak/lib/node/runner/api/resource"
 	"boscoin.io/sebak/lib/storage"
@@ -28,9 +29,11 @@ func (api NetworkHandlerAPI) GetBlocksHandler(w http.ResponseWriter, r *http.Req
 		var cursor string
 		if p.Cursor() != nil {
 			height, err := strconv.ParseUint(string(p.Cursor()), 10, 64)
-			if err == nil {
-				cursor = block.GetBlockKeyPrefixHeight(height)
+			if err != nil {
+				httputils.WriteJSONError(w, errors.BadRequestParameter)
+				return
 			}
+			cursor = block.GetBlockKeyPrefixHeight(height)
 		}
 		option = storage.NewWalkOption(cursor, p.Limit()+1, p.Reverse())
 	}

--- a/lib/node/runner/api/blocks_test.go
+++ b/lib/node/runner/api/blocks_test.go
@@ -59,7 +59,7 @@ func TestBlocksHandler(t *testing.T) {
 	{
 		q := "cursor=10&limit=10&reverse=true"
 		records, _ := testFunc(q)
-		require.Equal(t, len(records), 10)
+		require.Equal(t, 10, len(records))
 		for i, a := range inserted {
 			b := records[9-i].(map[string]interface{})
 			require.Equal(t, a.Hash, b["hash"])

--- a/lib/node/runner/api/blocks_test.go
+++ b/lib/node/runner/api/blocks_test.go
@@ -49,7 +49,7 @@ func TestBlocksHandler(t *testing.T) {
 		q := "cursor=1&limit=10&reverse=false"
 		records, _ := testFunc(q)
 
-		require.Equal(t, len(records), 10)
+		require.Equal(t, 10, len(records))
 		for i, a := range inserted {
 			b := records[i].(map[string]interface{})
 			require.Equal(t, a.Hash, b["hash"])

--- a/lib/node/runner/api/pagequery.go
+++ b/lib/node/runner/api/pagequery.go
@@ -65,6 +65,9 @@ func (p *PageQuery) SelfLink() string {
 }
 
 func (p *PageQuery) PrevLink(cursor []byte) string {
+	if cursor == nil {
+		return ""
+	}
 	path := p.request.URL.Path
 	query := p.urlValues(cursor, true, p.limit).Encode()
 	link := fmt.Sprintf("%s?%s", path, query)
@@ -72,6 +75,10 @@ func (p *PageQuery) PrevLink(cursor []byte) string {
 }
 
 func (p *PageQuery) NextLink(cursor []byte) string {
+	if cursor == nil {
+		// If cursor is nil, no exist link
+		return ""
+	}
 	path := p.request.URL.Path
 	query := p.urlValues(cursor, false, p.limit).Encode()
 	link := fmt.Sprintf("%s?%s", path, query)

--- a/lib/node/runner/api/pagequery.go
+++ b/lib/node/runner/api/pagequery.go
@@ -65,9 +65,6 @@ func (p *PageQuery) SelfLink() string {
 }
 
 func (p *PageQuery) PrevLink(cursor []byte) string {
-	if cursor == nil {
-		return ""
-	}
 	path := p.request.URL.Path
 	query := p.urlValues(cursor, true, p.limit).Encode()
 	link := fmt.Sprintf("%s?%s", path, query)
@@ -75,10 +72,6 @@ func (p *PageQuery) PrevLink(cursor []byte) string {
 }
 
 func (p *PageQuery) NextLink(cursor []byte) string {
-	if cursor == nil {
-		// If cursor is nil, no exist link
-		return ""
-	}
 	path := p.request.URL.Path
 	query := p.urlValues(cursor, false, p.limit).Encode()
 	link := fmt.Sprintf("%s?%s", path, query)

--- a/lib/node/runner/api/resource/resource.go
+++ b/lib/node/runner/api/resource/resource.go
@@ -37,12 +37,8 @@ func (l ResourceList) Resource() *hal.Resource {
 	}
 	rl.EmbedCollection("records", rCollection)
 
-	if l.LinkPrev() != "" {
-		rl.AddLink("prev", hal.NewLink(l.LinkPrev())) //TODO: set prev/next url
-	}
-	if l.LinkNext() != "" {
-		rl.AddLink("next", hal.NewLink(l.LinkNext()))
-	}
+	rl.AddLink("prev", hal.NewLink(l.LinkPrev())) //TODO: set prev/next url
+	rl.AddLink("next", hal.NewLink(l.LinkNext()))
 
 	return rl
 }

--- a/lib/node/runner/api/resource/resource.go
+++ b/lib/node/runner/api/resource/resource.go
@@ -36,8 +36,13 @@ func (l ResourceList) Resource() *hal.Resource {
 		rCollection = append(rCollection, apiResource.Resource())
 	}
 	rl.EmbedCollection("records", rCollection)
-	rl.AddLink("prev", hal.NewLink(l.LinkPrev())) //TODO: set prev/next url
-	rl.AddLink("next", hal.NewLink(l.LinkNext()))
+
+	if l.LinkPrev() != "" {
+		rl.AddLink("prev", hal.NewLink(l.LinkPrev())) //TODO: set prev/next url
+	}
+	if l.LinkNext() != "" {
+		rl.AddLink("next", hal.NewLink(l.LinkNext()))
+	}
 
 	return rl
 }

--- a/lib/storage/leveldb_test.go
+++ b/lib/storage/leveldb_test.go
@@ -436,7 +436,7 @@ func TestLevelDBWalk(t *testing.T) {
 		cnt        int
 	)
 
-	walkOption := NewWalkOption("test-1", 10, false, true)
+	walkOption := NewWalkOption("test-1", 10, false)
 	err := st.Walk("test-", walkOption, func(k, v []byte) (bool, error) {
 		cnt++
 		walkedKeys = append(walkedKeys, string(k))
@@ -446,15 +446,13 @@ func TestLevelDBWalk(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if cnt != len(kv)-1 {
-		t.Errorf("want: %v have: %v", len(kv)-1, cnt)
+	if cnt != len(kv) {
+		t.Errorf("want: %v have: %v", len(kv), cnt)
 	}
 
 	var keys []string
 	for k, _ := range kv {
-		if k != "test-1" {
-			keys = append(keys, k)
-		}
+		keys = append(keys, k)
 	}
 	sort.Strings(keys)
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

- `/api/v1/blocks` 's cursor is height `cursor=12123`. So  this cursor should not do base64 encoding 
- Remove `storage.WalkOption.SkipCursor`.  It's an insane approach. 
 
### Solution

- `PageQueryOption` for base64encoding or not. Default is encoding.  e.g. `p, err := NewPageQuery(r, WithEncodePageCursor(false))`
-  Remove `WalkOption.SkipCursor`
- Without cursor, `storage.Walk` call `iter.Last()` or `iter.First()` depend on `WalkOption.Reverse`.



### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

