### PR TITLE
Support `leveldb.Snapshot` in jsonrpc

### DIFF
--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -112,4 +112,6 @@ var (
 	EndpointNotFound                          = NewError(194, "endpoint not found")
 	DiscoveryFromUnknownValidator             = NewError(195, "DiscoveryMessage from unknown validator")
 	DiscoveryPolicyDoesNotMatch               = NewError(196, "policy does not matched with discovery node")
+	SnapshotNotFound                          = NewError(197, "snapshot not found")
+	SnapshotLimitReached                      = NewError(198, "snapshots over limit")
 )

--- a/lib/node/runner/jsonrpc.go
+++ b/lib/node/runner/jsonrpc.go
@@ -176,7 +176,7 @@ func (j *expireSnapshots) isExpired(key string) bool {
 		return true
 	}
 
-	return time.Now().Sub(t.(time.Time)) > time.Second
+	return (t.(time.Time)).Before(time.Now())
 }
 
 func (j *expireSnapshots) updateExpire(key string) {

--- a/lib/node/runner/jsonrpc.go
+++ b/lib/node/runner/jsonrpc.go
@@ -1,46 +1,222 @@
 package runner
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/rpc"
 	jsonrpc "github.com/gorilla/rpc/json"
+	"golang.org/x/sync/syncmap"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/storage"
 )
 
 const MaxLimitListOptions uint64 = 10000
+const MaxSnapshots uint64 = 500
 
 type DBEchoArgs string
 type DBEchoResult string
 
-type DBHasArgs string
+type DBOpenSnapshot struct{}
+
+type DBOpenSnapshotResult struct {
+	Snapshot string `json:"snapshot"`
+}
+
+type DBReleaseSnapshot struct {
+	Snapshot string `json:"snapshot"`
+}
+
+type DBReleaseSnapshotResult bool
+
+type DBHasArgs struct {
+	Snapshot string `json:"snapshot"`
+	Key      string `json:"key"`
+}
+
 type DBHasResult bool
 
