### PR TITLE
Minor: Expected is Equal's first argument

### DIFF
--- a/lib/transaction/operation/operation_test.go
+++ b/lib/transaction/operation/operation_test.go
@@ -25,7 +25,7 @@ func TestMakeHashOfOperationBodyPayment(t *testing.T) {
 	hashed := op.MakeHashString()
 
 	expected := "GodiXQkWvAAbobhLBnWK8QS8aArb1ZoR2Ms8JswYUvL3"
-	require.Equal(t, hashed, expected)
+	require.Equal(t, expected, hashed)
 }
 
 func TestIsWellFormedOperation(t *testing.T) {
@@ -63,7 +63,7 @@ func TestOperationBodyCongressVoting(t *testing.T) {
 	hashed := op.MakeHashString()
 
 	expected := "EtVW5hG3p4YsSzL3mgwejHvtskzYuxW8dNaM6UEm42DX"
-	require.Equal(t, hashed, expected)
+	require.Equal(t, expected, hashed)
 
 	err := op.IsWellFormed(common.NewTestConfig())
 	require.NoError(t, err)


### PR DESCRIPTION
```
When the test fails, something like this is displayed for L25:
FAIL: TestMakeHashOfOperationBodyPayment (0.00s)
    require.go:157:
            Error Trace:    operation_test.go:28
            Error:          Not equal:
                            expected: 5khwjo7zt1zY1wV15neGY1TPY5YPQrJrNeJoyEKGPUa9
                            actual  : GodiXQkWvAAbobhLBnWK8QS8aArb1ZoR2Ms8JswYUvL3
As seen here, expected and actual are reversed.
```