### PR TITLE
Support stage (-rcXXX) with bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,7 +5,7 @@ tag_name = {new_version}
 current_version = 0.1.1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<stage>.*))?
 serialize =
-    {major}.{minor}.{patch}-rc{stage}
+    {major}.{minor}.{patch}-rc.{stage}
     {major}.{minor}.{patch}
 
 [bumpversion:part:stage]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,9 +3,12 @@ commit = True
 tag = True
 tag_name = {new_version}
 current_version = 0.1.1
-parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<stage>.*))?
 serialize =
-	{major}.{minor}.{patch}
+    {major}.{minor}.{patch}-rc{stage}
+    {major}.{minor}.{patch}
+
+[bumpversion:part:stage]
 
 [bumpversion:file:VERSION]
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

```
$bumpversion  --dry-run --verbose stage

Would prepare Git commit
Would add changes in file 'VERSION' to Git
Would add changes in file '.bumpversion.cfg' to Git
Would commit to Git with message 'Bump version: 0.1.1 → 0.1.1-rc1'
Would tag '0.1.1-rc1' in Git

```

```
$bumpversion  --dry-run --verbose patch

Would prepare Git commit
Would add changes in file 'VERSION' to Git
Would add changes in file '.bumpversion.cfg' to Git
Would commit to Git with message 'Bump version: 0.1.1 → 0.1.2'
Would tag '0.1.2' in Git
```


### Solution


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

