### PR TITLE
Save BlockTransaction and BlockOperation when sync 

### DIFF
--- a/lib/sync/types.go
+++ b/lib/sync/types.go
@@ -7,7 +7,6 @@ import (
 
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
-	"boscoin.io/sebak/lib/transaction"
 )
 
 type SyncProgress struct {
@@ -23,7 +22,7 @@ type SyncController interface {
 type SyncInfo struct {
 	Height uint64
 	Block  *block.Block
-	Txs    []*transaction.Transaction
+	Bts    []*block.BlockTransaction
 	Ptx    *ballot.ProposerTransaction
 
 	// Fetching target node addresses, NodeList is  the validators which

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -135,10 +135,6 @@ func (v *BlockValidator) finishBlock(ctx context.Context, syncInfo *SyncInfo) er
 			bs.Discard()
 			return err
 		}
-		if err := bt.Save(bs); err != nil {
-			bs.Discard()
-			return err
-		}
 	}
 
 	ptx := syncInfo.Ptx

--- a/lib/sync/validator.go
+++ b/lib/sync/validator.go
@@ -135,6 +135,10 @@ func (v *BlockValidator) finishBlock(ctx context.Context, syncInfo *SyncInfo) er
 			bs.Discard()
 			return err
 		}
+		if _, err := block.SaveTransactionPool(bs, bt.Transaction()); err != nil {
+			bs.Discard()
+			return err
+		}
 	}
 
 	// ProposerTx
@@ -147,6 +151,11 @@ func (v *BlockValidator) finishBlock(ctx context.Context, syncInfo *SyncInfo) er
 
 		bt := block.NewBlockTransactionFromTransaction(blk.Hash, blk.Height, blk.ProposedTime, ptx.Transaction)
 		if err := bt.Save(bs); err != nil {
+			bs.Discard()
+			return err
+		}
+
+		if _, err := block.SaveTransactionPool(bs, ptx.Transaction); err != nil {
 			bs.Discard()
 			return err
 		}


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->

### Background

> The operation of above a blockheight is congress-voting-result and it needs to check the operation of congress-voting which should be saved already.

This PR intent that when syncer finishes a block, the operations and the transactions of this block are saved with finishing the block in sync/watcher node.



### Solution

when syncer finishes a block, the operations and the transactions of this block are saved with finishing the block in sync/watcher node.


### Possible Drawbacks
<!--
    What are the possible side-effects or negative impacts of the code change?
-->

Without `SavingBlockOperations`, It makes slower  sync/watcher time than with `SavingBlockOperations`.