### PR TITLE
Log debug when receiving different height ballot

### DIFF
--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -314,18 +314,10 @@ func BallotCheckBasis(c common.Checker, args ...interface{}) (err error) {
 	}
 
 	blk := block.GetLatestBlock(checker.NodeRunner.Storage())
-	if isValid, reason := checker.NodeRunner.Consensus().IsValidVotingBasis(
+	if isValid := checker.NodeRunner.Consensus().IsValidVotingBasis(
 		checker.Ballot.VotingBasis(),
 		blk,
 	); !isValid {
-		checker.NodeRunner.Log().Error(
-			"voting basis is invalid",
-			"reason", reason,
-			"ballot-basis", checker.Ballot.VotingBasis(),
-			"voting-basis", checker.NodeRunner.Consensus().LatestVotingBasis(),
-			"latest-block-height", blk.Height,
-			"latest-block-hash", blk.Hash,
-		)
 		return errors.InvalidVotingBasis
 	}
 


### PR DESCRIPTION
### Background
N of nodes: 4, TH: 3
When all four nodes are alive, error message is occurred every height because of fourth ballot.
Consensus is already done when a node receives only three ballots.

<img width="1680" alt="2019-01-04 5 31 50" src="https://user-images.githubusercontent.com/15343839/50679440-b2800400-1046-11e9-91f5-5ce36411c3fb.png">


### Solution
Make this log message `Debug`
I think receiving different height ballot is not error condition.