### PR TITLE
Improve client's streaming code

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -77,14 +77,34 @@ type Client struct {
 	HTTP *common.HTTP2Client
 }
 
-func NewClient(url string) *Client {
+//
+// Create a new Client object
+//
+// Params:
+//     url = The url of the node, e.g. "https://127.0.0.1:1234"
+//
+// Returns:
+//   error   = An error object, if the client could not be created.
+//             `nil` otherwise.
+//   Client* = If `error == nil`, the constructed `Client`
+//
+func NewClient(url string) (*Client, error) {
 	httpClient, err := common.NewHTTP2Client(0, 0, true)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	return &Client{
 		URL:  url,
 		HTTP: httpClient,
+	}, nil
+}
+
+// Calls `NewClient` and panic if an `error` is returned
+func MustNewClient(url string) *Client {
+	if cli, err := NewClient(url); err != nil {
+		panic(err)
+	} else {
+		return cli
 	}
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -259,7 +259,7 @@ func (c *Client) SubmitTransactionAndWait(hash string, tx []byte) (pTransaction 
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		err = c.StreamTransactionStatus(ctx, hash, nil, func(status TransactionStatus) {
+		err = c.StreamTransactionStatus(ctx, hash, func(status TransactionStatus) {
 			if status.Status == "confirmed" {
 				pTransaction.Status = status.Status
 				cancel()
@@ -410,7 +410,7 @@ func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, han
 	return c.stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
-func (c *Client) StreamTransactionStatus(ctx context.Context, id string, body []byte, handler func(TransactionStatus)) (err error) {
+func (c *Client) StreamTransactionStatus(ctx context.Context, id string, handler func(TransactionStatus)) (err error) {
 	url := strings.Replace(UrlTransactionStatus, "{id}", id, -1)
 	handlerFunc := func(b []byte) (err error) {
 		var v TransactionStatus

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"boscoin.io/sebak/lib/common/observer"
 	"bufio"
 	"context"
 	"encoding/json"
@@ -12,6 +11,7 @@ import (
 	"sync"
 
 	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/observer"
 	"boscoin.io/sebak/lib/storage"
 )
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -223,6 +223,14 @@ func (c *Client) LoadOperationsByTransaction(id string, queries ...Q) (oPage Ope
 	return
 }
 
+// Submit a transaction to the node (via POST `UrlTransactions`)
+//
+// Params:
+//     tx = JSON serialized Transaction that will be sent as body
+//
+// Returns:
+//   TransactionPost = An object describing the node's answer (usually just an echo)
+//   error = An error object, or `nil`
 func (c *Client) SubmitTransaction(tx []byte) (pTransaction TransactionPost, err error) {
 	url := UrlTransactions
 	headers := http.Header{}
@@ -236,6 +244,15 @@ func (c *Client) SubmitTransaction(tx []byte) (pTransaction TransactionPost, err
 	return
 }
 
+// Submit a transaction to the node (via POST `UrlTransactions`)
+//
+// Params:
+//     hash = the hash of the transaction
+//     tx = JSON serialized Transaction that will be sent as body
+//
+// Returns:
+//   TransactionPost = An object describing the node's answer (usually just an echo)
+//   error = An error object, or `nil`
 func (c *Client) SubmitTransactionAndWait(hash string, tx []byte) (pTransaction TransactionPost, err error) {
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -262,7 +262,7 @@ func (c *Client) SubmitTransactionAndWait(hash string, tx []byte) (pTransaction 
 	return
 }
 
-func (c *Client) Stream(ctx context.Context, url string, body []byte, handler func(data []byte) error) (err error) {
+func (c *Client) stream(ctx context.Context, url string, body []byte, handler func(data []byte) error) (err error) {
 	var headers = http.Header{}
 	headers.Set("Accept", "text/event-stream")
 	var resp *http.Response
@@ -326,7 +326,7 @@ func (c *Client) StreamAccount(ctx context.Context, id string, handler func(Acco
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
+	return c.stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamTransactions(ctx context.Context, handler func(Transaction)) (err error) {
@@ -341,7 +341,7 @@ func (c *Client) StreamTransactions(ctx context.Context, handler func(Transactio
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
+	return c.stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, handler func(Transaction)) (err error) {
@@ -356,7 +356,7 @@ func (c *Client) StreamTransactionsByAccount(ctx context.Context, id string, han
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
+	return c.stream(ctx, UrlSubscribe, b, handlerFunc)
 }
 
 func (c *Client) StreamTransactionStatus(ctx context.Context, id string, body []byte, handler func(TransactionStatus)) (err error) {
@@ -370,7 +370,7 @@ func (c *Client) StreamTransactionStatus(ctx context.Context, id string, body []
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, url, nil, handlerFunc)
+	return c.stream(ctx, url, nil, handlerFunc)
 }
 
 func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, handler func(Transaction)) (err error) {
@@ -385,5 +385,5 @@ func (c *Client) StreamTransactionsByHash(ctx context.Context, id string, handle
 		handler(v)
 		return nil
 	}
-	return c.Stream(ctx, UrlSubscribe, b, handlerFunc)
+	return c.stream(ctx, UrlSubscribe, b, handlerFunc)
 }

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -6,20 +6,19 @@ import (
 	"fmt"
 	"io"
 
-	"boscoin.io/sebak/lib/node/runner/api"
-
-	logging "github.com/inconshreveable/log15"
-
 	"boscoin.io/sebak/lib/ballot"
 	"boscoin.io/sebak/lib/block"
 	"boscoin.io/sebak/lib/common"
 	"boscoin.io/sebak/lib/consensus"
 	"boscoin.io/sebak/lib/errors"
 	"boscoin.io/sebak/lib/node"
+	"boscoin.io/sebak/lib/node/runner/api"
 	"boscoin.io/sebak/lib/storage"
 	"boscoin.io/sebak/lib/transaction"
 	"boscoin.io/sebak/lib/transaction/operation"
 	"boscoin.io/sebak/lib/voting"
+
+	logging "github.com/inconshreveable/log15"
 )
 
 type CheckerStopCloseConsensus struct {

--- a/tests/client/account_test.go
+++ b/tests/client/account_test.go
@@ -27,7 +27,7 @@ func TestAccount(t *testing.T) {
 		//account2Secret = "SBOEFVTSQCFFTHHFAIPLOBMDY32JC4E4KEHR4TKCSUE2O5BSBTHOAANH"
 	)
 
-	c := client.NewClient("https://127.0.0.1:2830")
+	c := client.MustNewClient("https://127.0.0.1:2830")
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 

--- a/tests/client/congressvoting_inflationpf_test.go
+++ b/tests/client/congressvoting_inflationpf_test.go
@@ -37,7 +37,7 @@ func TestInflationPF(t *testing.T) {
 		fundingAmount = 123456789
 	)
 
-	c := client.NewClient("https://127.0.0.1:2830")
+	c := client.MustNewClient("https://127.0.0.1:2830")
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 

--- a/tests/client/freezing_test.go
+++ b/tests/client/freezing_test.go
@@ -27,7 +27,7 @@ func TestFreezingAccount(t *testing.T) {
 		account2Secret = "SC6X7ZH3OD77ZXLYZ32MJLGVIOPUCMMACI35HJMHX2PPCZXGLRVTMUPA"
 	)
 
-	c := client.NewClient("https://127.0.0.1:2830")
+	c := client.MustNewClient("https://127.0.0.1:2830")
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 

--- a/tests/client/operation_test.go
+++ b/tests/client/operation_test.go
@@ -22,7 +22,7 @@ func TestOperation(t *testing.T) {
 		//account2Secret = "SAUR6KPJY6GT7FQYDLYNXHHLIVPNA4JSJ4IABNBVYUBLZD7LCZM5KQPY"
 	)
 
-	c := client.NewClient("https://127.0.0.1:2830")
+	c := client.MustNewClient("https://127.0.0.1:2830")
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 

--- a/tests/client/ping_test.go
+++ b/tests/client/ping_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestPing(t *testing.T) {
-	c := client.NewClient("https://127.0.0.1:2830")
+	c := client.MustNewClient("https://127.0.0.1:2830")
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 	_, e := c.LoadAccount("GDIRF4UWPACXPPI4GW7CMTACTCNDIKJEHZK44RITZB4TD3YUM6CCVNGJ")

--- a/tests/client/test.go
+++ b/tests/client/test.go
@@ -16,7 +16,7 @@ import (
 
 func createAccount(t *testing.T, fromAddr, fromSecret, toAddr string, balance uint64) {
 
-	c := client.NewClient("https://127.0.0.1:2830")
+	c := client.MustNewClient("https://127.0.0.1:2830")
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 

--- a/tests/client/transaction_status_test.go
+++ b/tests/client/transaction_status_test.go
@@ -24,7 +24,7 @@ func TestTransactionStatus(t *testing.T) {
 		account1Secret = "SDJA7RJZUE4MJ3NAAHCYDXU54XI5W4ERM4CFY5PICBUDOB7Z6HW44STA"
 	)
 
-	c := client.NewClient("https://127.0.0.1:2830")
+	c := client.MustNewClient("https://127.0.0.1:2830")
 	headers := http.Header{}
 	headers.Set("Content-Type", "application/json")
 


### PR DESCRIPTION
Was looking into adapting the client for the integration tests, as well as for the explorer / API split, and some things popped up. As usual, review commit-by-commit for maximum efficiency.