### PR TITLE
block.Confirmed is updated when it is empty

### DIFF
--- a/lib/block/block.go
+++ b/lib/block/block.go
@@ -85,7 +85,9 @@ func (b Block) NewBlockKeyConfirmed() string {
 
 func (b *Block) Save(st *storage.LevelDBBackend) (err error) {
 	key := getBlockKey(b.Hash)
-	b.Confirmed = common.NowISO8601()
+	if b.Confirmed == "" {
+		b.Confirmed = common.NowISO8601()
+	}
 
 	var exists bool
 	exists, err = st.Has(key)


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

- Within `Block.Save()`,  it updates `block.Confirmed`.  It's OK with Consensus. But When sync, The `Confirmed` becomes a synced time. 

### Solution

 In `Block.Save()` ,  `Block.Confirmed` is updated when it's empty.

### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

