### PR TITLE
Makes a method(InvalidTransactions) simple and efficient

### DIFF
--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -34,7 +34,7 @@ type BallotTransactionChecker struct {
 	transactionCache      *TransactionCache
 }
 
-func (checker *BallotTransactionChecker) InvalidTransactions() (invalids []string) {
+func (checker *BallotTransactionChecker) invalidTransactions() (invalids []string) {
 	for _, hash := range checker.Transactions {
 		if _, found := checker.validTransactionsMap[hash]; found {
 			continue

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -46,6 +46,10 @@ func (checker *BallotTransactionChecker) invalidTransactions() (invalids []strin
 	return
 }
 
+func (checker *BallotTransactionChecker) allTransactionsValid() bool {
+	return len(checker.Transactions) == len(checker.validTransactionsMap)
+}
+
 func (checker *BallotTransactionChecker) setValidTransactions(hashes []string) {
 	checker.ValidTransactions = hashes
 
@@ -203,10 +207,10 @@ func BallotTransactionsOperationBodyCollectTxFee(c common.Checker, args ...inter
 func BallotTransactionsAllValid(c common.Checker, args ...interface{}) (err error) {
 	checker := c.(*BallotTransactionChecker)
 
-	if len(checker.InvalidTransactions()) > 0 {
-		checker.VotingHole = voting.NO
-	} else {
+	if checker.allTransactionsValid() {
 		checker.VotingHole = voting.YES
+	} else {
+		checker.VotingHole = voting.NO
 	}
 
 	return

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -659,12 +659,12 @@ func (nr *NodeRunner) proposeNewBallot(round uint64) (ballot.Ballot, error) {
 	}
 
 	// remove invalid transactions
-	if len(transactionsChecker.InvalidTransactions()) > 0 {
-		nr.TransactionPool.Remove(transactionsChecker.InvalidTransactions()...)
+	if len(transactionsChecker.invalidTransactions()) > 0 {
+		nr.TransactionPool.Remove(transactionsChecker.invalidTransactions()...)
 		nr.log.Debug(
 			"invalid transactions removed from pool",
 			"basis", basis,
-			"invalid-transactions", len(transactionsChecker.InvalidTransactions()),
+			"invalid-transactions", len(transactionsChecker.invalidTransactions()),
 			"transactionpool", nr.TransactionPool.Len(),
 		)
 	}


### PR DESCRIPTION
Fixes #663 
We don't have to get all invalid transactions to check that transactions are valid.
We can do it just comparing length of checker.Transactions and checker.validTransactionsMap