### PR TITLE
Make blocks API default to reverse=true

### DIFF
--- a/lib/node/runner/api/blocks.go
+++ b/lib/node/runner/api/blocks.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (api NetworkHandlerAPI) GetBlocksHandler(w http.ResponseWriter, r *http.Request) {
-	p, err := NewPageQuery(r, WithEncodePageCursor(false))
+	p, err := NewPageQuery(r, WithEncodePageCursor(false), WithDefaultReverse(true))
 	if err != nil {
 		httputils.WriteJSONError(w, err)
 		return

--- a/lib/node/runner/api/pagequery.go
+++ b/lib/node/runner/api/pagequery.go
@@ -35,6 +35,12 @@ func WithEncodePageCursor(ok bool) PageQueryOption {
 	}
 }
 
+func WithDefaultReverse(ok bool) PageQueryOption {
+	return func(p *PageQuery) {
+		p.reverse = ok
+	}
+}
+
 func NewPageQuery(r *http.Request, opts ...PageQueryOption) (*PageQuery, error) {
 	p := &PageQuery{
 		request:        r,


### PR DESCRIPTION
After @anarcher 's fixes (#845 ) I was looking at the block API and realized that it was more likely that people wanted the latest blocks to be returned by default, than the earliest ones.