### PR TITLE
Remove epsilon and simplify calculating block time buffer

### DIFF
--- a/lib/node/runner/block_time_buffer_test.go
+++ b/lib/node/runner/block_time_buffer_test.go
@@ -7,19 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCalculateAverageBlockTime(t *testing.T) {
-	now := time.Now()
-	lastDay := now.AddDate(0, 0, -1)
-
-	nBlocksInOneDay := 720 * 24
-	height := uint64(nBlocksInOneDay)
-
-	blockTime := calculateAverageBlockTime(lastDay, height)
-	require.True(t, blockTime > 4900*time.Millisecond)
-	require.True(t, blockTime < 5100*time.Millisecond)
-
-}
-
 func TestCalculateBlockTimeBuffer(t *testing.T) {
 	require.Equal(t, 1*time.Second, calculateBlockTimeBuffer(
 		1,
@@ -56,7 +43,7 @@ func TestCalculateBlockTimeBuffer(t *testing.T) {
 
 // We can check that after one year,
 // if it took 6 sec to confirm one block,
-// the next block should be confirmed about 4 seconds later.
+// the next block should be confirmed 4 seconds later.
 func TestLongTermBlockTimeBuffer(t *testing.T) {
 	oneYearHeight := uint64(365 * 24 * 60 * 60 / 5)
 	oneYearSeconds := time.Duration(oneYearHeight) * 5 * time.Second
@@ -64,17 +51,11 @@ func TestLongTermBlockTimeBuffer(t *testing.T) {
 	oneYearHeight++
 	oneYearSeconds += 6 * time.Second
 
-	averageOneHeightAfter := oneYearSeconds / time.Duration(oneYearHeight)
-
-	require.Equal(t, 4003462242*time.Nanosecond, calculateBlockTimeBuffer(
+	require.Equal(t, 4*time.Second, calculateBlockTimeBuffer(
 		oneYearHeight,
 		5*time.Second,
-		averageOneHeightAfter,
+		oneYearSeconds,
 		0*time.Second,
 		1*time.Second,
 	))
-
-	oneYearSeconds += 4003462242 * time.Nanosecond
-	averageTwoHeightAfter := oneYearSeconds / time.Duration(oneYearHeight+1)
-	require.Equal(t, 5*time.Second, averageTwoHeightAfter)
 }

--- a/lib/node/runner/block_time_buffer_test.go
+++ b/lib/node/runner/block_time_buffer_test.go
@@ -22,6 +22,7 @@ func TestCalculateAverageBlockTime(t *testing.T) {
 
 func TestCalculateBlockTimeBuffer(t *testing.T) {
 	require.Equal(t, 1*time.Second, calculateBlockTimeBuffer(
+		1,
 		5*time.Second,
 		7*time.Second,
 		3*time.Second,
@@ -29,6 +30,7 @@ func TestCalculateBlockTimeBuffer(t *testing.T) {
 	))
 
 	require.Equal(t, 2*time.Second, calculateBlockTimeBuffer(
+		1,
 		5*time.Second,
 		3*time.Second,
 		4*time.Second,
@@ -36,6 +38,7 @@ func TestCalculateBlockTimeBuffer(t *testing.T) {
 	))
 
 	require.Equal(t, time.Duration(0), calculateBlockTimeBuffer(
+		1,
 		5*time.Second,
 		3*time.Second,
 		7*time.Second,
@@ -43,9 +46,35 @@ func TestCalculateBlockTimeBuffer(t *testing.T) {
 	))
 
 	require.Equal(t, 2*time.Second, calculateBlockTimeBuffer(
+		1,
 		5*time.Second,
-		5020*time.Millisecond,
+		5*time.Second,
 		3*time.Second,
 		1*time.Second,
 	))
+}
+
+// We can check that after one year,
+// if it took 6 sec to confirm one block,
+// the next block should be confirmed about 4 seconds later.
+func TestLongTermBlockTimeBuffer(t *testing.T) {
+	oneYearHeight := uint64(365 * 24 * 60 * 60 / 5)
+	oneYearSeconds := time.Duration(oneYearHeight) * 5 * time.Second
+
+	oneYearHeight++
+	oneYearSeconds += 6 * time.Second
+
+	averageOneHeightAfter := oneYearSeconds / time.Duration(oneYearHeight)
+
+	require.Equal(t, 4003462242*time.Nanosecond, calculateBlockTimeBuffer(
+		oneYearHeight,
+		5*time.Second,
+		averageOneHeightAfter,
+		0*time.Second,
+		1*time.Second,
+	))
+
+	oneYearSeconds += 4003462242 * time.Nanosecond
+	averageTwoHeightAfter := oneYearSeconds / time.Duration(oneYearHeight+1)
+	require.Equal(t, 5*time.Second, averageTwoHeightAfter)
 }

--- a/tests/block-time/block-time.sh
+++ b/tests/block-time/block-time.sh
@@ -10,7 +10,7 @@ fi
 
 SECONDS=${1}
 DIV=`expr $SECONDS / 5`
-EXPECTED1=`expr $DIV + 2`
+EXPECTED1=`expr $DIV`
 EXPECTED2=`expr $EXPECTED1 - 1`
 EXPECTED3=`expr $EXPECTED1 + 1`
 


### PR DESCRIPTION
The `epsilon` is a range that does not control the block time.
For example, when epsilon is 50 milliseconds, the block time is not adjusted if the average block time is 5049 milliseconds.
But `epsilon` is redundant.
The node knows the time since the Genesis. So we can easily calculate next block time.
It should be `5sec*(currentHeight+1) - sinceGenesis`