### PR TITLE
Do not use Operation Hash for validation

### DIFF
--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -318,7 +318,6 @@ func GetBlockOperation(st *storage.LevelDBBackend, hash string) (bo BlockOperati
 }
 
 func GetBlockOperationWithIndex(st *storage.LevelDBBackend, hash string, opIndex int) (bo BlockOperation, err error) {
-
 	var found = false
 	iterFunc, closeFunc := GetBlockOperationsByTxHash(st, hash, nil)
 	for idx := 0; idx <= opIndex; idx++ {

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"strconv"
+	"strings"
 	"sync"
 
 	"boscoin.io/sebak/lib/ballot"
@@ -371,16 +373,19 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 			return errors.InvalidOperation
 		}
 
-		exists, err := block.ExistsBlockOperation(st, inflationPF.VotingResult)
-		if err != nil || !exists {
-			return errors.InflationPFResultMissed
-		}
-
 		var congressVotingHash string
 		{
 			var bo block.BlockOperation
 			var err error
-			if bo, err = block.GetBlockOperation(st, inflationPF.VotingResult); err != nil {
+
+			var opIndex int
+			parsedCongressVotingResultHash := strings.Split(inflationPF.VotingResult, "-") //0:TxHash, 1:Index
+			txHash := parsedCongressVotingResultHash[0]
+			if opIndex, err = strconv.Atoi(parsedCongressVotingResultHash[1]); err != nil {
+				return errors.InvalidOperation
+			}
+
+			if bo, err = block.GetBlockOperationWithIndex(st, txHash, opIndex); err != nil {
 				return err
 			}
 
@@ -404,7 +409,14 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 		{
 			var bo block.BlockOperation
 			var err error
-			if bo, err = block.GetBlockOperation(st, congressVotingHash); err != nil {
+			var opIndex int
+			parsedCongressVotingHash := strings.Split(congressVotingHash, "-") //0:TxHash, 1:Index
+			txHash := parsedCongressVotingHash[0]
+			if opIndex, err = strconv.Atoi(parsedCongressVotingHash[1]); err != nil {
+				return errors.InvalidOperation
+			}
+
+			if bo, err = block.GetBlockOperationWithIndex(st, txHash, opIndex); err != nil {
 				return err
 			}
 
@@ -432,12 +444,36 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 			return errors.InflationPFFundingAddressMissMatched
 		}
 
-	case operation.TypeCongressVoting, operation.TypeCongressVotingResult:
+	case operation.TypeCongressVoting:
 		//the CongressAddress is owned by blockchainOS. It is temporally check.
 		//TODO: When a node of BosNet is operated by anonymous then it will be removed.
 		if source.Address != config.CongressAccountAddress {
 			return errors.CongressAddressMisMatched
 		}
+	case operation.TypeCongressVotingResult:
+		//the CongressAddress is owned by blockchainOS. It is temporally check.
+		//TODO: When a node of BosNet is operated by anonymous then it will be removed.
+		if source.Address != config.CongressAccountAddress {
+			return errors.CongressAddressMisMatched
+		}
+
+		var ok bool
+		var cvResult operation.CongressVotingResult
+		if cvResult, ok = op.B.(operation.CongressVotingResult); !ok {
+			return errors.TypeOperationBodyNotMatched
+		}
+
+		var opIndex int
+		parsedCongressVotingResultHash := strings.Split(cvResult.CongressVotingHash, "-") //0:TxHash, 1:Index
+		txHash := parsedCongressVotingResultHash[0]
+		if opIndex, err = strconv.Atoi(parsedCongressVotingResultHash[1]); err != nil {
+			return errors.InvalidOperation
+		}
+
+		if _, err = block.GetBlockOperationWithIndex(st, txHash, opIndex); err != nil {
+			return err
+		}
+
 	default:
 		return errors.UnknownOperationType
 	}

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -380,6 +380,9 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 
 			var opIndex int
 			parsedCongressVotingResultHash := strings.Split(inflationPF.VotingResult, "-") //0:TxHash, 1:Index
+			if len(parsedCongressVotingResultHash) != 2 {
+				return errors.InvalidOperation
+			}
 			txHash := parsedCongressVotingResultHash[0]
 			if opIndex, err = strconv.Atoi(parsedCongressVotingResultHash[1]); err != nil {
 				return errors.InvalidOperation
@@ -411,6 +414,9 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 			var err error
 			var opIndex int
 			parsedCongressVotingHash := strings.Split(congressVotingHash, "-") //0:TxHash, 1:Index
+			if len(parsedCongressVotingHash) != 2 {
+				return errors.InvalidOperation
+			}
 			txHash := parsedCongressVotingHash[0]
 			if opIndex, err = strconv.Atoi(parsedCongressVotingHash[1]); err != nil {
 				return errors.InvalidOperation
@@ -465,6 +471,9 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 
 		var opIndex int
 		parsedCongressVotingResultHash := strings.Split(cvResult.CongressVotingHash, "-") //0:TxHash, 1:Index
+		if len(parsedCongressVotingResultHash) != 2 {
+			return errors.InvalidOperation
+		}
 		txHash := parsedCongressVotingResultHash[0]
 		if opIndex, err = strconv.Atoi(parsedCongressVotingResultHash[1]); err != nil {
 			return errors.InvalidOperation

--- a/lib/transaction/operation/congress_voting_result.go
+++ b/lib/transaction/operation/congress_voting_result.go
@@ -2,6 +2,8 @@ package operation
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/errors"
@@ -95,6 +97,14 @@ func (o CongressVotingResult) IsWellFormed(common.Config) (err error) {
 
 	if o.Result.Count != o.Result.Yes+o.Result.No+o.Result.ABS {
 		return errors.InvalidOperation
+	}
+
+	parsedCongressVotingResultHash := strings.Split(o.CongressVotingHash, "-") //0:TxHash, 1:Index
+	if len(parsedCongressVotingResultHash) != 2 {
+		return errors.InvalidOperation
+	}
+	if _, err := strconv.Atoi(parsedCongressVotingResultHash[1]); err != nil {
+		return errors.InvalidOperation.Clone().SetData("error", err)
 	}
 
 	return

--- a/lib/transaction/operation/inflation_pf.go
+++ b/lib/transaction/operation/inflation_pf.go
@@ -2,6 +2,8 @@ package operation
 
 import (
 	"encoding/json"
+	"strconv"
+	"strings"
 
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/errors"
@@ -33,6 +35,14 @@ func (o InflationPF) IsWellFormed(common.Config) (err error) {
 	if len(o.VotingResult) == 0 {
 		err = errors.InvalidOperation
 		return
+	}
+
+	parsedCongressVotingHash := strings.Split(o.VotingResult, "-") //0:TxHash, 1:Index
+	if len(parsedCongressVotingHash) != 2 {
+		return errors.InvalidOperation
+	}
+	if _, err = strconv.Atoi(parsedCongressVotingHash[1]); err != nil {
+		return errors.InvalidOperation.Clone().SetData("error", err)
 	}
 
 	return nil

--- a/lib/transaction/operation/operation_test.go
+++ b/lib/transaction/operation/operation_test.go
@@ -80,7 +80,7 @@ func TestOperationBodyCongressVotingResult(t *testing.T) {
 		string(common.MakeHash([]byte("dummydummy"))),
 		[]string{"http://www.boscoin.io/3", "http://www.boscoin.io/4"},
 		9, 2, 3, 4,
-		"dummy voting hash",
+		"dummy voting hash-0",
 	)
 	op := Operation{
 		H: Header{Type: TypeCongressVotingResult},
@@ -88,7 +88,7 @@ func TestOperationBodyCongressVotingResult(t *testing.T) {
 	}
 	hashed := op.MakeHashString()
 
-	expected := "3HYgpY1Rt24jMVGLzFKoogAWNzrcKf5BVbULnBRwLWya"
+	expected := "8t6e3gZ9BUFXGUbf8qEwQfJ3Hn7yWDAatkELaiaxbcCg"
 	require.Equal(t, expected, hashed)
 
 	err := op.IsWellFormed(common.NewTestConfig())
@@ -147,7 +147,7 @@ func TestOperationBodyCongressVotingResultInvalidMembership(t *testing.T) {
 			string(common.MakeHash([]byte("dummydummy"))),
 			[]string{"http://www.boscoin.io/3", "http://www.boscoin.io/4"},
 			9, 2, 3, 4,
-			"dummy voting hash",
+			"dummy voting hash-0",
 		)
 		op := Operation{
 			H: Header{Type: TypeCongressVotingResult},

--- a/tests/client/congressvoting_inflationpf_test.go
+++ b/tests/client/congressvoting_inflationpf_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"net/http"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -106,8 +107,6 @@ func TestInflationPF(t *testing.T) {
 		oPage, err := c.LoadOperationsByAccount(CongressAddr, client.Q{Key: client.QueryType, Value: string(operation.TypeCongressVoting)})
 		require.NoError(t, err)
 
-		oHash := oPage.Embedded.Records[0].Hash
-
 		ob := operation.NewCongressVotingResult(
 			"dummy1",
 			[]string{"http://1.1.1.1/a", "http://1.1.1.1/b"},
@@ -119,7 +118,7 @@ func TestInflationPF(t *testing.T) {
 			70,
 			20,
 			10,
-			oHash,
+			strings.Join([]string{oPage.Embedded.Records[0].TxHash, "0"}, "-"),
 		)
 		o, err := operation.NewOperation(ob)
 		require.NoError(t, err)
@@ -179,9 +178,11 @@ func TestInflationPF(t *testing.T) {
 		oPage, err := c.LoadOperationsByAccount(CongressAddr, client.Q{Key: client.QueryType, Value: string(operation.TypeCongressVotingResult)})
 		require.NoError(t, err)
 
-		oHash := oPage.Embedded.Records[0].Hash
-
-		ob := operation.NewInflationPF(account1Addr, common.Amount(fundingAmount), oHash)
+		ob := operation.NewInflationPF(
+			account1Addr,
+			common.Amount(fundingAmount),
+			strings.Join([]string{oPage.Embedded.Records[0].TxHash, "0"}, "-"),
+		)
 		o, err := operation.NewOperation(ob)
 		require.NoError(t, err)
 


### PR DESCRIPTION
### Github Issue
#851 

### Background
see #851 

### Solution
* Do not use Operation Hash for validation
* Identifier the operation is changed to Tx + Index

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

