### PR TITLE
Allow watch with Watcher node

### DIFF
--- a/lib/sync/config.go
+++ b/lib/sync/config.go
@@ -86,6 +86,7 @@ func (c *Config) NewFetcher() Fetcher {
 		c.localNode,
 		func(f *BlockFetcher) {
 			f.fetchTimeout = c.FetchTimeout
+			f.retryInterval = c.RetryInterval
 			f.logger = c.logger.New("submodule", "fetcher")
 		},
 	)

--- a/lib/sync/watcher.go
+++ b/lib/sync/watcher.go
@@ -207,8 +207,8 @@ func (w *Watcher) bestHeightFromNodes(ctx context.Context, nodes []*node.NodeInf
 	var height uint64
 
 	for _, n := range nodes {
-		if n.Node.State != node.StateCONSENSUS {
-			w.logger.Info("node state is not CONSENSUS", "node", n.Node.Address)
+		if n.Node.State != node.StateCONSENSUS && n.Node.State != node.StateWATCH {
+			w.logger.Info("node state is not CONSENSUS or WATCH", "node", n.Node.Address)
 			continue
 		}
 		nHeight := uint64(n.Block.Height)
@@ -223,7 +223,7 @@ func (w *Watcher) bestHeightFromNodes(ctx context.Context, nodes []*node.NodeInf
 func (w *Watcher) bestNodeAddrs(ctx context.Context, height uint64, nodes []*node.NodeInfo) ([]string, error) {
 	var addrs []string
 	for _, n := range nodes {
-		if n.Node.State != node.StateCONSENSUS {
+		if n.Node.State != node.StateCONSENSUS && n.Node.State != node.StateWATCH {
 			continue
 		}
 		addrs = append(addrs, n.Node.Address)


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

```
Consensus Node <- Watcher  <- Watcher  ...
```

I think that it's not bad topology.  With this topology, we can protect our consensus nodes. (maybe)


### Solution

- Watcher watches other watchers.


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

- This layered make delayed watching from consensus nodes.. :-> 

