### PR TITLE
load CommonAccountAddress with sync start

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -756,7 +756,10 @@ func runNode() error {
 
 	tp := transaction.NewPool(conf)
 
-	c := sync.NewConfig(localNode, st, nt, connectionManager, tp, conf)
+	c, err := sync.NewConfig(localNode, st, nt, connectionManager, tp, conf)
+	if err != nil {
+		return err
+	}
 	//Place setting config
 	c.SyncPoolSize = syncPoolSize
 	c.FetchTimeout = syncFetchTimeout

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
+	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/keypair"
 	"boscoin.io/sebak/lib/network"
 	"boscoin.io/sebak/lib/node"
-	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 
 	"github.com/stretchr/testify/require"
@@ -16,7 +16,7 @@ import (
 
 func TestNewConfig(t *testing.T) {
 	conf := common.NewTestConfig()
-	st := storage.NewTestStorage()
+	st := block.InitTestBlockchain()
 	_, nt, _ := network.CreateMemoryNetwork(nil)
 	cm := &mockConnectionManager{}
 	tp := transaction.NewPool(conf)
@@ -26,7 +26,8 @@ func TestNewConfig(t *testing.T) {
 
 	node, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
 
-	cfg := NewConfig(node, st, nt, cm, tp, conf)
+	cfg, err := NewConfig(node, st, nt, cm, tp, conf)
+	require.NoError(t, err)
 	cfg.SyncPoolSize = 100
 	cfg.logger = common.NopLogger()
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

`common/Config.CommonAccountAddress` is not loaded when `common.Config` is created. So sync has to load `CommonAccountAddress` and add it to `Config.CommonAccountAddress`

### Background

Block height 348204 has `inflation-pf` operation, and this operation validation needs `common.Config.CommonAccountAddress`. 

### Solution

`sync/Config` loads `CommonAccountAddress` and add it to `common/Config.CommonAccountAddress`.


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

IHMO, `common/Config` itself loads it's own attributes when it is created makes sense.