-type DBGetArgs string
+type DBGetArgs struct {
+	Snapshot string `json:"snapshot"`
+	Key      string `json:"key"`
+}
+
 type DBGetResult storage.IterItem
 
 type GetIteratorOptions struct {
-	Reverse bool
-	Cursor  []byte
-	Limit   uint64
+	Reverse bool   `json:"reverse"`
+	Cursor  []byte `json:"cursor"`
+	Limit   uint64 `json:"limit"`
 }
 
 type DBGetIteratorArgs struct {
-	Prefix  string
-	Options GetIteratorOptions
+	Snapshot string             `json:"snapshot"`
+	Prefix   string             `json:"prefix"`
+	Options  GetIteratorOptions `json:"options"`
 }
 
 type DBGetIteratorResult struct {
-	Limit uint64
-	Items []storage.IterItem
+	Limit uint64             `json:"limit"`
+	Items []storage.IterItem `json:"items"`
 }
 
 type jsonrpcDBApp struct {
-	st *storage.LevelDBBackend
+	st        *storage.LevelDBBackend
+	snapshots *expireSnapshots
+}
+
+type expireSnapshots struct {
+	sync.RWMutex
+	st           *storage.LevelDBBackend
+	interval     time.Duration
+	maxSnapshots uint64
+	ticker       *time.Ticker
+	snapshots    *syncmap.Map
+	expires      *syncmap.Map
+}
+
+func newExpireSnapshots(st *storage.LevelDBBackend, interval time.Duration, maxSnapshots uint64) *expireSnapshots {
+	return &expireSnapshots{
+		st:           st,
+		interval:     interval,
+		maxSnapshots: maxSnapshots,
+		ticker:       time.NewTicker(time.Second * 10),
+		snapshots:    &syncmap.Map{},
+		expires:      &syncmap.Map{},
+	}
+}
+
+func (j *expireSnapshots) len() (l int) {
+	j.snapshots.Range(func(_, _ interface{}) bool {
+		l++
+		return true
+	})
+
+	return
+}
+
+func (j *expireSnapshots) newSnapshot() (string, *storage.LevelDBBackend, error) {
+	if j.len() >= int(j.maxSnapshots) {
+		return "", nil, errors.SnapshotLimitReached
+	}
+
+	j.Lock()
+	defer j.Unlock()
+
+	st, err := j.st.OpenSnapshot()
+	if err != nil {
+		return "", nil, err
+	}
+
+	key := common.GetUniqueIDFromUUID()
+	j.snapshots.Store(key, st)
+	j.updateExpire(key)
+
+	log.Debug("new snapshot created", "key", key, "current", j.len())
+	return key, st, nil
+}
+
+func (j *expireSnapshots) snapshot(key string) (*storage.LevelDBBackend, bool) {
+	j.RLock()
+	defer j.RUnlock()
+
+	s, ok := j.snapshots.Load(key)
+	if !ok {
+		return nil, false
+	}
+
+	j.updateExpire(key)
+	return s.(*storage.LevelDBBackend), true
+}
+
+func (j *expireSnapshots) expire(key string) bool {
+	go func() {
+		log.Debug("snapshot expired", "key", key, "current", j.len())
+	}()
+	return j.release_(key)
+}
+
+func (j *expireSnapshots) release(key string) bool {
+	go func() {
+		log.Debug("snapshot released", "key", key, "current", j.len())
+	}()
+	return j.release_(key)
+}
+
+func (j *expireSnapshots) release_(key string) bool {
+	st, ok := j.snapshot(key)
+	if !ok {
+		return false
+	}
+
+	j.Lock()
+	defer j.Unlock()
+
+	if st.Core != nil {
+		st.Core.(*storage.Snapshot).Release()
+	}
+	j.snapshots.Delete(key)
+	j.expires.Delete(key)
+
+	return true
+}
+
+func (j *expireSnapshots) isExpired(key string) bool {
+	j.RLock()
+	defer j.RUnlock()
+
+	t, ok := j.expires.Load(key)
+	if !ok {
+		return true
+	}
+
+	return time.Now().Sub(t.(time.Time)) > time.Second
+}
+
+func (j *expireSnapshots) updateExpire(key string) {
+	j.expires.Store(key, time.Now().Add(j.interval))
+}
+
+func (j *expireSnapshots) start() {
+	go func() {
+		for _ = range j.ticker.C {
+			var expired []string
+			j.snapshots.Range(func(k, _ interface{}) bool {
+				key := k.(string)
+				if j.isExpired(key) {
+					expired = append(expired, key)
+				}
+				return true
+			})
+
+			for _, key := range expired {
+				j.expire(key)
+			}
+		}
+	}()
+}
+
+func (j *expireSnapshots) stop() {
+	j.ticker.Stop()
+}
+
+func newJSONRPCDBApp(st *storage.LevelDBBackend) *jsonrpcDBApp {
+	app := &jsonrpcDBApp{
+		st:        st,
+		snapshots: newExpireSnapshots(st, time.Minute*1, MaxSnapshots),
+	}
+
+	return app
+}
+
+func (j *jsonrpcDBApp) stop() {
+	j.snapshots.stop()
 }
 
 func (j *jsonrpcDBApp) Echo(r *http.Request, args *DBEchoArgs, result *DBEchoResult) error {
@@ -48,8 +224,32 @@ func (j *jsonrpcDBApp) Echo(r *http.Request, args *DBEchoArgs, result *DBEchoRes
 	return nil
 }
 
+func (j *jsonrpcDBApp) OpenSnapshot(r *http.Request, args *DBOpenSnapshot, result *DBOpenSnapshotResult) error {
+	key, _, err := j.snapshots.newSnapshot()
+	if err != nil {
+		return err
+	}
+	*result = DBOpenSnapshotResult{Snapshot: key}
+	return nil
+}
+
+func (j *jsonrpcDBApp) ReleaseSnapshot(r *http.Request, args *DBReleaseSnapshot, result *DBReleaseSnapshotResult) error {
+	ok := j.snapshots.release(args.Snapshot)
+	*result = DBReleaseSnapshotResult(ok)
+	return nil
+}
+
 func (j *jsonrpcDBApp) Has(r *http.Request, args *DBHasArgs, result *DBHasResult) error {
-	o, err := j.st.Has(string(*args))
+	if len(args.Snapshot) < 1 {
+		return fmt.Errorf("snapshot must be given")
+	}
+
+	st, found := j.snapshots.snapshot(args.Snapshot)
+	if !found {
+		return errors.SnapshotNotFound
+	}
+
+	o, err := st.Has(args.Key)
 	if err != nil {
 		return err
 	}
@@ -59,16 +259,34 @@ func (j *jsonrpcDBApp) Has(r *http.Request, args *DBHasArgs, result *DBHasResult
 }
 
 func (j *jsonrpcDBApp) Get(r *http.Request, args *DBGetArgs, result *DBGetResult) error {
-	o, err := j.st.GetRaw(string(*args))
+	if len(args.Snapshot) < 1 {
+		return fmt.Errorf("snapshot must be given")
+	}
+
+	st, found := j.snapshots.snapshot(args.Snapshot)
+	if !found {
+		return errors.SnapshotNotFound
+	}
+
+	o, err := st.GetRaw(args.Key)
 	if err != nil {
 		return err
 	}
 
-	*result = DBGetResult{Key: []byte(*args), Value: o}
+	*result = DBGetResult{Key: []byte(args.Key), Value: o}
 	return nil
 }
 
 func (j *jsonrpcDBApp) GetIterator(r *http.Request, args *DBGetIteratorArgs, result *DBGetIteratorResult) error {
+	if len(args.Snapshot) < 1 {
+		return fmt.Errorf("snapshot must be given")
+	}
+
+	st, found := j.snapshots.snapshot(args.Snapshot)
+	if !found {
+		return errors.SnapshotNotFound
+	}
+
 	limit := args.Options.Limit
 	if limit > MaxLimitListOptions {
 		limit = MaxLimitListOptions
@@ -80,7 +298,7 @@ func (j *jsonrpcDBApp) GetIterator(r *http.Request, args *DBGetIteratorArgs, res
 		limit,
 	)
 
-	it, closeFunc := j.st.GetIterator(args.Prefix, options)
+	it, closeFunc := st.GetIterator(args.Prefix, options)
 	defer closeFunc()
 
 	collected := []storage.IterItem{}
@@ -103,6 +321,7 @@ type jsonrpcServer struct {
 	endpoint *common.Endpoint
 	st       *storage.LevelDBBackend
 	server   *http.Server
+	app      *jsonrpcDBApp
 }
 
 func newJSONRPCServer(endpoint *common.Endpoint, st *storage.LevelDBBackend) *jsonrpcServer {
@@ -137,8 +356,8 @@ func (j *jsonrpcServer) Ready() *mux.Router {
 	s.RegisterCodec(jsonrpc.NewCodec(), "application/json")
 	s.RegisterCodec(jsonrpc.NewCodec(), "application/json;charset=UTF-8")
 
-	dbApp := &jsonrpcDBApp{st: j.st}
-	s.RegisterService(dbApp, "DB")
+	j.app = newJSONRPCDBApp(j.st)
+	s.RegisterService(j.app, "DB")
 
 	router := mux.NewRouter()
 
@@ -153,6 +372,7 @@ func (j *jsonrpcServer) Ready() *mux.Router {
 
 func (j *jsonrpcServer) Start() error {
 	j.server.Handler = j.Ready()
+	j.app.snapshots.start()
 
 	err := func() error {
 		if strings.ToLower(j.endpoint.Scheme) == "http" {
@@ -173,5 +393,9 @@ func (j *jsonrpcServer) Start() error {
 }
 
 func (j *jsonrpcServer) Stop() {
+	if j.app != nil {
+		j.app.stop()
+	}
+
 	j.server.Close()
 }

--- a/lib/storage/leveldb.go
+++ b/lib/storage/leveldb.go
@@ -65,6 +65,14 @@ func (st *LevelDBBackend) Close() error {
 	return st.DB.Close()
 }
 
+func (st *LevelDBBackend) Release() error {
+	if snapshot, ok := st.Core.(*Snapshot); ok {
+		snapshot.Release()
+	}
+
+	return nil
+}
+
 func (st *LevelDBBackend) OpenTransaction() (*LevelDBBackend, error) {
 	_, ok := st.Core.(*leveldb.Transaction)
 	if ok {
@@ -92,6 +100,18 @@ func (st *LevelDBBackend) OpenBatch() (*LevelDBBackend, error) {
 	return &LevelDBBackend{
 		DB:   st.DB,
 		Core: NewBatchCore(st.DB),
+	}, nil
+}
+
+func (st *LevelDBBackend) OpenSnapshot() (*LevelDBBackend, error) {
+	snapshot, err := NewSnapshot(st)
+	if err != nil {
+		return nil, err
+	}
+
+	return &LevelDBBackend{
+		DB:   st.DB,
+		Core: snapshot,
 	}, nil
 }
 

--- a/lib/storage/snapshot.go
+++ b/lib/storage/snapshot.go
@@ -1,0 +1,33 @@
+package storage
+
+import (
+	"github.com/syndtr/goleveldb/leveldb"
+	leveldbOpt "github.com/syndtr/goleveldb/leveldb/opt"
+
+	"boscoin.io/sebak/lib/errors"
+)
+
+type Snapshot struct {
+	*leveldb.Snapshot
+}
+
+func NewSnapshot(st *LevelDBBackend) (*Snapshot, error) {
+	snapshot, err := st.DB.GetSnapshot()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Snapshot{Snapshot: snapshot}, nil
+}
+
+func (s *Snapshot) Put([]byte, []byte, *leveldbOpt.WriteOptions) error {
+	return errors.NotImplemented
+}
+
+func (s *Snapshot) Write(*leveldb.Batch, *leveldbOpt.WriteOptions) error {
+	return errors.NotImplemented
+}
+
+func (s *Snapshot) Delete([]byte, *leveldbOpt.WriteOptions) error {
+	return errors.NotImplemented
+}


### PR DESCRIPTION
### Github Issue

Resolves #888 

### Background

See #888 

### Solution

* `DB.OpenSnapshot` method will return the snapshot id, it is the unique id of the snapshot.
* All the `DB` methods must have 'snapshot' in the argument.
* `DB.ReleaseSnapshot` method will release the snapshot of the snapshot id.
* The opened snapshot will be released automatically after expired.

The snapshot version of python example can be found at https://gist.github.com/spikeekips/a914b9747b868caabd8adc4cb53cbbe7#file-jsonrpc-sebak-prior-v0-1-2-py .

This example, https://gist.github.com/spikeekips/cc007f925435a13650f9c5a587b8e0e5 dumps and creates new leveldb.