### PR TITLE
Simplify some validator-related code

### DIFF
--- a/lib/network/memory_test.go
+++ b/lib/network/memory_test.go
@@ -107,7 +107,8 @@ func TestMemoryNetworkConnect(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	v, err := node.NewValidatorFromString(b)
+	var v node.Validator
+	err = json.Unmarshal(b, &v)
 	if err != nil {
 		t.Error(err)
 		return

--- a/lib/network/validator_connection_manager.go
+++ b/lib/network/validator_connection_manager.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"bufio"
+	"encoding/json"
 	"errors"
 	"strings"
 	"sync"
@@ -290,8 +291,8 @@ func (c *ValidatorConnectionManager) connectValidator(v *node.Validator) (err er
 	}
 
 	// load and check validator info; addresses are same?
-	var validator *node.Validator
-	validator, err = node.NewValidatorFromString(b)
+	var validator node.Validator
+	err = json.Unmarshal(b, &validator)
 	if err != nil {
 		return
 	}

--- a/lib/node/node_test.go
+++ b/lib/node/node_test.go
@@ -69,10 +69,11 @@ func TestNodeMarshalJSONWithValidator(t *testing.T) {
 	tmpByte, err := localNode.MarshalJSON()
 	require.NoError(t, err)
 
-	require.Equal(t, true, strings.Contains(string(tmpByte), `"alias":"node"`))
-	require.Equal(t, true, strings.Contains(string(tmpByte), `"state":"CONSENSUS"`))
-	require.Equal(t, true, strings.Contains(string(tmpByte), `"alias":"v1"`))
-	require.Equal(t, true, strings.Contains(string(tmpByte), `"endpoint":"https://localhost:5001"`))
-	require.Equal(t, true, strings.Contains(string(tmpByte), `"alias":"v2"`))
-	require.Equal(t, true, strings.Contains(string(tmpByte), `"endpoint":"https://localhost:5002"`))
+	str := string(tmpByte)
+	require.True(t, strings.Contains(str, `"alias":"node"`), str)
+	require.True(t, strings.Contains(str, `"state":"CONSENSUS"`), str)
+	require.True(t, strings.Contains(str, `"alias":"v1"`), str)
+	require.True(t, strings.Contains(str, `"endpoint":"https://localhost:5001"`), str)
+	require.True(t, strings.Contains(str, `"alias":"v2"`), str)
+	require.True(t, strings.Contains(str, `"endpoint":"https://localhost:5002"`), str)
 }

--- a/lib/node/runner/node_runner.go
+++ b/lib/node/runner/node_runner.go
@@ -504,10 +504,7 @@ func (nr *NodeRunner) handleMessage(message common.NetworkMessage) {
 	}
 	switch message.Type {
 	case common.ConnectMessage:
-		if _, err := node.NewValidatorFromString(message.Data); err != nil {
-			nr.log.Error("invalid validator data was received", "error", err)
-			return
-		}
+		return // We don't do anything with that data
 	case common.BallotMessage:
 		nr.handleBallotMessage(message)
 	default:

--- a/lib/node/validator.go
+++ b/lib/node/validator.go
@@ -113,15 +113,6 @@ func NewValidator(address string, endpoint *common.Endpoint, alias string) (v *V
 	return
 }
 
-func NewValidatorFromString(b []byte) (*Validator, error) {
-	var v Validator
-	if err := json.Unmarshal(b, &v); err != nil {
-		return nil, err
-	}
-
-	return &v, nil
-}
-
 func NewValidatorFromURI(v string) (validator *Validator, err error) {
 	var parsed *url.URL
 	if parsed, err = url.Parse(v); err != nil {

--- a/lib/node/validator_test.go
+++ b/lib/node/validator_test.go
@@ -89,20 +89,6 @@ func TestValidatorMarshalJSON(t *testing.T) {
 	require.Equal(t, true, strings.Contains(string(tmpByte), fmt.Sprintf(jsonStr, "v1", "5000")))
 }
 
-func TestValidatorNewValidatorFromString(t *testing.T) {
-	validator, _ := NewValidatorFromString([]byte(
-		`{
-			"address":"GATCSN5N6WST3GIJNOF3P55KZTBXG6KUSEFZFHJHV6ZLYNX3OQS2IJTN",
-			"alias":"v1",
-			"endpoint":"https://localhost:5000",
-			"state":"NONE"
-		}`,
-	))
-
-	require.Equal(t, "v1", validator.Alias())
-	require.Equal(t, "https://localhost:5000", validator.Endpoint().String())
-}
-
 func TestValidatorUnMarshalJSON(t *testing.T) {
 	kp := keypair.Random()
 


### PR DESCRIPTION
The first commit moves the deserialization to the network code. As we saw in previous example, having serialization baked into the type is problematic: e.g. we might want to serialize the host using RLP / just as a string, instead of always going for JSON.

The second commit is just a unittest that failed when I was testing something else, and I could see improved.