### PR TITLE
Simplify BlockOperation and remove unused members

### DIFF
--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -31,10 +31,9 @@ type BlockOperation struct {
 	Height uint64                  `json:"block_height"`
 
 	// bellows will be used only for `Save` time.
-	seqID     uint64
-	operation operation.Operation
-	linked    string
-	isSaved   bool
+	seqID   uint64
+	linked  string
+	isSaved bool
 }
 
 func NewBlockOperationKey(opHash, txHash string) string {
@@ -74,9 +73,8 @@ func NewBlockOperationFromOperation(op operation.Operation, tx transaction.Trans
 		Body:   body,
 		Height: blockHeight,
 
-		seqID:     tx.B.SequenceID,
-		operation: op,
-		linked:    linked,
+		seqID:  tx.B.SequenceID,
+		linked: linked,
 	}, nil
 }
 

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -35,14 +35,13 @@ type BlockOperation struct {
 	operation operation.Operation
 	linked    string
 	isSaved   bool
-	opIndex   int
 }
 
 func NewBlockOperationKey(opHash, txHash string) string {
 	return fmt.Sprintf("%s-%s", opHash, txHash)
 }
 
-func NewBlockOperationFromOperation(op operation.Operation, tx transaction.Transaction, blockHeight uint64, opIndex int) (BlockOperation, error) {
+func NewBlockOperationFromOperation(op operation.Operation, tx transaction.Transaction, blockHeight uint64) (BlockOperation, error) {
 	body, err := json.Marshal(op.B)
 	if err != nil {
 		return BlockOperation{}, err
@@ -78,7 +77,6 @@ func NewBlockOperationFromOperation(op operation.Operation, tx transaction.Trans
 		seqID:     tx.B.SequenceID,
 		operation: op,
 		linked:    linked,
-		opIndex:   opIndex,
 	}, nil
 }
 

--- a/lib/block/operation.go
+++ b/lib/block/operation.go
@@ -313,26 +313,15 @@ func GetBlockOperation(st *storage.LevelDBBackend, hash string) (bo BlockOperati
 	return
 }
 
-func GetBlockOperationWithIndex(st *storage.LevelDBBackend, hash string, opIndex int) (bo BlockOperation, err error) {
-	var found = false
-	iterFunc, closeFunc := GetBlockOperationsByTx(st, hash, nil)
-	for idx := 0; idx <= opIndex; idx++ {
-
-		o, hasNext, _ := iterFunc()
-		if !hasNext {
-			break
-		}
-		if idx == opIndex {
-			found = true
-			bo = o
-			break
-		}
+// Looks up the operation referenced by `txHash`, then get the operation's hash from it
+func GetBlockOperationByIndex(st *storage.LevelDBBackend, txHash string, opIndex int) (BlockOperation, error) {
+	if bt, err := GetBlockTransaction(st, txHash); err != nil {
+		return BlockOperation{}, err
+	} else if opIndex < 0 || opIndex >= len(bt.Operations) {
+		return BlockOperation{}, errors.BlockOperationDoesNotExists
+	} else {
+		return GetBlockOperation(st, bt.Operations[opIndex])
 	}
-	if !found {
-		err = errors.OperationNotFound
-	}
-	closeFunc()
-	return
 }
 
 func LoadBlockOperationsInsideIterator(

--- a/lib/block/operation_test.go
+++ b/lib/block/operation_test.go
@@ -16,7 +16,7 @@ func TestNewBlockOperationFromOperation(t *testing.T) {
 	_, tx := transaction.TestMakeTransaction(conf.NetworkID, 1)
 
 	op := tx.B.Operations[0]
-	bo, err := NewBlockOperationFromOperation(op, tx, 0, 0)
+	bo, err := NewBlockOperationFromOperation(op, tx, 0)
 	require.NoError(t, err)
 
 	require.Equal(t, bo.Type, op.H.Type)

--- a/lib/block/test.go
+++ b/lib/block/test.go
@@ -132,8 +132,8 @@ func TestMakeNewBlockWithPrevBlock(prevBlock Block, txs []string) Block {
 func TestMakeNewBlockOperation(networkID []byte, n int) (bos []BlockOperation) {
 	_, tx := transaction.TestMakeTransaction(networkID, n)
 
-	for i, op := range tx.B.Operations {
-		bo, err := NewBlockOperationFromOperation(op, tx, 0, i)
+	for _, op := range tx.B.Operations {
+		bo, err := NewBlockOperationFromOperation(op, tx, 0)
 		if err != nil {
 			panic(err)
 		}

--- a/lib/block/transaction.go
+++ b/lib/block/transaction.go
@@ -178,8 +178,8 @@ func (bt *BlockTransaction) SaveBlockOperations(st *storage.LevelDBBackend) (err
 		}
 	}
 
-	for i, op := range bt.Transaction().B.Operations {
-		if err = bt.SaveBlockOperation(st, op, i); err != nil {
+	for _, op := range bt.Transaction().B.Operations {
+		if err = bt.SaveBlockOperation(st, op); err != nil {
 			return
 		}
 	}
@@ -187,7 +187,7 @@ func (bt *BlockTransaction) SaveBlockOperations(st *storage.LevelDBBackend) (err
 	return nil
 }
 
-func (bt *BlockTransaction) SaveBlockOperation(st *storage.LevelDBBackend, op operation.Operation, opIndex int) (err error) {
+func (bt *BlockTransaction) SaveBlockOperation(st *storage.LevelDBBackend, op operation.Operation) (err error) {
 	if bt.blockHeight < 1 {
 		var blk Block
 		if blk, err = GetBlock(st, bt.Block); err != nil {
@@ -198,7 +198,7 @@ func (bt *BlockTransaction) SaveBlockOperation(st *storage.LevelDBBackend, op op
 	}
 
 	var bo BlockOperation
-	bo, err = NewBlockOperationFromOperation(op, bt.Transaction(), bt.blockHeight, opIndex)
+	bo, err = NewBlockOperationFromOperation(op, bt.Transaction(), bt.blockHeight)
 	if err != nil {
 		return
 	}

--- a/lib/node/runner/api/base_test.go
+++ b/lib/node/runner/api/base_test.go
@@ -81,8 +81,8 @@ func prepareOpsWithoutSave(count int, st *storage.LevelDBBackend) (*keypair.Full
 
 	theBlock := block.TestMakeNewBlockWithPrevBlock(block.GetLatestBlock(st), txHashes)
 	for _, tx := range txs {
-		for i, op := range tx.B.Operations {
-			bo, err := block.NewBlockOperationFromOperation(op, tx, theBlock.Height, i)
+		for _, op := range tx.B.Operations {
+			bo, err := block.NewBlockOperationFromOperation(op, tx, theBlock.Height)
 			if err != nil {
 				panic(err)
 			}
@@ -102,7 +102,7 @@ func prepareBlkTxOpWithoutSave(st *storage.LevelDBBackend) (*keypair.Full, block
 	bt := block.NewBlockTransactionFromTransaction(theBlock.Hash, theBlock.Height, theBlock.ProposedTime, tx)
 
 	op := tx.B.Operations[0]
-	bo, err := block.NewBlockOperationFromOperation(op, tx, theBlock.Height, 0)
+	bo, err := block.NewBlockOperationFromOperation(op, tx, theBlock.Height)
 	if err != nil {
 		panic(err)
 	}

--- a/lib/node/runner/api/operation.go
+++ b/lib/node/runner/api/operation.go
@@ -25,19 +25,11 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashOpIndexHandler(w http.Response
 	}
 
 	readFunc := func() (payload interface{}, err error) {
-		found, err := block.ExistsBlockTransaction(api.storage, txHash)
-		if err != nil {
+		if bo, err := block.GetBlockOperationByIndex(api.storage, txHash, opIndexInt); err != nil {
 			return nil, err
+		} else {
+			return resource.NewOperation(&bo, opIndexInt), nil
 		}
-		if !found {
-			return nil, errors.BlockTransactionDoesNotExists
-		}
-		bo, err := block.GetBlockOperationByIndex(api.storage, txHash, opIndexInt)
-		if err != nil {
-			return nil, err
-		}
-		payload = resource.NewOperation(&bo, opIndexInt)
-		return payload, nil
 	}
 
 	payload, err := readFunc()

--- a/lib/node/runner/api/operation.go
+++ b/lib/node/runner/api/operation.go
@@ -32,7 +32,7 @@ func (api NetworkHandlerAPI) GetOperationsByTxHashOpIndexHandler(w http.Response
 		if !found {
 			return nil, errors.BlockTransactionDoesNotExists
 		}
-		bo, err := block.GetBlockOperationWithIndex(api.storage, txHash, opIndexInt)
+		bo, err := block.GetBlockOperationByIndex(api.storage, txHash, opIndexInt)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/node/runner/block_operations.go
+++ b/lib/node/runner/block_operations.go
@@ -316,7 +316,7 @@ func (sb *SavingBlockOperations) CheckTransactionByBlock(st *storage.LevelDBBack
 		}
 
 		if !exists {
-			if err = bt.SaveBlockOperation(st, op, i); err != nil {
+			if err = bt.SaveBlockOperation(st, op); err != nil {
 				return err
 			}
 		}

--- a/lib/node/runner/checker_ballot_transaction.go
+++ b/lib/node/runner/checker_ballot_transaction.go
@@ -393,7 +393,7 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 				return errors.InvalidOperation
 			}
 
-			if bo, err = block.GetBlockOperationWithIndex(st, txHash, opIndex); err != nil {
+			if bo, err = block.GetBlockOperationByIndex(st, txHash, opIndex); err != nil {
 				return err
 			}
 
@@ -427,7 +427,7 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 				return errors.InvalidOperation
 			}
 
-			if bo, err = block.GetBlockOperationWithIndex(st, txHash, opIndex); err != nil {
+			if bo, err = block.GetBlockOperationByIndex(st, txHash, opIndex); err != nil {
 				return err
 			}
 
@@ -484,7 +484,7 @@ func ValidateOp(st *storage.LevelDBBackend, config common.Config, source *block.
 			return errors.InvalidOperation
 		}
 
-		if _, err = block.GetBlockOperationWithIndex(st, txHash, opIndex); err != nil {
+		if _, err = block.GetBlockOperationByIndex(st, txHash, opIndex); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
One of my current goals is to merge `BlockOperation` into `BlockTransaction`. This should make the code much simpler and the DB much less heavy. However, there's a few things that are currently blocking this:
- Usage of operation hashes
- The million way operations are indexed with something else
- The amount of duplication between operation and transaction

This addresses some of the 2nd and 3rd point. Operation hashes should be dealt with by using an unified way to access blocks/txs/ops (e.g. hash/hash/idx, hash/idx/idx or height/idx/idx).