### PR TITLE
Resolve long time consensus stuck by network and simple refactorings

### DIFF
--- a/lib/ballot/ballot.go
+++ b/lib/ballot/ballot.go
@@ -2,7 +2,6 @@ package ballot
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/btcsuite/btcutil/base58"
 
@@ -106,15 +105,7 @@ func (b Ballot) isBallotWellFormed(conf common.Config) (err error) {
 		return
 	}
 
-	var confirmed time.Time
-	if confirmed, err = common.ParseISO8601(b.B.Confirmed); err != nil {
-		return
-	}
-	now := time.Now()
-	timeStart := now.Add(time.Duration(-1) * common.BallotConfirmedTimeAllowDuration)
-	timeEnd := now.Add(common.BallotConfirmedTimeAllowDuration)
-	if confirmed.Before(timeStart) || confirmed.After(timeEnd) {
-		err = errors.MessageHasIncorrectTime
+	if err = CheckHasCorrectTime(b.B.Confirmed); err != nil {
 		return
 	}
 
@@ -126,17 +117,7 @@ func (b Ballot) isBallotWellFormed(conf common.Config) (err error) {
 }
 
 func (b Ballot) isProposerInfoWellFormed(conf common.Config) (err error) {
-	var proposerConfirmed time.Time
-	if proposerConfirmed, err = common.ParseISO8601(b.ProposerConfirmed()); err != nil {
-		return
-	}
-
-	now := time.Now()
-	timeStart := now.Add(time.Duration(-1) * common.BallotConfirmedTimeAllowDuration)
-	timeEnd := now.Add(common.BallotConfirmedTimeAllowDuration)
-
-	if proposerConfirmed.Before(timeStart) || proposerConfirmed.After(timeEnd) {
-		err = errors.MessageHasIncorrectTime
+	if err = CheckHasCorrectTime(b.ProposerConfirmed()); err != nil {
 		return
 	}
 

--- a/lib/ballot/util.go
+++ b/lib/ballot/util.go
@@ -8,17 +8,15 @@ import (
 )
 
 func CheckHasCorrectTime(timeStr string) error {
-	var proposerConfirmed time.Time
+	var t time.Time
 	var err error
-	if proposerConfirmed, err = common.ParseISO8601(timeStr); err != nil {
+	if t, err = common.ParseISO8601(timeStr); err != nil {
 		return err
 	}
-
 	now := time.Now()
 	timeStart := now.Add(time.Duration(-1) * common.BallotConfirmedTimeAllowDuration)
 	timeEnd := now.Add(common.BallotConfirmedTimeAllowDuration)
-
-	if proposerConfirmed.Before(timeStart) || proposerConfirmed.After(timeEnd) {
+	if t.Before(timeStart) || t.After(timeEnd) {
 		return errors.MessageHasIncorrectTime
 	}
 

--- a/lib/consensus/ballot_send_record.go
+++ b/lib/consensus/ballot_send_record.go
@@ -24,11 +24,24 @@ func NewBallotSendRecord(nodeAlias string) *BallotSendRecord {
 	return p
 }
 
+// SetSent sets that the ballot of this ISAACState has already been sent.
+// This is to prevent one node from retransmitting another result.
 func (r *BallotSendRecord) SetSent(state ISAACState) {
 	r.Lock()
 	defer r.Unlock()
 	log.Debug("BallotSendRecord.SetSent()", "state", state)
 	r.record[state] = true
+
+	return
+}
+
+// InitSent initializes the ballot transfer record of this ISAACState.InitSent.
+// This function is used when an existing ballot has expired.
+func (r *BallotSendRecord) InitSent(state ISAACState) {
+	r.Lock()
+	defer r.Unlock()
+	log.Debug("BallotSendRecord.InitSent()", "state", state)
+	r.record[state] = false
 
 	return
 }

--- a/lib/consensus/isaac.go
+++ b/lib/consensus/isaac.go
@@ -241,14 +241,14 @@ func (is *ISAAC) Vote(b ballot.Ballot) (isNew bool, err error) {
 	return
 }
 
-func (is *ISAAC) CanGetVotingResult(b ballot.Ballot) (rv RoundVoteResult, vh voting.Hole, finished bool) {
+func (is *ISAAC) CanGetVotingResult(blt ballot.Ballot) (rv RoundVoteResult, vh voting.Hole, finished bool) {
 	is.RLock()
 	defer is.RUnlock()
 
 	defer func() {
 		is.log.Debug(
 			"CanGetVotingResult",
-			"ballot", b.GetHash(),
+			"ballot", blt.GetHash(),
 			"round-vote-result", rv,
 			"voting-hole", vh,
 			"finished", finished,
@@ -259,17 +259,16 @@ func (is *ISAAC) CanGetVotingResult(b ballot.Ballot) (rv RoundVoteResult, vh vot
 	vh = voting.NOTYET
 	finished = false
 
-	runningRound, found := is.RunningRounds[b.VotingBasis().Index()]
+	runningRound, found := is.RunningRounds[blt.VotingBasis().Index()]
 	if !found {
 		// if RunningRound is not found, this ballot will be stopped.
 		finished = true
 		return
 	}
 
-	roundVote, err := runningRound.RoundVote(b.Proposer())
+	roundVote, err := runningRound.RoundVote(blt.Proposer())
 	if err == nil {
-		rv, vh, finished = roundVote.CanGetVotingResult(is.policy, b.State(), is.log)
-		return
+		rv, vh, finished = roundVote.CanGetVotingResult(is.policy, blt.State(), is.log)
 	}
 
 	return

--- a/lib/node/runner/checker.go
+++ b/lib/node/runner/checker.go
@@ -70,6 +70,14 @@ func BallotUnmarshal(c common.Checker, args ...interface{}) (err error) {
 	}
 
 	if err = b.IsWellFormed(checker.Conf); err != nil {
+		if err == errors.MessageHasIncorrectTime && b.State().IsValidForVote() {
+			blt, ierr := checker.NodeRunner.Consensus().GenerateExpiredBallot(b.VotingBasis(), b.State())
+			if ierr != nil {
+				checker.NodeRunner.Log().Error("an error generating an expired ballot", "err", ierr)
+			} else {
+				checker.NodeRunner.BroadcastBallot(blt)
+			}
+		}
 		return
 	}
 

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -770,3 +770,7 @@ func (nr *NodeRunner) BroadcastBallot(b ballot.Ballot) {
 
 	nr.ConnectionManager().Broadcast(b)
 }
+
+func (nr *NodeRunner) InitSent(state consensus.ISAACState) {
+	nr.ballotSendRecord.InitSent(state)
+}

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -54,6 +54,7 @@ var DefaultHandleSIGNBallotCheckerFuncs = []common.CheckerFunc{
 	BallotAlreadyVoted,
 	BallotVote,
 	BallotIsSameProposer,
+	BallotRenewal,
 	BallotCheckResult,
 	ExpiredInSIGN,
 	ACCEPTBallotBroadcast,
@@ -64,6 +65,7 @@ var DefaultHandleACCEPTBallotCheckerFuncs = []common.CheckerFunc{
 	BallotAlreadyVoted,
 	BallotVote,
 	BallotIsSameProposer,
+	BallotRenewal,
 	BallotCheckResult,
 	FinishedBallotStore,
 }

--- a/lib/node/runner/remove_old_ballots_test.go
+++ b/lib/node/runner/remove_old_ballots_test.go
@@ -1,0 +1,75 @@
+package runner
+
+import (
+	"testing"
+	"time"
+
+	"boscoin.io/sebak/lib/ballot"
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/consensus"
+	"boscoin.io/sebak/lib/voting"
+	"github.com/stretchr/testify/require"
+)
+
+func insertOldRunningRound(t *testing.T, is *consensus.ISAAC, blt ballot.Ballot) {
+	if runningRound, found := is.RunningRounds[blt.VotingBasis().Index()]; !found {
+		rr, err := consensus.NewRunningRound(blt.Proposer(), blt)
+		require.NoError(t, err)
+		is.RunningRounds[blt.VotingBasis().Index()] = rr
+	} else {
+		runningRound.Vote(blt)
+	}
+}
+
+func TestRemoveOldBallots(t *testing.T) {
+	nr, nodes, _ := createNodeRunnerForTesting(3, common.NewTestConfig(), nil)
+
+	basis := voting.Basis{
+		Height: 10,
+		Round:  0,
+	}
+
+	is := nr.consensus
+
+	invalidBlt := *ballot.NewBallot(nodes[0].Address(), nodes[0].Address(), basis, []string{})
+	invalidBlt.SetVote(ballot.StateSIGN, voting.YES)
+	invalidBlt.B.Proposed.Confirmed = common.FormatISO8601(time.Now().Add(-2 * time.Minute))
+	invalidBlt.B.Confirmed = common.FormatISO8601(time.Now().Add(-3 * time.Minute))
+
+	proposedInvalidBlt := *ballot.NewBallot(nodes[1].Address(), nodes[1].Address(), basis, []string{})
+	proposedInvalidBlt.SetVote(ballot.StateSIGN, voting.YES)
+	proposedInvalidBlt.B.Proposed.Confirmed = common.FormatISO8601(time.Now().Add(-2 * time.Minute))
+	proposedInvalidBlt.B.Confirmed = common.FormatISO8601(time.Now())
+
+	validBlt := *ballot.NewBallot(nodes[2].Address(), nodes[2].Address(), basis, []string{})
+	validBlt.SetVote(ballot.StateSIGN, voting.YES)
+	validBlt.B.Proposed.Confirmed = common.FormatISO8601(time.Now())
+	validBlt.B.Confirmed = common.FormatISO8601(time.Now())
+
+	insertOldRunningRound(t, is, invalidBlt)
+	insertOldRunningRound(t, is, proposedInvalidBlt)
+	insertOldRunningRound(t, is, validBlt)
+
+	rr := is.RunningRounds[basis.Index()]
+	require.True(t, rr.IsVoted(invalidBlt))
+	require.True(t, rr.IsVoted(proposedInvalidBlt))
+	require.True(t, rr.IsVoted(validBlt))
+
+	needRenewal := is.RemoveOldBallots(invalidBlt)
+	require.True(t, needRenewal)
+
+	require.False(t, rr.IsVoted(invalidBlt))
+	require.True(t, rr.IsVoted(proposedInvalidBlt))
+	require.True(t, rr.IsVoted(validBlt))
+
+	needRenewal = is.RemoveOldBallots(proposedInvalidBlt)
+	require.False(t, needRenewal) // because it's not made by itself
+
+	require.False(t, rr.IsVoted(proposedInvalidBlt))
+	require.True(t, rr.IsVoted(validBlt))
+
+	needRenewal = is.RemoveOldBallots(validBlt)
+	require.False(t, needRenewal)
+
+	require.True(t, rr.IsVoted(validBlt))
+}

--- a/tests/retry/run.sh
+++ b/tests/retry/run.sh
@@ -60,11 +60,20 @@ sleep 1
 # Check sync
 docker run --rm --network host ${CLIENT_IMAGE} sync.sh
 
+# Network problem for a short time
 docker stop ${NODE3}
 sleep 10
 docker start ${NODE3}
 
-# Check sync after starting NODE3
+# Ensure consensus is in progress
+docker run --rm --network host ${CLIENT_IMAGE} consensus_alive.sh
+
+# Network problem for a long time
+docker stop ${NODE3}
+sleep 61
+docker start ${NODE3}
+
+# Ensure consensus is in progress
 docker run --rm --network host ${CLIENT_IMAGE} consensus_alive.sh
 
 # Shut down the containers - we need to do so for integration reports to be written


### PR DESCRIPTION
### Github Issue
<!--
    Add the Github issue number if one exists, prefixed by one of Github's keywords, ex. `Fixes #1`, `Closes #1` or `Resolves #1`.
-->
fixes #900

### Solution
1. When receiving the old ballot, a node broadcasts expired ballot.
1. If the ballot what a node has is old, a node removes it from the voting results and broadcasts an expired ballot
1. Because of expired ballot, the consensus stuck is resolved and the next round of voting begins.

ps. As usual, please check each commits

@spikeekips Thanks for your awesome design idea :)