### PR TITLE
Use time format for time related fields in configuration

### DIFF
--- a/cmd/sebak/cmd/cmd_test.go
+++ b/cmd/sebak/cmd/cmd_test.go
@@ -15,12 +15,54 @@ import (
 	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/sync"
 )
 
 func TestParseFlagValidators(t *testing.T) {
 	vs, err := parseFlagValidators("https://localhost:12346?address=GDPQ2LBYP3RL3O675H2N5IEYM6PRJNUA5QFMKXIHGTKEB5KS5T3KHFA2")
 	require.NoError(t, err)
 	require.Equal(t, 1, len(vs))
+}
+
+func TestParseFlagsNode(t *testing.T) {
+	flagNetworkID = "sebak-test-network"
+	flagValidators = "https://localhost:12346?address=GDPQ2LBYP3RL3O675H2N5IEYM6PRJNUA5QFMKXIHGTKEB5KS5T3KHFA2"
+	flagKPSecretSeed = "SCN4NSV5SVHIZWUDJFT4Z5FFVHO3TFRTOIBQLHMNPAZJ37K5A2YFSCBM"
+	flagBindURL = "http://0.0.0.0:12345"
+
+	flagBlockTime = "200ms"
+	flagBlockTimeDelta = "50ms"
+	flagTimeoutINIT = "100ms"
+	flagTimeoutSIGN = "50ms"
+	flagTimeoutACCEPT = "50ms"
+	flagTimeoutALLCONFIRM = "10s"
+
+	parseFlagsNode()
+
+	require.Equal(t, 200*time.Millisecond, blockTime)
+	require.Equal(t, 50*time.Millisecond, blockTimeDelta)
+	require.Equal(t, 100*time.Millisecond, timeoutINIT)
+	require.Equal(t, 50*time.Millisecond, timeoutSIGN)
+	require.Equal(t, 50*time.Millisecond, timeoutACCEPT)
+	require.Equal(t, 10*time.Second, timeoutALLCONFIRM)
+
+	require.Equal(t, uint64(common.DefaultTransactionsInBallotLimit), transactionsLimit)
+	require.Equal(t, uint64(common.DefaultOperationsInTransactionLimit), operationsLimit)
+	require.Equal(t, uint64(common.DefaultOperationsInBallotLimit), operationsInBallotLimit)
+
+	require.Equal(t, 67, threshold)
+
+	require.Equal(t, uint64(1000000), txPoolClientLimit)
+	require.Equal(t, uint64(0) /* unlimited */, txPoolNodeLimit)
+
+	require.Equal(t, uint64(241920), common.UnfreezingPeriod)
+	require.Equal(t, uint64(300), syncPoolSize)
+
+	require.Equal(t, sync.RetryInterval, syncRetryInterval)
+	require.Equal(t, sync.FetchTimeout, syncFetchTimeout)
+	require.Equal(t, sync.CheckBlockHeightInterval, syncCheckInterval)
+	require.Equal(t, sync.CheckPrevBlockInterval, syncCheckPrevBlock)
+	require.Equal(t, sync.WatchInterval, watchInterval)
 }
 
 func TestParseFlagSelfValidators(t *testing.T) {

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -389,12 +389,12 @@ func parseFlagsNode() {
 		cmdcommon.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
-	timeoutINIT = getTime(flagTimeoutINIT, 2*time.Second, "--timeout-init")
-	timeoutSIGN = getTime(flagTimeoutSIGN, 2*time.Second, "--timeout-sign")
-	timeoutACCEPT = getTime(flagTimeoutACCEPT, 2*time.Second, "--timeout-accept")
-	timeoutALLCONFIRM = getTime(flagTimeoutALLCONFIRM, 30*time.Second, "--timeout-accept")
-	blockTime = getTime(flagBlockTime, 5*time.Second, "--block-time")
-	blockTimeDelta = getTime(flagBlockTimeDelta, 1*time.Second, "--block-time-delta")
+	timeoutINIT = getTime(flagTimeoutINIT, common.DefaultTimeoutINIT, "--timeout-init")
+	timeoutSIGN = getTime(flagTimeoutSIGN, common.DefaultTimeoutSIGN, "--timeout-sign")
+	timeoutACCEPT = getTime(flagTimeoutACCEPT, common.DefaultTimeoutACCEPT, "--timeout-accept")
+	timeoutALLCONFIRM = getTime(flagTimeoutALLCONFIRM, common.DefaultTimeoutALLCONFIRM, "--timeout-allconfirm")
+	blockTime = getTime(flagBlockTime, common.DefaultBlockTime, "--block-time")
+	blockTimeDelta = getTime(flagBlockTimeDelta, common.DefaultBlockTimeDelta, "--block-time-delta")
 
 	if transactionsLimit, err = strconv.ParseUint(flagTransactionsLimit, 10, 64); err != nil {
 		cmdcommon.PrintFlagsError(nodeCmd, "--transactions-limit", err)

--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -39,8 +39,8 @@ const (
 
 var (
 	flagBindURL                    string = common.GetENVValue("SEBAK_BIND", defaultBindURL)
-	flagBlockTime                  string = common.GetENVValue("SEBAK_BLOCK_TIME", "5")
-	flagBlockTimeDelta             string = common.GetENVValue("SEBAK_BLOCK_TIME_DELTA", "1")
+	flagBlockTime                  string = common.GetENVValue("SEBAK_BLOCK_TIME", "5s")
+	flagBlockTimeDelta             string = common.GetENVValue("SEBAK_BLOCK_TIME_DELTA", "1s")
 	flagDebugPProf                 bool   = common.GetENVValue("SEBAK_DEBUG_PPROF", "0") == "1"
 	flagKPSecretSeed               string = common.GetENVValue("SEBAK_SECRET_SEED", "")
 	flagLog                        string = common.GetENVValue("SEBAK_LOG", "")
@@ -55,10 +55,10 @@ var (
 	flagSyncRetryInterval          string = common.GetENVValue("SEBAK_SYNC_RETRY_INTERVAL", "10s")
 	flagSyncCheckPrevBlockInterval string = common.GetENVValue("SEBAK_SYNC_CHECK_PREVBLOCK", "30s")
 	flagThreshold                  string = common.GetENVValue("SEBAK_THRESHOLD", "67")
-	flagTimeoutACCEPT              string = common.GetENVValue("SEBAK_TIMEOUT_ACCEPT", "2")
-	flagTimeoutALLCONFIRM          string = common.GetENVValue("SEBAK_TIMEOUT_ALLCONFIRM", "30")
-	flagTimeoutINIT                string = common.GetENVValue("SEBAK_TIMEOUT_INIT", "2")
-	flagTimeoutSIGN                string = common.GetENVValue("SEBAK_TIMEOUT_SIGN", "2")
+	flagTimeoutACCEPT              string = common.GetENVValue("SEBAK_TIMEOUT_ACCEPT", "2s")
+	flagTimeoutALLCONFIRM          string = common.GetENVValue("SEBAK_TIMEOUT_ALLCONFIRM", "30s")
+	flagTimeoutINIT                string = common.GetENVValue("SEBAK_TIMEOUT_INIT", "2s")
+	flagTimeoutSIGN                string = common.GetENVValue("SEBAK_TIMEOUT_SIGN", "2s")
 	flagTLSCertFile                string = common.GetENVValue("SEBAK_TLS_CERT", "sebak.crt")
 	flagTLSKeyFile                 string = common.GetENVValue("SEBAK_TLS_KEY", "sebak.key")
 	flagUnfreezingPeriod           string = common.GetENVValue("SEBAK_UNFREEZING_PERIOD", strconv.FormatUint(common.UnfreezingPeriod, 10))
@@ -389,12 +389,12 @@ func parseFlagsNode() {
 		cmdcommon.PrintFlagsError(nodeCmd, "--storage", err)
 	}
 
-	timeoutINIT = getTime(flagTimeoutINIT, common.DefaultTimeoutINIT, "--timeout-init")
-	timeoutSIGN = getTime(flagTimeoutSIGN, common.DefaultTimeoutSIGN, "--timeout-sign")
-	timeoutACCEPT = getTime(flagTimeoutACCEPT, common.DefaultTimeoutACCEPT, "--timeout-accept")
-	timeoutALLCONFIRM = getTime(flagTimeoutALLCONFIRM, common.DefaultTimeoutALLCONFIRM, "--timeout-allconfirm")
-	blockTime = getTime(flagBlockTime, common.DefaultBlockTime, "--block-time")
-	blockTimeDelta = getTime(flagBlockTimeDelta, common.DefaultBlockTimeDelta, "--block-time-delta")
+	timeoutINIT = getTimeDuration(flagTimeoutINIT, common.DefaultTimeoutINIT, "--timeout-init")
+	timeoutSIGN = getTimeDuration(flagTimeoutSIGN, common.DefaultTimeoutSIGN, "--timeout-sign")
+	timeoutACCEPT = getTimeDuration(flagTimeoutACCEPT, common.DefaultTimeoutACCEPT, "--timeout-accept")
+	timeoutALLCONFIRM = getTimeDuration(flagTimeoutALLCONFIRM, common.DefaultTimeoutALLCONFIRM, "--timeout-allconfirm")
+	blockTime = getTimeDuration(flagBlockTime, common.DefaultBlockTime, "--block-time")
+	blockTimeDelta = getTimeDuration(flagBlockTimeDelta, common.DefaultBlockTimeDelta, "--block-time-delta")
 
 	if transactionsLimit, err = strconv.ParseUint(flagTransactionsLimit, 10, 64); err != nil {
 		cmdcommon.PrintFlagsError(nodeCmd, "--transactions-limit", err)
@@ -621,19 +621,6 @@ func parseHTTPCacheRedisAddrs(s string) (map[string]string, error) {
 		addrs[addr[0]] = addr[1]
 	}
 	return addrs, nil
-}
-
-func getTime(timeoutStr string, defaultValue time.Duration, errMessage string) time.Duration {
-	var timeoutDuration time.Duration
-	if tmpUint64, err := strconv.ParseUint(timeoutStr, 10, 64); err != nil {
-		cmdcommon.PrintFlagsError(nodeCmd, errMessage, err)
-	} else {
-		timeoutDuration = time.Duration(tmpUint64) * time.Second
-	}
-	if timeoutDuration == 0 {
-		timeoutDuration = defaultValue
-	}
-	return timeoutDuration
 }
 
 func getTimeDuration(str string, defaultValue time.Duration, errMessage string) time.Duration {

--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -44,12 +44,12 @@ type Config struct {
 func NewConfig(networkID []byte) Config {
 	p := Config{}
 
-	p.TimeoutINIT = 2 * time.Second
-	p.TimeoutSIGN = 2 * time.Second
-	p.TimeoutACCEPT = 2 * time.Second
-	p.TimeoutALLCONFIRM = 30 * time.Second
-	p.BlockTime = 5 * time.Second
-	p.BlockTimeDelta = 1 * time.Second
+	p.TimeoutINIT = DefaultTimeoutINIT
+	p.TimeoutSIGN = DefaultTimeoutSIGN
+	p.TimeoutACCEPT = DefaultTimeoutACCEPT
+	p.TimeoutALLCONFIRM = DefaultTimeoutALLCONFIRM
+	p.BlockTime = DefaultBlockTime
+	p.BlockTimeDelta = DefaultBlockTimeDelta
 
 	p.TxsLimit = DefaultTransactionsInBallotLimit
 	p.OpsLimit = DefaultOperationsInTransactionLimit

--- a/lib/common/config_test.go
+++ b/lib/common/config_test.go
@@ -13,15 +13,15 @@ import (
 //	TestConfigDefault tests the default timeout values.
 func TestConfigDefault(t *testing.T) {
 	n := NewTestConfig()
-	require.Equal(t, 2*time.Second, n.TimeoutINIT)
-	require.Equal(t, 2*time.Second, n.TimeoutSIGN)
-	require.Equal(t, 2*time.Second, n.TimeoutACCEPT)
-	require.Equal(t, 30*time.Second, n.TimeoutALLCONFIRM)
-	require.Equal(t, 5*time.Second, n.BlockTime)
-	require.Equal(t, 1*time.Second, n.BlockTimeDelta)
+	require.Equal(t, DefaultTimeoutINIT, n.TimeoutINIT)
+	require.Equal(t, DefaultTimeoutSIGN, n.TimeoutSIGN)
+	require.Equal(t, DefaultTimeoutACCEPT, n.TimeoutACCEPT)
+	require.Equal(t, DefaultTimeoutALLCONFIRM, n.TimeoutALLCONFIRM)
+	require.Equal(t, DefaultBlockTime, n.BlockTime)
+	require.Equal(t, DefaultBlockTimeDelta, n.BlockTimeDelta)
 
-	require.Equal(t, 1000, n.TxsLimit)
-	require.Equal(t, 1000, n.OpsLimit)
+	require.Equal(t, DefaultTransactionsInBallotLimit, n.TxsLimit)
+	require.Equal(t, DefaultOperationsInTransactionLimit, n.OpsLimit)
 }
 
 //	TestConfigSetAndGet tests setting timeout fields and checking.

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -56,6 +56,13 @@ const (
 	// operations in one ballot. This does not count the operations of
 	// `ProposerTransaction`.
 	DefaultOperationsInBallotLimit int = 10000
+
+	DefaultTimeoutINIT       = 2 * time.Second
+	DefaultTimeoutSIGN       = 2 * time.Second
+	DefaultTimeoutACCEPT     = 2 * time.Second
+	DefaultTimeoutALLCONFIRM = 30 * time.Second
+	DefaultBlockTime         = 5 * time.Second
+	DefaultBlockTimeDelta    = 1 * time.Second
 )
 
 var (

--- a/tests/long-term/run.sh
+++ b/tests/long-term/run.sh
@@ -6,7 +6,7 @@ set -xe
 # So make sure we're in the right WD
 cd -- `dirname ${BASH_SOURCE[0]}`
 ROOT_DIR="../.."
-export BLOCK_TIME_DELTA=2
+export BLOCK_TIME_DELTA=2s
 source accounts.sh
 CONTAINERS=""
 function dumpLogsAndCleanup () {


### PR DESCRIPTION
Use time format for timeouts in configuration
Because we need to set blockTime, timeoutINIT, etc... as milliseconds for testing

Please check each commits