### PR TITLE
Replace NewEndpointFromString with ParseEndpoint, improve tests

### DIFF
--- a/cmd/sebak/cmd/run.go
+++ b/cmd/sebak/cmd/run.go
@@ -313,7 +313,7 @@ func parseFlagDiscovery(l cmdcommon.ListFlags) (endpoints []*common.Endpoint, er
 
 	var endpoint *common.Endpoint
 	for _, s := range l {
-		if endpoint, err = common.NewEndpointFromString(s); err != nil {
+		if endpoint, err = common.ParseEndpoint(s); err != nil {
 			return
 		}
 

--- a/lib/ballot/ballot_test.go
+++ b/lib/ballot/ballot_test.go
@@ -20,7 +20,7 @@ import (
 func TestErrorBallotHasOverMaxTransactionsInBallot(t *testing.T) {
 	kp := keypair.Random()
 	commonKP := keypair.Random()
-	endpoint, _ := common.NewEndpointFromString("https://localhost:1000")
+	endpoint := common.MustParseEndpoint("https://localhost:1000")
 	node, _ := node.NewLocalNode(kp, endpoint, "")
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
@@ -68,7 +68,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 	conf := common.NewTestConfig()
 	kp := keypair.Random()
 	commonKP := keypair.Random()
-	endpoint, _ := common.NewEndpointFromString("https://localhost:1000")
+	endpoint := common.MustParseEndpoint("https://localhost:1000")
 	node, _ := node.NewLocalNode(kp, endpoint, "")
 
 	basis := voting.Basis{Round: 0, Height: 0, BlockHash: "showme", TotalTxs: 0}
@@ -159,7 +159,7 @@ func TestBallotProposerTransaction(t *testing.T) {
 	conf := common.NewTestConfig()
 	kp := keypair.Random()
 	commonKP := keypair.Random()
-	endpoint, _ := common.NewEndpointFromString("https://localhost:1000")
+	endpoint := common.MustParseEndpoint("https://localhost:1000")
 	node, _ := node.NewLocalNode(kp, endpoint, "")
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
@@ -198,8 +198,8 @@ func TestBallotProposerTransaction(t *testing.T) {
 
 func TestNewBallot(t *testing.T) {
 	kp := keypair.Random()
-	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
-	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
+	nodeEndpoint := common.MustParseEndpoint("https://localhost:1000")
+	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
 	n, _ := node.NewLocalNode(kp, nodeEndpoint, "")
 	p, _ := node.NewLocalNode(kp, proposerEndpoint, "")
 
@@ -214,8 +214,8 @@ func TestNewBallot(t *testing.T) {
 // In this test, we can check that the normal ballot(not expired) should be signed by proposer.
 func TestIsBallotWellFormed(t *testing.T) {
 	conf := common.NewTestConfig()
-	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
-	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
+	nodeEndpoint := common.MustParseEndpoint("https://localhost:1000")
+	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
 
 	nodeKP := keypair.Random()
 	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
@@ -258,8 +258,8 @@ func TestIsBallotWellFormed(t *testing.T) {
 // We can check that expired ballot could be signed by node key pair(not proposer).
 func TestIsExpiredBallotWellFormed(t *testing.T) {
 	conf := common.NewTestConfig()
-	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
-	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
+	nodeEndpoint := common.MustParseEndpoint("https://localhost:1000")
+	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
 
 	nodeKP := keypair.Random()
 	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
@@ -287,8 +287,8 @@ func TestIsExpiredBallotWellFormed(t *testing.T) {
 // As a result, in expired ballot's validation, it does not matter whether there is a proposal transaction or not.
 func TestIsExpiredBallotWithProposerTransactionWellFormed(t *testing.T) {
 	conf := common.NewTestConfig()
-	nodeEndpoint, _ := common.NewEndpointFromString("https://localhost:1000")
-	proposerEndpoint, _ := common.NewEndpointFromString("https://localhost:1001")
+	nodeEndpoint := common.MustParseEndpoint("https://localhost:1000")
+	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
 
 	nodeKP := keypair.Random()
 	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")

--- a/lib/common/net.go
+++ b/lib/common/net.go
@@ -75,17 +75,6 @@ func NewEndpointFromURL(u *url.URL) *Endpoint {
 	return (*Endpoint)(u)
 }
 
-func NewEndpointFromString(s string) (e *Endpoint, err error) {
-	var u *url.URL
-	if u, err = url.Parse(s); err != nil {
-		return
-	}
-
-	u.Scheme = strings.ToLower(u.Scheme)
-	e = NewEndpointFromURL(u)
-	return
-}
-
 func (e *Endpoint) String() string {
 	return (&url.URL{
 		Scheme: e.Scheme,

--- a/lib/common/test.go
+++ b/lib/common/test.go
@@ -54,3 +54,12 @@ func CheckRoundTripRLP(t *testing.T, record interface{}) {
 	require.Equal(t, record, result.Elem().Interface())
 	require.Equal(t, MustMakeObjectHash(record), MustMakeObjectHash(result.Elem().Interface()))
 }
+
+// Utility to get a new `common.Endpoint` from a string
+func MustParseEndpoint(endpoint string) *Endpoint {
+	if ret, err := ParseEndpoint(endpoint); err != nil {
+		panic(err)
+	} else {
+		return ret
+	}
+}

--- a/lib/network/discovery_message_test.go
+++ b/lib/network/discovery_message_test.go
@@ -16,14 +16,14 @@ func TestDiscoveryMessage(t *testing.T) {
 	var networkID []byte = []byte("show-me")
 
 	kp := keypair.Random()
-	endpoint, _ := common.NewEndpointFromString("http://1.2.3.4:5678")
+	endpoint := common.MustParseEndpoint("http://1.2.3.4:5678")
 	localNode, _ := node.NewLocalNode(kp, endpoint, "")
 
 	var validators []*node.Validator
 	{ // add validators
 		for i := 0; i < 3; i++ {
 			kpv := keypair.Random()
-			endpointv, _ := common.NewEndpointFromString(fmt.Sprintf("http://1.2.3.4:567%d", i))
+			endpointv := common.MustParseEndpoint(fmt.Sprintf("http://1.2.3.4:567%d", i))
 			v, _ := node.NewValidator(kpv.Address(), endpointv, "")
 			validators = append(validators, v)
 		}
@@ -90,14 +90,14 @@ func TestDiscoveryMessageUndiscovered(t *testing.T) {
 	var networkID []byte = []byte("show-me")
 
 	kp := keypair.Random()
-	endpoint, _ := common.NewEndpointFromString("http://1.2.3.4:5678")
+	endpoint := common.MustParseEndpoint("http://1.2.3.4:5678")
 	localNode, _ := node.NewLocalNode(kp, endpoint, "")
 
 	var validators []*node.Validator
 	{ // add validators
 		for i := 0; i < 4; i++ {
 			kpv := keypair.Random()
-			endpointv, _ := common.NewEndpointFromString(fmt.Sprintf("http://1.2.3.4:567%d", i))
+			endpointv := common.MustParseEndpoint(fmt.Sprintf("http://1.2.3.4:567%d", i))
 			v, _ := node.NewValidator(kpv.Address(), endpointv, "")
 			validators = append(validators, v)
 

--- a/lib/network/http2_test.go
+++ b/lib/network/http2_test.go
@@ -126,10 +126,7 @@ func TestHTTP2NetworkTLSSupport(t *testing.T) {
 // Without TLS configurations, `TLSCertFile`, `TLSKeyFile`, `HTTP2Network`
 // will be `HTTP` server, not `HTTPS`.
 func TestHTTP2NetworkWithoutTLS(t *testing.T) {
-	endpoint, err := common.NewEndpointFromString(
-		fmt.Sprintf("http://localhost:%s", getPort()),
-	)
-	require.NoError(t, err)
+	endpoint := common.MustParseEndpoint(fmt.Sprintf("http://localhost:%s", getPort()))
 
 	network, err := makeTestHTTP2NetworkForTLS(endpoint)
 	require.NoError(t, err)
@@ -170,8 +167,7 @@ func TestHTTP2NetworkRetryClient(t *testing.T) {
 	router := mux.NewRouter()
 	router.HandleFunc("/ping", ping).Methods("GET")
 	ts := httptest.NewServer(router)
-	endpoint, err := common.NewEndpointFromString(ts.URL + "/ping")
-	require.NoError(t, err)
+	endpoint := common.MustParseEndpoint(ts.URL + "/ping")
 	// with No Retry
 	{
 		client, err := common.NewHTTP2Client(

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestNodeStateChange(t *testing.T) {
 	kp := keypair.Random()
-	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
-	require.Equal(t, nil, err)
+	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
 
 	node, _ := NewLocalNode(kp, endpoint, "")
 
@@ -29,8 +28,7 @@ func TestNodeStateChange(t *testing.T) {
 
 func TestNodeMarshalJSON(t *testing.T) {
 	kp := keypair.Random()
-	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
-	require.Equal(t, nil, err)
+	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
 
 	marshalNode, _ := NewLocalNode(kp, endpoint, "")
 	tmpByte, err := marshalNode.MarshalJSON()
@@ -53,18 +51,12 @@ func TestNodeMarshalJSON(t *testing.T) {
 
 func TestNodeMarshalJSONWithValidator(t *testing.T) {
 	kp := keypair.Random()
-
-	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
-	require.Equal(t, nil, err)
-
-	endpoint2, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5001?NodeName=n2"))
-	require.Equal(t, nil, err)
-
-	endpoint3, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5002?NodeName=n3"))
-	require.Equal(t, nil, err)
-
 	kp2 := keypair.Random()
 	kp3 := keypair.Random()
+
+	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
+	endpoint2 := common.MustParseEndpoint("https://localhost:5001?NodeName=n2")
+	endpoint3 := common.MustParseEndpoint("https://localhost:5002?NodeName=n3")
 
 	validator1, _ := NewValidator(kp2.Address(), endpoint2, "v1")
 	validator2, _ := NewValidator(kp3.Address(), endpoint3, "v2")

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -71,17 +71,11 @@ func pingAndWait(t *testing.T, c0 network.NetworkClient) {
 }
 
 func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Network, nodeRunner *NodeRunner) {
+	kp = keypair.Random()
 	conf := common.NewTestConfig()
 	g := network.NewKeyGenerator(dirPath, certPath, keyPath)
 
-	var config *network.HTTP2NetworkConfig
-	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:%s?NodeName=n1", getPort()))
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	kp = keypair.Random()
+	endpoint := common.MustParseEndpoint(fmt.Sprintf("https://localhost:%s?NodeName=n1", getPort()))
 	localNode, _ := node.NewLocalNode(kp, endpoint, "")
 	localNode.AddValidators(localNode.ConvertToValidator())
 
@@ -90,7 +84,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Netw
 	queries.Add("TLSKeyFile", g.GetKeyPath())
 	endpoint.RawQuery = queries.Encode()
 
-	config, err = network.NewHTTP2NetworkConfigFromEndpoint(localNode.Alias(), endpoint)
+	config, err := network.NewHTTP2NetworkConfigFromEndpoint(localNode.Alias(), endpoint)
 	if err != nil {
 		t.Error(err)
 		return
@@ -167,7 +161,7 @@ func TestGetNodeInfoHandler(t *testing.T) {
 	st := storage.NewTestStorage()
 	defer st.Close()
 
-	endpoint, _ := common.NewEndpointFromString("http://localhost:12345")
+	endpoint := common.MustParseEndpoint("http://localhost:12345")
 	localNode, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
 	localNode.AddValidators(localNode.ConvertToValidator())
 	conf := common.NewTestConfig()
@@ -214,7 +208,7 @@ func TestGetNodeInfoHandler(t *testing.T) {
 	}
 
 	{ // with setting PublishEndpoint, `endpoint` of response should be requested URL
-		publishEndpoint, _ := common.NewEndpointFromString("https://9.9.9.9:54321")
+		publishEndpoint := common.MustParseEndpoint("https://9.9.9.9:54321")
 		localNode.SetPublishEndpoint(publishEndpoint)
 
 		u, _ := url.Parse(server.URL)

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -44,9 +44,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 	p.blocks = append(p.blocks, block.GetGenesis(p.st))
 
 	kp := keypair.Random()
-	endpoint, _ := common.NewEndpointFromString(
-		fmt.Sprintf("http://localhost:12345"),
-	)
+	endpoint := common.MustParseEndpoint("http://localhost:12345")
 	p.localNode, _ = node.NewLocalNode(kp, endpoint, "")
 	p.localNode.AddValidators(p.localNode.ConvertToValidator())
 

--- a/lib/node/runner/jsonrpc_test.go
+++ b/lib/node/runner/jsonrpc_test.go
@@ -27,7 +27,7 @@ type jsonrpcServerTestHelper struct {
 
 func (jp *jsonrpcServerTestHelper) prepare() {
 	jp.server = httptest.NewUnstartedServer(nil)
-	endpoint, _ := common.NewEndpointFromString("http://localhost/jsonrpc")
+	endpoint := common.MustParseEndpoint("http://localhost/jsonrpc")
 	jp.st = storage.NewTestStorage()
 
 	jp.js = newJSONRPCServer(endpoint, jp.st)

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -119,7 +119,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 		}
 		ports = append(ports, port)
 
-		endpoint, _ := common.NewEndpointFromString(
+		endpoint := common.MustParseEndpoint(
 			fmt.Sprintf(
 				"http://localhost:%d?NodeName=%s",
 				port,

--- a/lib/node/runner/post_transaction_test.go
+++ b/lib/node/runner/post_transaction_test.go
@@ -26,7 +26,7 @@ func TestPostTransaction(t *testing.T) {
 	conf := common.NewTestConfig()
 	conf.OpsLimit = 1
 
-	endpoint, _ := common.NewEndpointFromString("http://localhost:12345")
+	endpoint := common.MustParseEndpoint("http://localhost:12345")
 	localNode, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
 	localNode.AddValidators(localNode.ConvertToValidator())
 	isaac, _ := consensus.NewISAAC(

--- a/lib/node/validator_test.go
+++ b/lib/node/validator_test.go
@@ -79,9 +79,7 @@ func TestParseValidatorFromURI(t *testing.T) {
 func TestValidatorMarshalJSON(t *testing.T) {
 	kp := keypair.Random()
 
-	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
-	require.Equal(t, nil, err)
-
+	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
 	validator, _ := NewValidator(kp.Address(), endpoint, "v1")
 
 	tmpByte, err := validator.MarshalJSON()
@@ -108,12 +106,11 @@ func TestValidatorNewValidatorFromString(t *testing.T) {
 func TestValidatorUnMarshalJSON(t *testing.T) {
 	kp := keypair.Random()
 
-	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
-	require.Equal(t, nil, err)
+	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
+	validator, err := NewValidator(kp.Address(), endpoint, "node")
+	require.NoError(t, err)
 
-	validator, _ := NewValidator(kp.Address(), endpoint, "node")
-
-	validator.UnmarshalJSON([]byte(
+	err = validator.UnmarshalJSON([]byte(
 		`{
 			"address":"GATCSN5N6WST3GIJNOF3P55KZTBXG6KUSEFZFHJHV6ZLYNX3OQS2IJTN",
 			"alias":"v1",
@@ -121,7 +118,7 @@ func TestValidatorUnMarshalJSON(t *testing.T) {
 			"state":"NONE"
 		}`,
 	))
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 
 	require.Equal(t, "v1", validator.Alias())
 	require.Equal(t, "https://localhost:5000", validator.Endpoint().String())

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -1,7 +1,6 @@
 package sync
 
 import (
-	"fmt"
 	"testing"
 
 	"boscoin.io/sebak/lib/block"
@@ -21,9 +20,7 @@ func TestNewConfig(t *testing.T) {
 	cm := &mockConnectionManager{}
 	tp := transaction.NewPool(conf)
 
-	endpoint, err := common.NewEndpointFromString(fmt.Sprintf("https://localhost:5000?NodeName=n1"))
-	require.Equal(t, nil, err)
-
+	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
 	node, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
 
 	cfg, err := NewConfig(node, st, nt, cm, tp, conf)

--- a/lib/sync/fetcher_test.go
+++ b/lib/sync/fetcher_test.go
@@ -39,7 +39,7 @@ func TestBlockFetcher(t *testing.T) {
 	kp := keypair.Random()
 	_, _, localNode := network.CreateMemoryNetwork(nil)
 
-	ep, _ := common.NewEndpointFromString("https://node1?NodeName=n1")
+	ep := common.MustParseEndpoint("https://node1?NodeName=n1")
 	v, _ := node.NewValidator(kp.Address(), ep, "n1")
 
 	localNode.AddValidators(v)


### PR DESCRIPTION
```
NewEndpointFromString was primarily used from tests and had a different semantic
than the more complere ParseEndpoint.
Since having two functions to convert a string to an Endpoint is a bad sign,
the lesser function (with the longest name) was removed.
In addition, since many (mosts?) tests seemed to ignore the error return value,
a test-only MustParseEndpoint was introduced, as ignoring a return value
is a deadly sin.
```