### PR TITLE
Introduce NewTestLocalNode, simplify tests

### DIFF
--- a/lib/ballot/ballot_test.go
+++ b/lib/ballot/ballot_test.go
@@ -21,7 +21,7 @@ func TestErrorBallotHasOverMaxTransactionsInBallot(t *testing.T) {
 	kp := keypair.Random()
 	commonKP := keypair.Random()
 	endpoint := common.MustParseEndpoint("https://localhost:1000")
-	node, _ := node.NewLocalNode(kp, endpoint, "")
+	node := node.NewTestLocalNode(kp, endpoint)
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
@@ -69,7 +69,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 	kp := keypair.Random()
 	commonKP := keypair.Random()
 	endpoint := common.MustParseEndpoint("https://localhost:1000")
-	node, _ := node.NewLocalNode(kp, endpoint, "")
+	node := node.NewTestLocalNode(kp, endpoint)
 
 	basis := voting.Basis{Round: 0, Height: 0, BlockHash: "showme", TotalTxs: 0}
 
@@ -145,7 +145,7 @@ func TestBallotBadConfirmedTime(t *testing.T) {
 func TestBallotEmptyHash(t *testing.T) {
 	conf := common.NewTestConfig()
 	kp := keypair.Random()
-	node, _ := node.NewLocalNode(kp, &common.Endpoint{}, "")
+	node := node.NewTestLocalNode(kp, &common.Endpoint{})
 	r := voting.Basis{}
 	b := NewBallot(node.Address(), node.Address(), r, []string{})
 	b.Sign(kp, conf.NetworkID)
@@ -160,7 +160,7 @@ func TestBallotProposerTransaction(t *testing.T) {
 	kp := keypair.Random()
 	commonKP := keypair.Random()
 	endpoint := common.MustParseEndpoint("https://localhost:1000")
-	node, _ := node.NewLocalNode(kp, endpoint, "")
+	node := node.NewTestLocalNode(kp, endpoint)
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
@@ -200,8 +200,8 @@ func TestNewBallot(t *testing.T) {
 	kp := keypair.Random()
 	nodeEndpoint := common.MustParseEndpoint("https://localhost:1000")
 	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
-	n, _ := node.NewLocalNode(kp, nodeEndpoint, "")
-	p, _ := node.NewLocalNode(kp, proposerEndpoint, "")
+	n := node.NewTestLocalNode(kp, nodeEndpoint)
+	p := node.NewTestLocalNode(kp, proposerEndpoint)
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
@@ -218,10 +218,10 @@ func TestIsBallotWellFormed(t *testing.T) {
 	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
 
 	nodeKP := keypair.Random()
-	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
+	n := node.NewTestLocalNode(nodeKP, nodeEndpoint)
 
 	proposerKP := keypair.Random()
-	p, _ := node.NewLocalNode(proposerKP, proposerEndpoint, "")
+	p := node.NewTestLocalNode(proposerKP, proposerEndpoint)
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
@@ -262,10 +262,10 @@ func TestIsExpiredBallotWellFormed(t *testing.T) {
 	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
 
 	nodeKP := keypair.Random()
-	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
+	n := node.NewTestLocalNode(nodeKP, nodeEndpoint)
 
 	proposerKP := keypair.Random()
-	p, _ := node.NewLocalNode(proposerKP, proposerEndpoint, "")
+	p := node.NewTestLocalNode(proposerKP, proposerEndpoint)
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
@@ -291,10 +291,10 @@ func TestIsExpiredBallotWithProposerTransactionWellFormed(t *testing.T) {
 	proposerEndpoint := common.MustParseEndpoint("https://localhost:1001")
 
 	nodeKP := keypair.Random()
-	n, _ := node.NewLocalNode(nodeKP, nodeEndpoint, "")
+	n := node.NewTestLocalNode(nodeKP, nodeEndpoint)
 
 	proposerKP := keypair.Random()
-	p, _ := node.NewLocalNode(proposerKP, proposerEndpoint, "")
+	p := node.NewTestLocalNode(proposerKP, proposerEndpoint)
 
 	basis := voting.Basis{Round: 0, Height: 1, BlockHash: "hahaha", TotalTxs: 1}
 
@@ -317,5 +317,4 @@ func TestIsExpiredBallotWithProposerTransactionWellFormed(t *testing.T) {
 	err := b.IsWellFormed(conf)
 
 	require.NoError(t, err)
-
 }

--- a/lib/network/discovery_message_test.go
+++ b/lib/network/discovery_message_test.go
@@ -17,7 +17,7 @@ func TestDiscoveryMessage(t *testing.T) {
 
 	kp := keypair.Random()
 	endpoint := common.MustParseEndpoint("http://1.2.3.4:5678")
-	localNode, _ := node.NewLocalNode(kp, endpoint, "")
+	localNode := node.NewTestLocalNode(kp, endpoint)
 
 	var validators []*node.Validator
 	{ // add validators
@@ -91,7 +91,7 @@ func TestDiscoveryMessageUndiscovered(t *testing.T) {
 
 	kp := keypair.Random()
 	endpoint := common.MustParseEndpoint("http://1.2.3.4:5678")
-	localNode, _ := node.NewLocalNode(kp, endpoint, "")
+	localNode := node.NewTestLocalNode(kp, endpoint)
 
 	var validators []*node.Validator
 	{ // add validators

--- a/lib/network/test.go
+++ b/lib/network/test.go
@@ -18,7 +18,7 @@ import (
 func CreateMemoryNetwork(prev *MemoryNetwork) (*keypair.Full, *MemoryNetwork, *node.LocalNode) {
 	mn := prev.NewMemoryNetwork()
 	kp := keypair.Random()
-	localNode, _ := node.NewLocalNode(kp, mn.Endpoint(), "")
+	localNode := node.NewTestLocalNode(kp, mn.Endpoint())
 	mn.SetLocalNode(localNode)
 	return kp, mn, localNode
 }

--- a/lib/node/local_node.go
+++ b/lib/node/local_node.go
@@ -29,21 +29,24 @@ type LocalNode struct {
 	validators      map[ /* Node.Address() */ string]*Validator
 }
 
-func NewLocalNode(kp *keypair.Full, bindEndpoint *common.Endpoint, alias string) (n *LocalNode, err error) {
+func NewLocalNode(kp *keypair.Full, bindEndpoint *common.Endpoint, alias string) (*LocalNode, error) {
 	if len(alias) < 1 {
 		alias = MakeAlias(kp.Address())
 	}
 
-	n = &LocalNode{
+	node := &LocalNode{
 		keypair:      kp,
 		state:        StateCONSENSUS,
 		alias:        alias,
 		bindEndpoint: bindEndpoint,
 		validators:   map[string]*Validator{},
 	}
-	n.AddValidators(n.ConvertToValidator())
 
-	return
+	if err := node.AddValidators(node.ConvertToValidator()); err != nil {
+		return nil, err
+	} else {
+		return node, nil
+	}
 }
 
 func (n *LocalNode) String() string {

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -15,7 +15,7 @@ func TestNodeStateChange(t *testing.T) {
 	kp := keypair.Random()
 	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
 
-	node, _ := NewLocalNode(kp, endpoint, "")
+	node := NewTestLocalNode(kp, endpoint)
 
 	require.Equal(t, StateCONSENSUS, node.State())
 
@@ -30,7 +30,7 @@ func TestNodeMarshalJSON(t *testing.T) {
 	kp := keypair.Random()
 	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
 
-	marshalNode, _ := NewLocalNode(kp, endpoint, "")
+	marshalNode := NewTestLocalNode(kp, endpoint)
 	tmpByte, err := marshalNode.MarshalJSON()
 	require.Equal(t, nil, err)
 
@@ -61,12 +61,13 @@ func TestNodeMarshalJSONWithValidator(t *testing.T) {
 	validator1, _ := NewValidator(kp2.Address(), endpoint2, "v1")
 	validator2, _ := NewValidator(kp3.Address(), endpoint3, "v2")
 
-	localNode, _ := NewLocalNode(kp, endpoint, "node")
+	localNode, err := NewLocalNode(kp, endpoint, "node")
+	require.NoError(t, err)
 
 	localNode.AddValidators(validator1, validator2)
 
 	tmpByte, err := localNode.MarshalJSON()
-	require.Equal(t, nil, err)
+	require.NoError(t, err)
 
 	require.Equal(t, true, strings.Contains(string(tmpByte), `"alias":"node"`))
 	require.Equal(t, true, strings.Contains(string(tmpByte), `"state":"CONSENSUS"`))

--- a/lib/node/runner/api/node_info_test.go
+++ b/lib/node/runner/api/node_info_test.go
@@ -24,7 +24,7 @@ func TestAPIGetNodeInfoHandler(t *testing.T) {
 
 	endpoint, _ := common.ParseEndpoint("http://1.2.3.4:5678")
 	kp := keypair.Random()
-	localNode, _ := node.NewLocalNode(kp, endpoint, "")
+	localNode := node.NewTestLocalNode(kp, endpoint)
 
 	nv := node.NodeVersion{
 		Version:   version.Version,

--- a/lib/node/runner/api_node_test.go
+++ b/lib/node/runner/api_node_test.go
@@ -76,7 +76,7 @@ func createNewHTTP2Network(t *testing.T) (kp *keypair.Full, n *network.HTTP2Netw
 	g := network.NewKeyGenerator(dirPath, certPath, keyPath)
 
 	endpoint := common.MustParseEndpoint(fmt.Sprintf("https://localhost:%s?NodeName=n1", getPort()))
-	localNode, _ := node.NewLocalNode(kp, endpoint, "")
+	localNode := node.NewTestLocalNode(kp, endpoint)
 	localNode.AddValidators(localNode.ConvertToValidator())
 
 	queries := endpoint.Query()
@@ -162,7 +162,7 @@ func TestGetNodeInfoHandler(t *testing.T) {
 	defer st.Close()
 
 	endpoint := common.MustParseEndpoint("http://localhost:12345")
-	localNode, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
+	localNode := node.NewTestLocalNode(keypair.Random(), endpoint)
 	localNode.AddValidators(localNode.ConvertToValidator())
 	conf := common.NewTestConfig()
 	isaac, _ := consensus.NewISAAC(

--- a/lib/node/runner/api_transactions_test.go
+++ b/lib/node/runner/api_transactions_test.go
@@ -45,7 +45,7 @@ func (p *HelperTestGetNodeTransactionsHandler) Prepare() {
 
 	kp := keypair.Random()
 	endpoint := common.MustParseEndpoint("http://localhost:12345")
-	p.localNode, _ = node.NewLocalNode(kp, endpoint, "")
+	p.localNode = node.NewTestLocalNode(kp, endpoint)
 	p.localNode.AddValidators(p.localNode.ConvertToValidator())
 
 	_, p.network, _ = network.CreateMemoryNetwork(nil)

--- a/lib/node/runner/node_runner_test.go
+++ b/lib/node/runner/node_runner_test.go
@@ -126,7 +126,7 @@ func createTestNodeRunnersHTTP2Network(n int) (nodeRunners []*NodeRunner, rootKP
 				kp.Address(),
 			),
 		)
-		node, _ := node.NewLocalNode(kp, endpoint, "")
+		node := node.NewTestLocalNode(kp, endpoint)
 		nodes = append(nodes, node)
 	}
 

--- a/lib/node/runner/post_transaction_test.go
+++ b/lib/node/runner/post_transaction_test.go
@@ -27,7 +27,7 @@ func TestPostTransaction(t *testing.T) {
 	conf.OpsLimit = 1
 
 	endpoint := common.MustParseEndpoint("http://localhost:12345")
-	localNode, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
+	localNode := node.NewTestLocalNode(keypair.Random(), endpoint)
 	localNode.AddValidators(localNode.ConvertToValidator())
 	isaac, _ := consensus.NewISAAC(
 		localNode,

--- a/lib/node/test.go
+++ b/lib/node/test.go
@@ -1,0 +1,18 @@
+//
+// Functions and types usable only from unit tests
+//
+package node
+
+import (
+	"boscoin.io/sebak/lib/common"
+	"boscoin.io/sebak/lib/common/keypair"
+)
+
+// Return a new LocalNode with sensible defaults
+func NewTestLocalNode(kp *keypair.Full, endpoint *common.Endpoint) *LocalNode {
+	if ret, err := NewLocalNode(kp, endpoint, MakeAlias(kp.Address())); err != nil {
+		panic(err)
+	} else {
+		return ret
+	}
+}

--- a/lib/sync/config_test.go
+++ b/lib/sync/config_test.go
@@ -21,7 +21,7 @@ func TestNewConfig(t *testing.T) {
 	tp := transaction.NewPool(conf)
 
 	endpoint := common.MustParseEndpoint("https://localhost:5000?NodeName=n1")
-	node, _ := node.NewLocalNode(keypair.Random(), endpoint, "")
+	node := node.NewTestLocalNode(keypair.Random(), endpoint)
 
 	cfg, err := NewConfig(node, st, nt, cm, tp, conf)
 	require.NoError(t, err)


### PR DESCRIPTION
Once again, getting rid of missing `error` checks and simplifying test code by providing trivial wrapper... Which would not be necessary if go had default parameter, but that's another story.