### PR TITLE
Reduce the time to check `BlockOperation` at startup

### DIFF
--- a/lib/node/runner/block_operations.go
+++ b/lib/node/runner/block_operations.go
@@ -136,9 +136,10 @@ func (sb *SavingBlockOperations) check(lastBlock uint64) (err error) {
 errorCheck:
 	for {
 		select {
-		case err = <-errChan:
+		case e := <-errChan:
 			errs++
-			if err != nil {
+			if e != nil {
+				err = e
 				break errorCheck
 			}
 			if errs == lastBlock-1 {

--- a/lib/node/runner/block_operations.go
+++ b/lib/node/runner/block_operations.go
@@ -116,6 +116,8 @@ func (sb *SavingBlockOperations) check(lastBlock uint64) (err error) {
 	}
 
 	go func() {
+		defer close(blocks)
+
 		var blk block.Block
 		for {
 			if blk, err = sb.getNextBlock(blk.Height); err != nil {
@@ -128,8 +130,6 @@ func (sb *SavingBlockOperations) check(lastBlock uint64) (err error) {
 				break
 			}
 		}
-
-		close(blocks)
 	}()
 
 	var errs uint64


### PR DESCRIPTION
### Github Issue

Resolves #847 

### Background

See #847 

### Solution

Up to `100` workers checks the existing Blocks simultaneously.