### PR TITLE
Support Time Sync

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/allegro/bigcache v1.1.0 // indirect
+	github.com/beevik/ntp v0.2.0
 	github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 // indirect
 	github.com/btcsuite/btcd v0.0.0-20180810000619-f899737d7f27 // indirect
 	github.com/btcsuite/btcutil v0.0.0-20170726183619-501929d3d046

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7I
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
 github.com/allegro/bigcache v1.1.0 h1:MLuIKTjdxDc+qsG2rhjsYjsHQC5LUGjIWzutg7M+W68=
 github.com/allegro/bigcache v1.1.0/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
+github.com/beevik/ntp v0.2.0 h1:sGsd+kAXzT0bfVfzJfce04g+dSRfrs+tbQW8lweuYgw=
+github.com/beevik/ntp v0.2.0/go.mod h1:hIHWr+l3+/clUnF44zdK+CWW7fO8dR5cIylAQ76NRpg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/btcsuite/btcd v0.0.0-20180810000619-f899737d7f27 h1:WU7sAs3XGB9kUkEum8TfmtKl8seYpgyNplGgifi6ZgE=

--- a/lib/common/constant.go
+++ b/lib/common/constant.go
@@ -99,4 +99,8 @@ var (
 		"":                         true, // default value is nop cache
 	}
 	DefaultJSONRPCBindURL string = "http://127.0.0.1:54321/jsonrpc" // JSONRPC only can be accessed from localhost
+
+	// MaxTimeDiffAllow is the allowed difference of node time. The default
+	// value, 4 seconds is from BlockTime.
+	MaxTimeDiffAllow time.Duration = time.Second * 4
 )

--- a/lib/common/exec.go
+++ b/lib/common/exec.go
@@ -1,0 +1,26 @@
+package common
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+// wrapExternalCommand is for the other platform like windows. SEBAK does not
+// support officially, and if you wish to support windows platform, create
+// custom `wrapExternalCommand` for it.
+func wrapExternalCommand(cmd string) (string, []string) {
+	return "sh", []string{"-c", cmd}
+}
+
+func ExecExternalCommand(cmd string) ([]byte, error) {
+	name, extras := wrapExternalCommand(cmd)
+
+	c := exec.Command(name, extras...)
+
+	var b bytes.Buffer
+	c.Stderr = &b
+	c.Stdout = &b
+
+	err := c.Run()
+	return b.Bytes(), err
+}

--- a/lib/common/init.go
+++ b/lib/common/init.go
@@ -1,0 +1,15 @@
+package common
+
+import (
+	logging "github.com/inconshreveable/log15"
+)
+
+var log logging.Logger = logging.New("module", "common")
+
+func init() {
+	SetLogging(DefaultLogLevel, DefaultLogHandler)
+}
+
+func SetLogging(level logging.Lvl, handler logging.Handler) {
+	log.SetHandler(logging.LvlFilterHandler(level, handler))
+}

--- a/lib/common/log.go
+++ b/lib/common/log.go
@@ -17,11 +17,6 @@ var (
 	DefaultLogHandler logging.Handler = logging.StreamHandler(os.Stdout, logging.TerminalFormat())
 )
 
-// SetLogging set the logger
-func SetLogging(logger logging.Logger, level logging.Lvl, handler logging.Handler) {
-	logger.SetHandler(logging.LvlFilterHandler(level, handler))
-}
-
 // `formatJSONValue` and `JsonFormatEx` was derived from
 // https://github.com/inconshreveable/log15/blob/199fca55789248e0520a3bd33e9045799738e793/format.go#L131
 // .

--- a/lib/common/time.go
+++ b/lib/common/time.go
@@ -1,6 +1,13 @@
 package common
 
-import "time"
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"time"
+
+	"github.com/beevik/ntp"
+)
 
 const (
 	TIMEFORMAT_ISO8601 string = "2006-01-02T15:04:05.000000000Z07:00"
@@ -16,4 +23,93 @@ func NowISO8601() string {
 
 func ParseISO8601(s string) (time.Time, error) {
 	return time.Parse(TIMEFORMAT_ISO8601, s)
+}
+
+type TimeSync struct {
+	ntpServer string
+	syncCmd   string
+}
+
+func NewTimeSync(ntpServer string, syncCmd string) (*TimeSync, error) {
+	ts := &TimeSync{
+		ntpServer: ntpServer,
+		syncCmd:   syncCmd,
+	}
+
+	if _, err := ts.Query(); err != nil {
+		return nil, err
+	}
+
+	return ts, nil
+}
+
+func (ts *TimeSync) Start() {
+	log.Debug("starting to sync time periodically")
+
+	go func() {
+		for _ = range time.NewTicker(time.Second * 60).C {
+			go func() {
+				if err := ts.Sync(); err != nil {
+					log.Error("failed to sync time", "error", err)
+				}
+			}()
+		}
+	}()
+}
+
+func (ts *TimeSync) Query() (*ntp.Response, error) {
+	return ntp.Query(ts.ntpServer)
+}
+
+func (ts *TimeSync) checkNTPOffset() (bool, error) {
+	resp, err := ts.Query()
+	if err != nil {
+		return false, err
+	}
+
+	log.Debug("check time difference", "offset", resp.ClockOffset, "allowed", MaxTimeDiffAllow)
+	if resp.ClockOffset > MaxTimeDiffAllow || resp.ClockOffset < (MaxTimeDiffAllow*-1) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (ts *TimeSync) Sync() error {
+	if len(ts.syncCmd) < 1 {
+		return nil
+	}
+
+	log.Debug("trying to sync time")
+
+	var b bytes.Buffer
+	cmd := exec.Command("sh", "-c", ts.syncCmd)
+	cmd.Stderr = &b
+	cmd.Stdout = &b
+
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run time-sync-command: `%s`: %s", ts.syncCmd, b.String())
+	} else {
+		log.Debug("time-sync-command was executed", "output", b.String())
+	}
+
+	var err error
+	var synced bool
+	for i := 0; i < 3; i++ {
+		time.Sleep(time.Second * 3)
+		if synced, err = ts.checkNTPOffset(); err != nil {
+			return err
+		}
+		if synced {
+			break
+		}
+	}
+
+	if !synced {
+		return fmt.Errorf("time-sync-command was executed, but still not synced")
+	}
+
+	log.Debug("time synced")
+
+	return nil
 }

--- a/lib/node/runner/init_test.go
+++ b/lib/node/runner/init_test.go
@@ -3,10 +3,9 @@ package runner
 import (
 	logging "github.com/inconshreveable/log15"
 
-	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/common/test"
 )
 
 func init() {
-	common.SetLogging(log, logging.LvlInfo, test.LogHandler())
+	SetLogging(logging.LvlInfo, test.LogHandler())
 }


### PR DESCRIPTION
### Github Issue
Resolves #571 

### Background

Time is very important in SEBAK, the creation time of ballot and transaction time is used for its validation and node discovery also validates its time.

If time is different from the other nodes,
* The node will not join the network, discovery will be failed
* The ballots from problem node will be ignored

### Solution

At starting time, `common.TimeSync` compares local time with the NTP server(`--ntp`). If it's different is over `common.MaxTimeDiffAllow`(4 seconds by default), the node tries to sync time using `--time-sync-command` command.

The `TimeSync` will check and sync time periodically(every 1 minute).

#### Changes

* `--ntp` option added; set the NTP server, by default `time.bora.net`
* `--time-sync-command` option added; this command will be executed when time difference is over `common.MaxTimeDiffAllow`. For example, `rdate time.bora.net` will be used.