### PR TITLE
Remove unused block prefixes

### DIFF
--- a/lib/common/prefix.go
+++ b/lib/common/prefix.go
@@ -4,7 +4,6 @@ const (
 	BlockPrefixHash                       = string(0x00)
 	BlockPrefixConfirmed                  = string(0x01)
 	BlockPrefixHeight                     = string(0x02)
-	BlockPrefixTime                       = string(0x03)
 	BlockTransactionPrefixHash            = string(0x10)
 	BlockTransactionPrefixSource          = string(0x11)
 	BlockTransactionPrefixConfirmed       = string(0x12)
@@ -25,7 +24,6 @@ const (
 	BlockAccountPrefixCreated             = string(0x31)
 	BlockAccountSequenceIDPrefix          = string(0x32)
 	BlockAccountSequenceIDByAddressPrefix = string(0x33)
-	BlockAccountPrefixFrozen              = string(0x34)
 	TransactionPoolPrefix                 = string(0x40)
 	InternalPrefix                        = string(0x50) // internal data
 )


### PR DESCRIPTION
### Background

Unused block prefixes found.

### Solution

Simply removed them.