### PR TITLE
`SavingBlockOpertion.Check()` hangs when some `block.Block` are missing

### DIFF
--- a/lib/node/runner/block_operations.go
+++ b/lib/node/runner/block_operations.go
@@ -181,6 +181,7 @@ func (sb *SavingBlockOperations) check(startBlockHeight uint64) (err error) {
 		for {
 			if blk, err = sb.getNextBlock(height); err != nil {
 				err = errors.FailedToSaveBlockOperaton.Clone().SetData("error", err)
+				errChan <- err
 				return
 			}
 


### PR DESCRIPTION
### Github Issue
Resolves #905 

### Background

See #905 