### PR TITLE
Fix and improve RLP tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module boscoin.io/sebak
 require (
 	github.com/GianlucaGuarini/go-observable v0.0.0-20180829201609-d386f0081a66
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
+	github.com/allegro/bigcache v1.1.0 // indirect
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/btcsuite/btcd v0.0.0-20180810000619-f899737d7f27 // indirect
 	github.com/btcsuite/btcutil v0.0.0-20170726183619-501929d3d046
 	github.com/davecgh/go-spew v1.1.0 // indirect
-	github.com/ethereum/go-ethereum v1.8.13
+	github.com/ethereum/go-ethereum v1.8.19
 	github.com/fsnotify/fsnotify v1.4.7 // indirect
 	github.com/go-kit/kit v0.8.0
 	github.com/go-redis/cache v6.3.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/GianlucaGuarini/go-observable v0.0.0-20180829201609-d386f0081a66 h1:Z
 github.com/GianlucaGuarini/go-observable v0.0.0-20180829201609-d386f0081a66/go.mod h1:2pqNiwoZ8Fj1HBGWyPTXW/iPD332sJzTp3Iy0dIcFMc=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
+github.com/allegro/bigcache v1.1.0 h1:MLuIKTjdxDc+qsG2rhjsYjsHQC5LUGjIWzutg7M+W68=
+github.com/allegro/bigcache v1.1.0/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/btcsuite/btcd v0.0.0-20180810000619-f899737d7f27 h1:WU7sAs3XGB9kUkEum8TfmtKl8seYpgyNplGgifi6ZgE=
@@ -10,8 +12,8 @@ github.com/btcsuite/btcutil v0.0.0-20170726183619-501929d3d046 h1:U/592rFHSSO4Vl
 github.com/btcsuite/btcutil v0.0.0-20170726183619-501929d3d046/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/ethereum/go-ethereum v1.8.13 h1:AYgNAj97NBZIyNThOV0Wt8aTs+A+g3SmS/3eboPFJ0o=
-github.com/ethereum/go-ethereum v1.8.13/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
+github.com/ethereum/go-ethereum v1.8.19 h1:H3m/wLo1hx3gpduVMQWb9ertqkmuTXvqjQNcxiA6XNI=
+github.com/ethereum/go-ethereum v1.8.19/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-kit/kit v0.8.0 h1:Wz+5lgoB0kkuqLEc6NVmwRknTKP6dTGbSqvhZtBI/j0=

--- a/lib/common/hash_test.go
+++ b/lib/common/hash_test.go
@@ -9,7 +9,7 @@ import (
 type intType uint64
 
 type intSideType struct {
-	i int64
+	I uint64
 }
 
 func TestInt64HashableRLP(t *testing.T) {
@@ -22,7 +22,7 @@ func TestInt64HashableRLP(t *testing.T) {
 }
 
 func TestInt64StructHashableRLP(t *testing.T) {
-	i := intSideType{i: 64}
+	i := intSideType{I: 64}
 	_, err := rlp.EncodeToBytes(i)
 	if err != nil {
 		t.Error(err)

--- a/lib/common/hash_test.go
+++ b/lib/common/hash_test.go
@@ -2,8 +2,6 @@ package common
 
 import (
 	"testing"
-
-	"github.com/ethereum/go-ethereum/rlp"
 )
 
 type intType uint64
@@ -12,20 +10,14 @@ type intSideType struct {
 	I uint64
 }
 
+func TestUnsignedIntHashableRLP(t *testing.T) {
+	CheckRoundTripRLP(t, uint(10))
+}
+
 func TestInt64HashableRLP(t *testing.T) {
-	i := intType(10)
-	_, err := rlp.EncodeToBytes(i)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	CheckRoundTripRLP(t, intType(10))
 }
 
 func TestInt64StructHashableRLP(t *testing.T) {
-	i := intSideType{I: 64}
-	_, err := rlp.EncodeToBytes(i)
-	if err != nil {
-		t.Error(err)
-		return
-	}
+	CheckRoundTripRLP(t, intSideType{I: 64})
 }

--- a/lib/common/test.go
+++ b/lib/common/test.go
@@ -1,6 +1,14 @@
 // Provide test utilities for the common package
 package common
 
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/stretchr/testify/require"
+)
+
 // Initialize a new config object for unittests
 func NewTestConfig() Config {
 	p := Config{}
@@ -28,4 +36,21 @@ func NewTestConfig() Config {
 	p.HTTPCachePoolSize = HTTPCachePoolSize
 
 	return p
+}
+
+// Test that a record that gets serialized to RLP deserialize to the same data
+//
+// Params:
+//   t = The testing object
+//   record = A pointer to the record to serialize
+func CheckRoundTripRLP(t *testing.T, record interface{}) {
+	binary, err := rlp.EncodeToBytes(record)
+	require.NoError(t, err)
+
+	result := reflect.New(reflect.TypeOf(record))
+	err = rlp.DecodeBytes(binary, result.Interface())
+	require.NoError(t, err)
+
+	require.Equal(t, record, result.Elem().Interface())
+	require.Equal(t, MustMakeObjectHash(record), MustMakeObjectHash(result.Elem().Interface()))
 }


### PR DESCRIPTION
Once again, better reviewed commit-by-commit.
I was working on encoding and realize that the tests were not testing anything, thanks to the packages ignoring private values. This utility is also helpful to test other records.