### PR TITLE
Enable binary serialization of BlockOperation (+ add upgrade command)

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -755,6 +755,11 @@ func runNode() error {
 		log.Crit("failed to initialize storage", "error", err)
 		return err
 	}
+	// Check that no upgrades are needed
+	if needsDBUpgrade(st) {
+		log.Crit("cannot start node - Upgrades are needed. Run sebak upgrade [--storage ...]")
+		return fmt.Errorf("Upgrades to the database needed")
+	}
 
 	// get the initial balance of geness account
 	initialBalance, err := runner.GetGenesisBalance(st)

--- a/cmd/sebak/cmd/upgrade.go
+++ b/cmd/sebak/cmd/upgrade.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/syndtr/goleveldb/leveldb/util"
+
+	cmdcommon "boscoin.io/sebak/cmd/sebak/common"
+	"boscoin.io/sebak/lib/block"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/storage"
+)
+
+var (
+	flagStorage string
+)
+
+func init() {
+	upgradeCmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade the DB from a previously existing version (or do nothing)",
+		Run:   runUpgrade,
+	}
+
+	flagStorage = common.GetENVValue("SEBAK_STORAGE", cmdcommon.GetDefaultStoragePath(upgradeCmd))
+	upgradeCmd.Flags().StringVar(&flagStorage, "storage", flagStorage, "storage uri")
+
+	rootCmd.AddCommand(upgradeCmd)
+}
+
+// Entry point of the command
+func runUpgrade(c *cobra.Command, args []string) {
+	// Open the DB
+	var st *storage.LevelDBBackend
+	if storageConfig, err := storage.NewConfigFromString(flagStorage); err != nil {
+		cmdcommon.PrintFlagsError(c, "--storage", err)
+	} else if st, err = storage.NewStorage(storageConfig); err != nil {
+		cmdcommon.PrintFlagsError(c, "--storage", err)
+	}
+	if err := apply20190107UpgradeBlockOperation(st); err != nil {
+		fmt.Println("Upgrade 2019-01-07 failed; nothing was changed; Error: ", err)
+	} else {
+		fmt.Println("Triggering compaction of the DB...")
+		st.DB.CompactRange(util.Range{})
+	}
+}
+
+// 2019-01-07: BlockOperation is binary serialized instead of JSON
+func apply20190107UpgradeBlockOperation(st *storage.LevelDBBackend) error {
+	// Start to iterate over all operations, and if we can deserialize the first
+	// one as JSON, keep going
+	iter, closer := st.GetIterator(common.BlockOperationPrefixHash, nil)
+	defer closer()
+	item, hasNext := iter()
+	if item.N == 0 {
+		return fmt.Errorf("<upgrade> will not run on an empty storage")
+	}
+	var bo block.BlockOperation
+	// If deserialization succeed, the data is not binary
+	if err := json.Unmarshal(item.Value, &bo); err != nil {
+		fmt.Println("Upgrade 2019-01-07: Already applied")
+		return nil
+	}
+
+	fmt.Println("Applying upgrade 2019-01-07: Binary serialization for BlockOperation")
+	batch, err := st.OpenBatch()
+	if err != nil {
+		return err
+	}
+	// Write the (already deserialized) first value
+	if err = batch.Set(string(item.Key), bo); err != nil {
+		batch.Discard()
+		return err
+	}
+	count := uint64(1)
+	// And everything else
+	for ; hasNext; item, hasNext = iter() {
+		if err = json.Unmarshal(item.Value, &bo); err != nil {
+			batch.Discard()
+			return err
+		}
+		if err = batch.Set(string(item.Key), bo); err != nil {
+			batch.Discard()
+			return err
+		}
+		count = item.N
+	}
+	if err := batch.Commit(); err != nil {
+		fmt.Println("Failed to commit a batch of ", count, " BlockOperations")
+		batch.Discard()
+		return err
+	}
+	fmt.Println("2019-01-07 applied; ", count, " items affected")
+	return nil
+}
+
+// This function is called by `run` to ensure that the node DB is up to date
+func needsDBUpgrade(st *storage.LevelDBBackend) bool {
+	iter, closer := st.GetIterator(common.BlockOperationPrefixHash, nil)
+	defer closer()
+	item, _ := iter()
+	if item.N == 0 {
+		return false
+	}
+	var bo block.BlockOperation
+	// If deserialization succeed, the data is not binary
+	if err := json.Unmarshal(item.Value, &bo); err == nil {
+		return true
+	}
+	return false
+}

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -9,6 +9,8 @@ import (
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"
+
+	"github.com/ethereum/go-ethereum/rlp"
 )
 
 // BlockOperation is `Operation` data for block. the storage should support,
@@ -34,6 +36,16 @@ type BlockOperation struct {
 	seqID   uint64
 	linked  string
 	isSaved bool
+}
+
+// Implement `encoding.BinaryMarshaler`
+func (bo BlockOperation) MarshalBinary() (data []byte, err error) {
+	return rlp.EncodeToBytes(bo)
+}
+
+// Implement `encoding.BinaryUnmarshaler`
+func (bo *BlockOperation) UnmarshalBinary(data []byte) error {
+	return rlp.DecodeBytes(data, bo)
 }
 
 func NewBlockOperationKey(opHash, txHash string) string {


### PR DESCRIPTION
**~Still working / testing this, it should be ready but I want hard data on the amount of space saved~**

~Please review commit-by-commit.~
~The most important commit is the last one (f52a7c5 ATM).~

This patch enables binary serialization on `BlockOperation`, saving some disk space.
```
In the LevelDB serialization code, `BinaryMarshaller` takes priority over `TextMarshaller`.
This allows us to simply switch on binary serialization with a few lines of code.

However, it is a breaking change for existing deployments,
as old text-serialized data won't be deserializable.

There are multiple way to approach this problem, among other things:
- Trying one of the method, then falling back if it doesn't work
- Setting a given block height in the future for the transition
- Replay all the transaction data to recreate the DB
- Force conversion of all the existing data

We choose, for simplicity, and to help reducing existing load on nodes,
to go with the later approach.
We introduce `sebak upgrade`, which will do the job only if needed.
In addition, a check was introduced in `run`,
to avoid the node starting with the new code and old data,
which could lead to memory corruption or crash.

Note that the code in `sebak upgrade` is not guaranteed to work in a future release.
Doing so would require specifying exactly what transformation is to be made,
which would overly complicate the process for little benefit.
It can be done in the future if the user base justifies the need.
```