### PR TITLE
Set `formatted` field at default rate

### DIFF
--- a/cmd/sebak/cmd/cmd_test.go
+++ b/cmd/sebak/cmd/cmd_test.go
@@ -52,6 +52,9 @@ func TestParseFlagsNode(t *testing.T) {
 
 	require.Equal(t, 67, threshold)
 
+	require.Equal(t, "100-M", rateLimitRuleAPI.Default.Formatted)
+	require.Equal(t, "100-S", rateLimitRuleNode.Default.Formatted)
+
 	require.Equal(t, uint64(1000000), txPoolClientLimit)
 	require.Equal(t, uint64(0) /* unlimited */, txPoolNodeLimit)
 

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -83,17 +83,11 @@ var (
 
 	// RateLimitAPI set the rate limit for API interface, the default value
 	// allows 100 requests per minute.
-	RateLimitAPI limiter.Rate = limiter.Rate{
-		Period: 1 * time.Minute,
-		Limit:  100,
-	}
+	RateLimitAPI, _ = limiter.NewRateFromFormatted("100-M")
 
 	// RateLimitNode set the rate limit for node interface, the default value
 	// allows 100 requests per seconds.
-	RateLimitNode limiter.Rate = limiter.Rate{
-		Period: 1 * time.Second,
-		Limit:  100,
-	}
+	RateLimitNode, _ = limiter.NewRateFromFormatted("100-S")
 
 	HTTPCacheAdapterNames = map[string]bool{
 		HTTPCacheMemoryAdapterName: true,


### PR DESCRIPTION
There is no `rate-limit-node` value in https://mainnet.blockchainos.org/

```
"rate-limit-api": "200-M",
"rate-limit-node": "",
"transactions-limit": 1000,
```

It's because default `formatted` of `rate-limit-node` is empty.

This can be fixed simply using `limiter.NewRateFromFormatted` method.