### PR TITLE
Options to prevent starting consensus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 tmp*
 *tmp
 /vendor/
-db
+/db
 *.orig
 .idea
 tests/*/*/coverage/

--- a/lib/common/config.go
+++ b/lib/common/config.go
@@ -39,4 +39,5 @@ type Config struct {
 	WatcherMode bool
 
 	DiscoveryEndpoints []*Endpoint
+	StopConsensus      bool
 }

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -390,7 +390,9 @@ func (nr *NodeRunner) Start() (err error) {
 
 	go nr.handleMessages()
 	go nr.ConnectValidators()
-	go nr.InitRound()
+	if !nr.Conf.StopConsensus {
+		go nr.InitRound()
+	}
 	go nr.savingBlockOperations.Start()
 
 	if nr.jsonrpcServer != nil {


### PR DESCRIPTION
### Background

**This PR is for testing usage**

The new option, `--stop-consensus` prevents starting consensus(especially `InitRound()`), so SEBAK does not do anything, only waits for a client's requests. 

The main usage of this option is for,

* When you download SEBAK db and you want to test it without modifying the original db.
* When you want to test the other features without regarding consensus.

At this time, I have been used this option for getting statistics data from mainnet dumped db.