### PR TITLE
Rename GetBlockOperationsByTxHash to GetBlockOperationsByTx

### DIFF
--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -315,7 +315,7 @@ func GetBlockOperation(st *storage.LevelDBBackend, hash string) (bo BlockOperati
 
 func GetBlockOperationWithIndex(st *storage.LevelDBBackend, hash string, opIndex int) (bo BlockOperation, err error) {
 	var found = false
-	iterFunc, closeFunc := GetBlockOperationsByTxHash(st, hash, nil)
+	iterFunc, closeFunc := GetBlockOperationsByTx(st, hash, nil)
 	for idx := 0; idx <= opIndex; idx++ {
 
 		o, hasNext, _ := iterFunc()
@@ -364,7 +364,7 @@ func LoadBlockOperationsInsideIterator(
 		})
 }
 
-func GetBlockOperationsByTxHash(st *storage.LevelDBBackend, txHash string, options storage.ListOptions) (
+func GetBlockOperationsByTx(st *storage.LevelDBBackend, txHash string, options storage.ListOptions) (
 	func() (BlockOperation, bool, []byte),
 	func(),
 ) {

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -80,7 +80,7 @@ func TestGetSortedBlockOperationsByTxHash(t *testing.T) {
 
 	for _, txHash := range txHashes {
 		var saved []BlockOperation
-		iterFunc, closeFunc := GetBlockOperationsByTxHash(st, txHash, nil)
+		iterFunc, closeFunc := GetBlockOperationsByTx(st, txHash, nil)
 		for {
 			bo, hasNext, _ := iterFunc()
 			if !hasNext {
@@ -108,7 +108,7 @@ func TestBlockOperationSaveByTransaction(t *testing.T) {
 	require.NoError(t, err)
 
 	var saved []BlockOperation
-	iterFunc, closeFunc := GetBlockOperationsByTxHash(st, tx.GetHash(), nil)
+	iterFunc, closeFunc := GetBlockOperationsByTx(st, tx.GetHash(), nil)
 	for {
 		bo, hasNext, _ := iterFunc()
 		if !hasNext {

--- a/lib/node/runner/api/base_test.go
+++ b/lib/node/runner/api/base_test.go
@@ -33,7 +33,7 @@ func prepareAPIServer() (*httptest.Server, *storage.LevelDBBackend) {
 	router.HandleFunc(GetTransactionsHandlerPattern, apiHandler.GetTransactionsHandler).Methods("GET")
 	router.HandleFunc(GetTransactionByHashHandlerPattern, apiHandler.GetTransactionByHashHandler).Methods("GET")
 	router.HandleFunc(GetTransactionStatusHandlerPattern, apiHandler.GetTransactionStatusByHashHandler).Methods("GET")
-	router.HandleFunc(GetTransactionOperationsHandlerPattern, apiHandler.GetOperationsByTxHashHandler).Methods("GET")
+	router.HandleFunc(GetTransactionOperationsHandlerPattern, apiHandler.GetOperationsByTxHandler).Methods("GET")
 	router.HandleFunc(GetBlocksHandlerPattern, apiHandler.GetBlocksHandler).Methods("GET")
 	router.HandleFunc(GetBlockHandlerPattern, apiHandler.GetBlockHandler).Methods("GET")
 	router.HandleFunc(PostSubscribePattern, apiHandler.PostSubscribeHandler).Methods("POST")

--- a/lib/node/runner/api/tx_operations.go
+++ b/lib/node/runner/api/tx_operations.go
@@ -12,7 +12,7 @@ import (
 	"boscoin.io/sebak/lib/storage"
 )
 
-func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter, r *http.Request) {
+func (api NetworkHandlerAPI) GetOperationsByTxHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	hash := vars["id"]
 
@@ -30,12 +30,12 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter,
 	options := p.ListOptions()
 
 	var blk *block.Block
-	if blk, err = api.getBlockByTxHash(hash); err != nil {
+	if blk, err = api.getBlockByTx(hash); err != nil {
 		httputils.WriteJSONError(w, err)
 		return
 	}
 
-	ops, firstCursor, cursor := api.getOperationsByTxHash(hash, blk, options)
+	ops, firstCursor, cursor := api.getOperationsByTx(hash, blk, options)
 	if len(ops) < 1 {
 		httputils.WriteJSONError(w, errors.BlockTransactionDoesNotExists)
 		return
@@ -45,8 +45,8 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashHandler(w http.ResponseWriter,
 	httputils.MustWriteJSON(w, 200, list)
 }
 
-func (api NetworkHandlerAPI) getOperationsByTxHash(txHash string, blk *block.Block, options storage.ListOptions) (txs []resource.Resource, firstCursor, cursor []byte) {
-	iterFunc, closeFunc := block.GetBlockOperationsByTxHash(api.storage, txHash, options)
+func (api NetworkHandlerAPI) getOperationsByTx(txHash string, blk *block.Block, options storage.ListOptions) (txs []resource.Resource, firstCursor, cursor []byte) {
+	iterFunc, closeFunc := block.GetBlockOperationsByTx(api.storage, txHash, options)
 	for idx := 0; ; idx++ {
 		o, hasNext, c := iterFunc()
 		if !hasNext {
@@ -65,7 +65,7 @@ func (api NetworkHandlerAPI) getOperationsByTxHash(txHash string, blk *block.Blo
 	return
 }
 
-func (api NetworkHandlerAPI) getBlockByTxHash(hash string) (*block.Block, error) {
+func (api NetworkHandlerAPI) getBlockByTx(hash string) (*block.Block, error) {
 	// get block by it's `Height`
 	if found, err := block.ExistsBlockTransaction(api.storage, hash); err != nil {
 		return nil, err

--- a/lib/node/runner/ballot_proposer_transaction_test.go
+++ b/lib/node/runner/ballot_proposer_transaction_test.go
@@ -648,7 +648,7 @@ func TestProposedTransactionStoreWithZeroAmount(t *testing.T) {
 	require.Equal(t, 2, len(bt.Operations))
 
 	var bos []block.BlockOperation
-	iterFunc, closeFunc := block.GetBlockOperationsByTxHash(p.nr.Storage(), bt.Hash, nil)
+	iterFunc, closeFunc := block.GetBlockOperationsByTx(p.nr.Storage(), bt.Hash, nil)
 	for {
 		bo, hasNext, _ := iterFunc()
 		if !hasNext {

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -329,7 +329,7 @@ func (nr *NodeRunner) Ready() {
 	).Methods("GET", "OPTIONS")
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetTransactionOperationsHandlerPattern),
-		listCache.WrapHandlerFunc(apiHandler.GetOperationsByTxHashHandler),
+		listCache.WrapHandlerFunc(apiHandler.GetOperationsByTxHandler),
 	).Methods("GET", "OPTIONS")
 	nr.network.AddHandler(
 		apiHandler.HandlerURLPattern(api.GetTransactionStatusHandlerPattern),


### PR DESCRIPTION
Because hash is implied when getting an association.