### PR TITLE
Use CallerFileHandler

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -537,9 +537,7 @@ func parseFlagsNode() {
 		}
 	}
 
-	if logLevel == logging.LvlDebug { // only debug produces `caller` data
-		logHandler = logging.CallerFileHandler(logHandler)
-	}
+	logHandler = logging.CallerFileHandler(logHandler)
 	logHandler = logging.LvlFilterHandler(logLevel, logHandler)
 	log.SetHandler(logHandler)
 


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

Use `CallerFileHandler` with all log level. 
```
t=2018-12-20T23:10:48+0900 lvl=info msg="Starting Sebak" module=main version= gitcommit= caller=run.go:611
```

### Solution

I have no reason that only logging `caller` when debugging level is enabled.

For example

```

level=info ts=2018-12-18T15:00:00.785579852Z caller=compact.go:352 component=tsdb msg="compact blocks" count=3 mint=1545112800000 maxt=1545134400000 ulid=01CZ0X9C2S3P4WWEXA234KJ142 sources="[01CZ08P5P3QD6S4DW07JYD78YR 01CZ0FHWY4FFZ40S3N6QS6WHJP 01CZ0PDM64XZGCMAZFER7N18AK]"

```

There is a log example from Prometheus with logfmt and caller.

### Possible Drawbacks

<!--
    What are the possible side-effects or negative impacts of the code change?
-->

